### PR TITLE
feat(server): implement get_project_map MCP tool

### DIFF
--- a/src/indexer/project-map.ts
+++ b/src/indexer/project-map.ts
@@ -1,0 +1,167 @@
+import { readFile } from 'node:fs/promises';
+import { join, dirname, basename, extname } from 'node:path';
+import { scanProject } from './scanner.js';
+import { summarizeFile } from './summarizer.js';
+import { CacheStore } from '../cache/store.js';
+import { hashContents } from '../cache/hash.js';
+import type { FileSummary } from '../types.js';
+
+export interface DirectoryNode {
+  name: string;
+  path: string;
+  files: Array<{ name: string; purpose: string }>;
+  children: DirectoryNode[];
+  fileCount: number;
+}
+
+export interface ProjectMap {
+  tree: DirectoryNode;
+  entryPoints: string[];
+  totalFiles: number;
+  languageBreakdown: Record<string, number>;
+}
+
+interface FileSummaryEntry {
+  relativePath: string;
+  summary: FileSummary;
+}
+
+async function getSummaries(
+  projectRoot: string,
+  files: string[],
+): Promise<FileSummaryEntry[]> {
+  const cache = new CacheStore(projectRoot);
+  const entries: FileSummaryEntry[] = [];
+
+  for (const relativePath of files) {
+    const cached = cache.getEntry(relativePath);
+    if (cached?.summary) {
+      entries.push({ relativePath, summary: cached.summary });
+      continue;
+    }
+
+    const absolutePath = join(projectRoot, relativePath);
+    let contents: string;
+    try {
+      contents = await readFile(absolutePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const summary = summarizeFile(relativePath, contents);
+    const hash = hashContents(contents);
+    cache.setEntry(relativePath, hash, summary);
+    entries.push({ relativePath, summary });
+  }
+
+  return entries;
+}
+
+function buildTree(
+  entries: FileSummaryEntry[],
+  rootName: string,
+  maxDepth?: number,
+): DirectoryNode {
+  const root: DirectoryNode = {
+    name: rootName,
+    path: '.',
+    files: [],
+    children: [],
+    fileCount: 0,
+  };
+
+  const dirMap = new Map<string, DirectoryNode>();
+  dirMap.set('.', root);
+
+  function getOrCreateDir(dirPath: string, currentDepth: number): DirectoryNode | null {
+    if (dirPath === '.') return root;
+    if (maxDepth !== undefined && currentDepth > maxDepth) return null;
+
+    const existing = dirMap.get(dirPath);
+    if (existing) return existing;
+
+    const parentPath = dirname(dirPath);
+    const parentDepth = parentPath === '.' ? 0 : parentPath.split('/').length;
+    const parent = getOrCreateDir(parentPath, parentDepth);
+    if (!parent) return null;
+
+    const node: DirectoryNode = {
+      name: basename(dirPath),
+      path: dirPath,
+      files: [],
+      children: [],
+      fileCount: 0,
+    };
+
+    dirMap.set(dirPath, node);
+    parent.children.push(node);
+    return node;
+  }
+
+  for (const entry of entries) {
+    const dirPath = dirname(entry.relativePath);
+    const depth = dirPath === '.' ? 0 : dirPath.split('/').length;
+    const dir = getOrCreateDir(dirPath, depth);
+    if (!dir) continue;
+
+    dir.files.push({
+      name: basename(entry.relativePath),
+      purpose: entry.summary.purpose,
+    });
+  }
+
+  function computeFileCounts(node: DirectoryNode): number {
+    let count = node.files.length;
+    for (const child of node.children) {
+      count += computeFileCounts(child);
+    }
+    node.fileCount = count;
+    return count;
+  }
+
+  computeFileCounts(root);
+
+  function sortTree(node: DirectoryNode): void {
+    node.files.sort((a, b) => a.name.localeCompare(b.name));
+    node.children.sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of node.children) {
+      sortTree(child);
+    }
+  }
+
+  sortTree(root);
+
+  return root;
+}
+
+function computeLanguageBreakdown(files: string[]): Record<string, number> {
+  const breakdown: Record<string, number> = {};
+  for (const file of files) {
+    const ext = extname(file) || '(no extension)';
+    breakdown[ext] = (breakdown[ext] ?? 0) + 1;
+  }
+  return breakdown;
+}
+
+function findEntryPoints(entries: FileSummaryEntry[]): string[] {
+  return entries
+    .filter((e) => e.summary.purpose === 'entry point')
+    .map((e) => e.relativePath)
+    .sort();
+}
+
+export async function buildProjectMap(
+  projectRoot: string,
+  options?: { depth?: number },
+): Promise<ProjectMap> {
+  const files = await scanProject(projectRoot);
+  const entries = await getSummaries(projectRoot, files);
+  const rootName = basename(projectRoot);
+
+  return {
+    tree: buildTree(entries, rootName, options?.depth),
+    entryPoints: findEntryPoints(entries),
+    totalFiles: files.length,
+    languageBreakdown: computeLanguageBreakdown(files),
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { getProjectMap } from './tools/get-project-map.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -65,21 +66,16 @@ server.registerTool('get_project_map', {
   description:
     'Returns a structural overview of the project including directory tree, entry points, and key modules.',
   inputSchema: {
+    project_root: z.string().describe('Absolute path to the project root'),
     depth: z.number().optional().describe('Max directory depth to include'),
   },
-}, async ({ depth }) => {
+}, async ({ project_root, depth }) => {
+  const projectMap = await getProjectMap(project_root, depth);
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify({
-          tree: null,
-          entryPoints: [],
-          totalFiles: 0,
-          status: 'not_implemented',
-          message: 'get_project_map is not yet implemented. See issue #21.',
-          depth: depth ?? null,
-        }),
+        text: JSON.stringify(projectMap),
       },
     ],
   };

--- a/src/tools/get-project-map.ts
+++ b/src/tools/get-project-map.ts
@@ -1,0 +1,8 @@
+import { buildProjectMap, type ProjectMap } from '../indexer/project-map.js';
+
+export async function getProjectMap(
+  projectRoot: string,
+  depth?: number,
+): Promise<ProjectMap> {
+  return buildProjectMap(projectRoot, depth !== undefined ? { depth } : undefined);
+}

--- a/tests/unit/project-map.test.ts
+++ b/tests/unit/project-map.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildProjectMap } from '../../src/indexer/project-map.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+
+function createTempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'repo-memory-test-'));
+
+  // Create directory structure
+  mkdirSync(join(dir, 'src', 'utils'), { recursive: true });
+  mkdirSync(join(dir, 'src', 'lib'), { recursive: true });
+  mkdirSync(join(dir, 'docs'), { recursive: true });
+
+  // Root files
+  writeFileSync(join(dir, 'package.json'), '{ "name": "test" }');
+  writeFileSync(join(dir, 'README.md'), '# Test Project');
+
+  // Source files
+  writeFileSync(
+    join(dir, 'src', 'index.ts'),
+    'export function main(): void { console.log("hi"); }\n',
+  );
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    'import { helper } from "./utils/helper.js";\nexport const app = helper();\n',
+  );
+  writeFileSync(
+    join(dir, 'src', 'utils', 'helper.ts'),
+    'export function helper(): string { return "help"; }\n',
+  );
+  writeFileSync(
+    join(dir, 'src', 'lib', 'index.ts'),
+    'export { default } from "./core.js";\n',
+  );
+  writeFileSync(
+    join(dir, 'src', 'lib', 'core.ts'),
+    'export default class Core {}\n',
+  );
+
+  // Docs
+  writeFileSync(join(dir, 'docs', 'guide.md'), '# Guide\nSome docs.');
+
+  // CSS file
+  writeFileSync(join(dir, 'src', 'styles.css'), 'body { margin: 0; }');
+
+  return dir;
+}
+
+describe('buildProjectMap', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should count total files correctly', async () => {
+    const map = await buildProjectMap(tempDir);
+    // package.json, README.md, src/index.ts, src/app.ts,
+    // src/utils/helper.ts, src/lib/index.ts, src/lib/core.ts,
+    // docs/guide.md, src/styles.css = 9
+    expect(map.totalFiles).toBe(9);
+  });
+
+  it('should build a directory tree', async () => {
+    const map = await buildProjectMap(tempDir);
+    const tree = map.tree;
+
+    expect(tree.path).toBe('.');
+    expect(tree.fileCount).toBe(9);
+
+    const srcNode = tree.children.find((c) => c.name === 'src');
+    expect(srcNode).toBeDefined();
+    expect(srcNode!.children.length).toBe(2); // utils, lib
+
+    const docsNode = tree.children.find((c) => c.name === 'docs');
+    expect(docsNode).toBeDefined();
+    expect(docsNode!.files).toEqual([{ name: 'guide.md', purpose: 'documentation' }]);
+  });
+
+  it('should identify entry points', async () => {
+    const map = await buildProjectMap(tempDir);
+    // src/index.ts and src/lib/index.ts should be entry points
+    expect(map.entryPoints).toContain('src/index.ts');
+    expect(map.entryPoints).toContain('src/lib/index.ts');
+  });
+
+  it('should compute language breakdown by extension', async () => {
+    const map = await buildProjectMap(tempDir);
+    expect(map.languageBreakdown['.ts']).toBe(5);
+    expect(map.languageBreakdown['.json']).toBe(1);
+    expect(map.languageBreakdown['.md']).toBe(2);
+    expect(map.languageBreakdown['.css']).toBe(1);
+  });
+
+  it('should respect depth parameter', async () => {
+    const map = await buildProjectMap(tempDir, { depth: 1 });
+    const tree = map.tree;
+
+    // depth 0 = root, depth 1 = src, docs
+    const srcNode = tree.children.find((c) => c.name === 'src');
+    expect(srcNode).toBeDefined();
+    // At depth 1, src should have no children (utils/lib would be depth 2)
+    expect(srcNode!.children.length).toBe(0);
+    // But root-level files and src direct files should still be present
+    expect(tree.files.length).toBeGreaterThan(0);
+  });
+
+  it('should use cached summaries on second call', async () => {
+    // First call populates the cache
+    const map1 = await buildProjectMap(tempDir);
+    // Second call should use cache
+    const map2 = await buildProjectMap(tempDir);
+
+    expect(map1.totalFiles).toBe(map2.totalFiles);
+    expect(map1.entryPoints).toEqual(map2.entryPoints);
+    expect(map1.languageBreakdown).toEqual(map2.languageBreakdown);
+  });
+
+  it('should work with the sample-project fixture', async () => {
+    const fixtureDir = join(__dirname, '..', 'fixtures', 'sample-project');
+    const map = await buildProjectMap(fixtureDir);
+
+    // sample-project has: .gitignore, package.json, README.md, src/index.ts, src/utils.ts
+    expect(map.totalFiles).toBeGreaterThanOrEqual(4);
+    expect(map.entryPoints).toContain('src/index.ts');
+    expect(map.languageBreakdown['.ts']).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `buildProjectMap` in `src/indexer/project-map.ts` that scans a project, summarizes files (using cache), and builds a directory tree with entry points and language breakdown
- Adds `getProjectMap` tool handler in `src/tools/get-project-map.ts`
- Replaces the stub `get_project_map` registration in `src/server.ts` with the real implementation
- Adds 7 unit tests covering tree building, entry point detection, language breakdown, depth limiting, caching, and fixture integration

Closes #21

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (74 tests, 9 suites)
- [x] New tests cover: total file count, directory tree structure, entry point identification, language breakdown, depth parameter, cache reuse, sample-project fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)