### PR TITLE
feat(server): implement force_reread and invalidate MCP tools

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { forceReread } from './tools/force-reread.js';
+import { invalidateCache } from './tools/invalidate.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -80,6 +82,46 @@ server.registerTool('get_project_map', {
           message: 'get_project_map is not yet implemented. See issue #21.',
           depth: depth ?? null,
         }),
+      },
+    ],
+  };
+});
+
+server.registerTool('force_reread', {
+  title: 'Force Re-read',
+  description:
+    'Re-reads a file from disk, generates a fresh summary, and updates the cache. Use when you know a file has changed or want guaranteed-fresh data.',
+  inputSchema: {
+    path: z.string().describe('File path relative to project root'),
+  },
+}, async ({ path }) => {
+  const projectRoot = process.cwd();
+  const result = await forceReread(projectRoot, path);
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result),
+      },
+    ],
+  };
+});
+
+server.registerTool('invalidate', {
+  title: 'Invalidate Cache',
+  description:
+    'Invalidates cached entries. If a path is provided, only that entry is removed. If no path is provided, all entries are removed.',
+  inputSchema: {
+    path: z.string().optional().describe('File path to invalidate, or omit to invalidate all'),
+  },
+}, async ({ path }) => {
+  const projectRoot = process.cwd();
+  const result = await invalidateCache(projectRoot, path);
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result),
       },
     ],
   };

--- a/src/tools/force-reread.ts
+++ b/src/tools/force-reread.ts
@@ -1,0 +1,21 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { hashContents } from '../cache/hash.js';
+import { CacheStore } from '../cache/store.js';
+import { summarizeFile } from '../indexer/summarizer.js';
+import type { FileSummary } from '../types.js';
+
+export async function forceReread(
+  projectRoot: string,
+  relativePath: string,
+): Promise<{ path: string; hash: string; summary: FileSummary; reread: true }> {
+  const absolutePath = join(projectRoot, relativePath);
+  const contents = await readFile(absolutePath, 'utf-8');
+  const hash = hashContents(contents);
+  const summary = summarizeFile(relativePath, contents);
+
+  const store = new CacheStore(projectRoot);
+  store.setEntry(relativePath, hash, summary);
+
+  return { path: relativePath, hash, summary, reread: true };
+}

--- a/src/tools/invalidate.ts
+++ b/src/tools/invalidate.ts
@@ -1,0 +1,21 @@
+import { CacheStore } from '../cache/store.js';
+
+export async function invalidateCache(
+  projectRoot: string,
+  path?: string,
+): Promise<{ invalidated: string | 'all'; entriesRemoved: number }> {
+  const store = new CacheStore(projectRoot);
+
+  if (path) {
+    store.deleteEntry(path);
+    return { invalidated: path, entriesRemoved: 1 };
+  }
+
+  const entries = store.getAllEntries();
+  const count = entries.length;
+  for (const entry of entries) {
+    store.deleteEntry(entry.path);
+  }
+
+  return { invalidated: 'all', entriesRemoved: count };
+}

--- a/tests/unit/force-reread.test.ts
+++ b/tests/unit/force-reread.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CacheStore } from '../../src/cache/store.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { forceReread } from '../../src/tools/force-reread.js';
+
+describe('forceReread', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-test-'));
+    mkdirSync(join(tempDir, 'src'), { recursive: true });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should always return fresh data', async () => {
+    const filePath = 'src/hello.ts';
+    const absolutePath = join(tempDir, filePath);
+    writeFileSync(absolutePath, 'export const hello = "world";', 'utf-8');
+
+    const result = await forceReread(tempDir, filePath);
+
+    expect(result.reread).toBe(true);
+    expect(result.path).toBe(filePath);
+    expect(result.hash).toBeTypeOf('string');
+    expect(result.hash.length).toBe(64); // SHA-256 hex
+    expect(result.summary).toBeDefined();
+    expect(result.summary.exports).toContain('hello');
+  });
+
+  it('should update the cache entry', async () => {
+    const filePath = 'src/counter.ts';
+    const absolutePath = join(tempDir, filePath);
+    writeFileSync(absolutePath, 'export const count = 1;', 'utf-8');
+
+    const store = new CacheStore(tempDir);
+    store.setEntry(filePath, 'old-hash', null);
+
+    const result = await forceReread(tempDir, filePath);
+
+    const entry = store.getEntry(filePath);
+    expect(entry).not.toBeNull();
+    expect(entry!.hash).toBe(result.hash);
+    expect(entry!.hash).not.toBe('old-hash');
+    expect(entry!.summary).toEqual(result.summary);
+  });
+
+  it('should work when no cache entry exists', async () => {
+    const filePath = 'src/brand-new.ts';
+    const absolutePath = join(tempDir, filePath);
+    writeFileSync(absolutePath, 'export function greet() {}', 'utf-8');
+
+    const store = new CacheStore(tempDir);
+    expect(store.getEntry(filePath)).toBeNull();
+
+    const result = await forceReread(tempDir, filePath);
+
+    expect(result.reread).toBe(true);
+    expect(result.summary.exports).toContain('greet');
+
+    const entry = store.getEntry(filePath);
+    expect(entry).not.toBeNull();
+    expect(entry!.hash).toBe(result.hash);
+  });
+});

--- a/tests/unit/invalidate.test.ts
+++ b/tests/unit/invalidate.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CacheStore } from '../../src/cache/store.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { invalidateCache } from '../../src/tools/invalidate.js';
+
+describe('invalidateCache', () => {
+  let tempDir: string;
+  let store: CacheStore;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-test-'));
+    store = new CacheStore(tempDir);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should invalidate a single path and remove that entry', async () => {
+    store.setEntry('src/a.ts', 'hash-a', null);
+    store.setEntry('src/b.ts', 'hash-b', null);
+
+    const result = await invalidateCache(tempDir, 'src/a.ts');
+
+    expect(result.invalidated).toBe('src/a.ts');
+    expect(result.entriesRemoved).toBe(1);
+    expect(store.getEntry('src/a.ts')).toBeNull();
+    expect(store.getEntry('src/b.ts')).not.toBeNull();
+  });
+
+  it('should invalidate all entries when no path is provided', async () => {
+    store.setEntry('src/a.ts', 'hash-a', null);
+    store.setEntry('src/b.ts', 'hash-b', null);
+    store.setEntry('src/c.ts', 'hash-c', null);
+
+    const result = await invalidateCache(tempDir);
+
+    expect(result.invalidated).toBe('all');
+    expect(result.entriesRemoved).toBe(3);
+    expect(store.getAllEntries()).toHaveLength(0);
+  });
+
+  it('should return correct count of entries removed', async () => {
+    store.setEntry('src/one.ts', 'h1', null);
+    store.setEntry('src/two.ts', 'h2', null);
+
+    const resultAll = await invalidateCache(tempDir);
+    expect(resultAll.entriesRemoved).toBe(2);
+
+    // After clearing, invalidating all again should return 0
+    const resultEmpty = await invalidateCache(tempDir);
+    expect(resultEmpty.entriesRemoved).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `force_reread` MCP tool that always re-reads a file from disk, generates a fresh summary, and updates the cache
- Adds `invalidate` MCP tool for explicit cache invalidation (single entry or all entries)
- Includes unit tests for both tools (6 new tests, all passing)

Closes #24

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (73 tests, 10 suites)
- [x] force_reread: returns fresh data, updates cache, works without existing cache entry
- [x] invalidate: single path removal, all entries removal, correct count returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)