### PR TITLE
feat(cache): file hashing module with SHA-256

### DIFF
--- a/src/cache/hash.ts
+++ b/src/cache/hash.ts
@@ -1,0 +1,22 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+/**
+ * Compute a SHA-256 hex digest of a file at the given absolute path.
+ * Returns `null` if the file does not exist or cannot be read.
+ */
+export async function hashFile(absolutePath: string): Promise<string | null> {
+  try {
+    const contents = await readFile(absolutePath);
+    return hashContents(contents);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute a SHA-256 hex digest of the given string or Buffer.
+ */
+export function hashContents(contents: string | Buffer): string {
+  return createHash('sha256').update(contents).digest('hex');
+}

--- a/tests/unit/hash.test.ts
+++ b/tests/unit/hash.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { hashFile, hashContents } from '../../src/cache/hash.js';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('hashFile', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = join(tmpdir(), `hash-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the same hash for the same file', async () => {
+    const filePath = join(tempDir, 'stable.txt');
+    await writeFile(filePath, 'hello world');
+
+    const hash1 = await hashFile(filePath);
+    const hash2 = await hashFile(filePath);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns different hashes for different contents', async () => {
+    const fileA = join(tempDir, 'a.txt');
+    const fileB = join(tempDir, 'b.txt');
+    await writeFile(fileA, 'content A');
+    await writeFile(fileB, 'content B');
+
+    const hashA = await hashFile(fileA);
+    const hashB = await hashFile(fileB);
+
+    expect(hashA).not.toBe(hashB);
+  });
+
+  it('returns null for a missing file', async () => {
+    const result = await hashFile(join(tempDir, 'nonexistent.txt'));
+    expect(result).toBeNull();
+  });
+
+  it('returns a hash for an empty file', async () => {
+    const filePath = join(tempDir, 'empty.txt');
+    await writeFile(filePath, '');
+
+    const result = await hashFile(filePath);
+
+    expect(result).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns a hash for binary content', async () => {
+    const filePath = join(tempDir, 'binary.bin');
+    await writeFile(filePath, Buffer.from([0x00, 0xff, 0x80, 0x7f]));
+
+    const result = await hashFile(filePath);
+
+    expect(result).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('hashContents', () => {
+  it('hashes a string', () => {
+    const result = hashContents('hello');
+    expect(result).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('hashes a Buffer', () => {
+    const result = hashContents(Buffer.from('hello'));
+    expect(result).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces the same hash for string and Buffer with same content', () => {
+    const fromString = hashContents('hello');
+    const fromBuffer = hashContents(Buffer.from('hello'));
+    expect(fromString).toBe(fromBuffer);
+  });
+
+  it('produces different hashes for different inputs', () => {
+    const a = hashContents('alpha');
+    const b = hashContents('beta');
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `hashFile(absolutePath)` — returns hex SHA-256 digest of a file, or `null` if the file is missing/unreadable
- Adds `hashContents(contents)` — synchronous SHA-256 from a string or Buffer
- Full test coverage in `tests/unit/hash.test.ts` (9 tests)

Closes #6 | Milestone: V1

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (9 new tests: determinism, uniqueness, missing file, empty file, binary, string/Buffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)