### PR TITLE
feat(indexer): diff-aware summary updates

### DIFF
--- a/src/indexer/diff-analyzer.ts
+++ b/src/indexer/diff-analyzer.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from 'child_process';
+
+export interface DiffAnalysis {
+  structural: boolean;
+  affectedExports: string[];
+  affectedImports: string[];
+  lineCountChanged: boolean;
+}
+
+const EXPORT_PATTERN =
+  /export\s+(?:default\s+)?(?:const|function|class|interface|type|enum)\b/;
+
+const IMPORT_PATTERN = /import\s+.*?\s+from\s+['"]|import\s+['"]/;
+
+const DECLARATION_PATTERN =
+  /(?:function|class|interface|type|enum)\s+\w+/;
+
+function extractAffectedExports(lines: string[]): string[] {
+  const results: string[] = [];
+  const re =
+    /export\s+(?:default\s+)?(?:const|let|var|function\s*\*?|class|interface|type|enum|abstract\s+class)\s+(\w+)/;
+  for (const line of lines) {
+    const match = re.exec(line);
+    if (match) {
+      results.push(match[1]);
+    }
+  }
+  return [...new Set(results)];
+}
+
+function extractAffectedImports(lines: string[]): string[] {
+  const results: string[] = [];
+  const fromRe = /import\s+.*?\s+from\s+['"]([^'"]+)['"]/;
+  const sideEffectRe = /import\s+['"]([^'"]+)['"]/;
+  for (const line of lines) {
+    const fromMatch = fromRe.exec(line);
+    if (fromMatch) {
+      results.push(fromMatch[1]);
+      continue;
+    }
+    const sideMatch = sideEffectRe.exec(line);
+    if (sideMatch) {
+      results.push(sideMatch[1]);
+    }
+  }
+  return [...new Set(results)];
+}
+
+export function analyzeDiff(
+  filePath: string,
+  projectRoot: string,
+): DiffAnalysis {
+  let diffOutput: string;
+  try {
+    diffOutput = execFileSync(
+      'git',
+      ['diff', 'HEAD', '--', filePath],
+      {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        timeout: 10_000,
+      },
+    );
+  } catch {
+    return {
+      structural: true,
+      affectedExports: [],
+      affectedImports: [],
+      lineCountChanged: true,
+    };
+  }
+
+  if (!diffOutput.trim()) {
+    return {
+      structural: true,
+      affectedExports: [],
+      affectedImports: [],
+      lineCountChanged: true,
+    };
+  }
+
+  const diffLines = diffOutput.split('\n');
+  const changedLines: string[] = [];
+  let addedLines = 0;
+  let removedLines = 0;
+
+  for (const line of diffLines) {
+    if (line.startsWith('@@') || line.startsWith('diff ') ||
+        line.startsWith('index ') || line.startsWith('---') ||
+        line.startsWith('+++')) {
+      continue;
+    }
+    if (line.startsWith('+')) {
+      addedLines++;
+      changedLines.push(line.slice(1));
+    } else if (line.startsWith('-')) {
+      removedLines++;
+      changedLines.push(line.slice(1));
+    }
+  }
+
+  const lineCountChanged = addedLines !== removedLines;
+
+  let structural = false;
+  for (const line of changedLines) {
+    if (EXPORT_PATTERN.test(line) || IMPORT_PATTERN.test(line) ||
+        DECLARATION_PATTERN.test(line)) {
+      structural = true;
+      break;
+    }
+  }
+
+  const affectedExports = extractAffectedExports(changedLines);
+  const affectedImports = extractAffectedImports(changedLines);
+
+  return {
+    structural,
+    affectedExports,
+    affectedImports,
+    lineCountChanged,
+  };
+}

--- a/src/indexer/smart-summarizer.ts
+++ b/src/indexer/smart-summarizer.ts
@@ -1,0 +1,36 @@
+import type { FileSummary } from '../types.js';
+import { analyzeDiff } from './diff-analyzer.js';
+import { summarizeFile } from './summarizer.js';
+
+export function smartSummarize(
+  filePath: string,
+  contents: string,
+  oldSummary: FileSummary | null,
+  projectRoot: string,
+): { summary: FileSummary; source: 'full' | 'diff-partial' } {
+  if (!oldSummary) {
+    return {
+      summary: summarizeFile(filePath, contents),
+      source: 'full',
+    };
+  }
+
+  const analysis = analyzeDiff(filePath, projectRoot);
+
+  if (analysis.structural) {
+    return {
+      summary: summarizeFile(filePath, contents),
+      source: 'full',
+    };
+  }
+
+  const lineCount = contents === '' ? 0 : contents.split('\n').length;
+
+  return {
+    summary: {
+      ...oldSummary,
+      lineCount,
+    },
+    source: 'diff-partial',
+  };
+}

--- a/tests/unit/diff-analyzer.test.ts
+++ b/tests/unit/diff-analyzer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { analyzeDiff } from '../../src/indexer/diff-analyzer.js';
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+describe('analyzeDiff', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'diff-analyzer-'));
+    git(['init'], tmpDir);
+    git(['config', 'user.email', 'test@test.com'], tmpDir);
+    git(['config', 'user.name', 'Test'], tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects structural change when export is added', () => {
+    const filePath = 'src/utils.ts';
+    const fullPath = join(tmpDir, filePath);
+    execFileSync('mkdir', ['-p', join(tmpDir, 'src')]);
+
+    writeFileSync(fullPath, 'export const foo = 1;\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-m', 'initial'], tmpDir);
+
+    writeFileSync(
+      fullPath,
+      'export const foo = 1;\nexport const bar = 2;\n',
+    );
+
+    const result = analyzeDiff(filePath, tmpDir);
+    expect(result.structural).toBe(true);
+    expect(result.affectedExports).toContain('bar');
+    expect(result.lineCountChanged).toBe(true);
+  });
+
+  it('detects structural change when import is added', () => {
+    const filePath = 'src/app.ts';
+    const fullPath = join(tmpDir, filePath);
+    execFileSync('mkdir', ['-p', join(tmpDir, 'src')]);
+
+    writeFileSync(fullPath, 'const x = 1;\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-m', 'initial'], tmpDir);
+
+    writeFileSync(
+      fullPath,
+      "import { foo } from './foo';\nconst x = 1;\n",
+    );
+
+    const result = analyzeDiff(filePath, tmpDir);
+    expect(result.structural).toBe(true);
+    expect(result.affectedImports).toContain('./foo');
+  });
+
+  it('detects non-structural change for body-only edit', () => {
+    const filePath = 'src/utils.ts';
+    const fullPath = join(tmpDir, filePath);
+    execFileSync('mkdir', ['-p', join(tmpDir, 'src')]);
+
+    writeFileSync(
+      fullPath,
+      'export function doStuff() {\n  return 1;\n}\n',
+    );
+    git(['add', '.'], tmpDir);
+    git(['commit', '-m', 'initial'], tmpDir);
+
+    writeFileSync(
+      fullPath,
+      'export function doStuff() {\n  return 42;\n}\n',
+    );
+
+    const result = analyzeDiff(filePath, tmpDir);
+    expect(result.structural).toBe(false);
+    expect(result.lineCountChanged).toBe(false);
+  });
+
+  it('returns structural true for empty diff', () => {
+    const filePath = 'src/nothing.ts';
+    const fullPath = join(tmpDir, filePath);
+    execFileSync('mkdir', ['-p', join(tmpDir, 'src')]);
+
+    writeFileSync(fullPath, 'const x = 1;\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-m', 'initial'], tmpDir);
+
+    // No changes made, diff is empty
+    const result = analyzeDiff(filePath, tmpDir);
+    expect(result.structural).toBe(true);
+    expect(result.lineCountChanged).toBe(true);
+  });
+
+  it('detects structural change when declaration is added', () => {
+    const filePath = 'src/lib.ts';
+    const fullPath = join(tmpDir, filePath);
+    execFileSync('mkdir', ['-p', join(tmpDir, 'src')]);
+
+    writeFileSync(fullPath, 'const x = 1;\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-m', 'initial'], tmpDir);
+
+    writeFileSync(
+      fullPath,
+      'const x = 1;\nfunction helper() { return 2; }\n',
+    );
+
+    const result = analyzeDiff(filePath, tmpDir);
+    expect(result.structural).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/indexer/diff-analyzer.ts` with `analyzeDiff()` that runs `git diff HEAD` and classifies changes as structural (exports, imports, declarations) vs non-structural (body-only edits)
- Adds `src/indexer/smart-summarizer.ts` with `smartSummarize()` that skips full re-summarization when only non-structural changes are detected, updating just `lineCount`
- Adds 5 unit tests covering structural export/import/declaration detection, body-only edits, and empty diff handling

Closes #23

## Test plan

- [x] All 137 unit tests pass (`npm test`)
- [x] TypeScript strict mode typecheck passes (`npm run typecheck`)
- [x] New tests use real git repos in temp directories to verify diff parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)