### PR TITLE
feat(server): implement get_changed_files MCP tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { getChangedFiles } from './tools/get-changed-files.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -42,19 +43,12 @@ server.registerTool('get_changed_files', {
     since: z.string().optional().describe('ISO timestamp or "last_check"'),
   },
 }, async ({ since }) => {
+  const result = await getChangedFiles(process.cwd(), since);
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify({
-          changed: [],
-          added: [],
-          deleted: [],
-          checkedAt: new Date().toISOString(),
-          status: 'not_implemented',
-          message: 'get_changed_files is not yet implemented. See issue #18.',
-          since: since ?? 'last_check',
-        }),
+        text: JSON.stringify(result),
       },
     ],
   };

--- a/src/tools/get-changed-files.ts
+++ b/src/tools/get-changed-files.ts
@@ -1,0 +1,89 @@
+import { join } from 'path';
+import { CacheStore } from '../cache/store.js';
+import { hashFile } from '../cache/hash.js';
+import { scanProject } from '../indexer/scanner.js';
+
+export interface ChangedFilesResult {
+  changed: string[];
+  added: string[];
+  deleted: string[];
+  checkedAt: string;
+}
+
+export async function getChangedFiles(
+  projectRoot: string,
+  since?: string,
+): Promise<ChangedFilesResult> {
+  const store = new CacheStore(projectRoot);
+  const scannedFiles = await scanProject(projectRoot);
+  const allEntries = store.getAllEntries();
+
+  const cachedByPath = new Map(allEntries.map((e) => [e.path, e]));
+  const scannedSet = new Set(scannedFiles);
+
+  const sinceTimestamp = parseSince(since);
+
+  const changed: string[] = [];
+  const added: string[] = [];
+
+  await Promise.all(
+    scannedFiles.map(async (relativePath) => {
+      const absolutePath = join(projectRoot, relativePath);
+      const currentHash = await hashFile(absolutePath);
+      if (!currentHash) return;
+
+      const cached = cachedByPath.get(relativePath);
+
+      if (!cached) {
+        added.push(relativePath);
+      } else if (cached.hash !== currentHash) {
+        if (sinceTimestamp === null || cached.lastChecked >= sinceTimestamp) {
+          changed.push(relativePath);
+        }
+      }
+
+      // Update the cache entry with current hash and timestamp
+      store.setEntry(relativePath, currentHash, cached?.summary ?? null);
+    }),
+  );
+
+  // Files in cache but not in scan are deleted
+  const deleted: string[] = [];
+  for (const [path, entry] of cachedByPath) {
+    if (!scannedSet.has(path)) {
+      if (sinceTimestamp === null || entry.lastChecked >= sinceTimestamp) {
+        deleted.push(path);
+      }
+      store.deleteEntry(path);
+    }
+  }
+
+  changed.sort();
+  added.sort();
+  deleted.sort();
+
+  return {
+    changed,
+    added,
+    deleted,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Parse the `since` parameter into a timestamp threshold.
+ * - undefined or "last_check": return null (no filtering, report all differences)
+ * - ISO timestamp string: return parsed timestamp (only report files checked after this time)
+ */
+function parseSince(since: string | undefined): number | null {
+  if (!since || since === 'last_check') {
+    return null;
+  }
+
+  const parsed = Date.parse(since);
+  if (!isNaN(parsed)) {
+    return parsed;
+  }
+
+  return null;
+}

--- a/tests/unit/get-changed-files.test.ts
+++ b/tests/unit/get-changed-files.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getChangedFiles } from '../../src/tools/get-changed-files.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+
+describe('getChangedFiles', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-changed-'));
+    execFileSync('git', ['init'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tempDir });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should report all files as added on first run', async () => {
+    writeFileSync(join(tempDir, 'a.ts'), 'const a = 1;');
+    writeFileSync(join(tempDir, 'b.ts'), 'const b = 2;');
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    const result = await getChangedFiles(tempDir);
+
+    expect(result.added.sort()).toEqual(['a.ts', 'b.ts']);
+    expect(result.changed).toEqual([]);
+    expect(result.deleted).toEqual([]);
+    expect(result.checkedAt).toBeTruthy();
+  });
+
+  it('should detect a modified file as changed', async () => {
+    writeFileSync(join(tempDir, 'a.ts'), 'const a = 1;');
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    // First run to populate cache
+    await getChangedFiles(tempDir);
+
+    // Modify the file
+    writeFileSync(join(tempDir, 'a.ts'), 'const a = 2;');
+
+    const result = await getChangedFiles(tempDir);
+
+    expect(result.changed).toEqual(['a.ts']);
+    expect(result.added).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+
+  it('should detect a deleted file', async () => {
+    writeFileSync(join(tempDir, 'a.ts'), 'const a = 1;');
+    writeFileSync(join(tempDir, 'b.ts'), 'const b = 2;');
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    // First run to populate cache
+    await getChangedFiles(tempDir);
+
+    // Delete a file and update git index
+    unlinkSync(join(tempDir, 'b.ts'));
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'delete b'], { cwd: tempDir });
+
+    const result = await getChangedFiles(tempDir);
+
+    expect(result.deleted).toEqual(['b.ts']);
+    expect(result.added).toEqual([]);
+  });
+
+  it('should not report unchanged files in any list', async () => {
+    writeFileSync(join(tempDir, 'a.ts'), 'const a = 1;');
+    writeFileSync(join(tempDir, 'b.ts'), 'const b = 2;');
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    // First run
+    await getChangedFiles(tempDir);
+
+    // Second run with no changes
+    const result = await getChangedFiles(tempDir);
+
+    expect(result.changed).toEqual([]);
+    expect(result.added).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `getChangedFiles()` in `src/tools/get-changed-files.ts` that scans project files, compares hashes against cached entries, and categorizes files as changed, added, or deleted
- Replaces the stub `get_changed_files` tool registration in `src/server.ts` with the real implementation
- Adds unit tests covering first run (all added), modified detection, deleted detection, and unchanged files

Closes #18

## Test plan

- [x] `npm run typecheck` passes
- [x] All 71 tests pass including 4 new `get-changed-files` tests
- [x] First run correctly reports all files as "added"
- [x] Modified file detected as "changed" on subsequent run
- [x] Deleted file detected as "deleted" on subsequent run
- [x] Unchanged files not reported in any category

🤖 Generated with [Claude Code](https://claude.com/claude-code)