### PR TITLE
feat(telemetry): token telemetry tracking

### DIFF
--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -63,6 +63,23 @@ const MIGRATIONS: Array<{ version: number; up: (db: Database.Database) => void }
       `);
     },
   },
+  {
+    version: 4,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS telemetry (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          timestamp INTEGER NOT NULL,
+          event_type TEXT NOT NULL,
+          file_path TEXT,
+          tokens_estimated INTEGER,
+          metadata_json TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_telemetry_type ON telemetry (event_type);
+        CREATE INDEX IF NOT EXISTS idx_telemetry_timestamp ON telemetry (timestamp);
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database.Database): void {

--- a/src/telemetry/tracker.ts
+++ b/src/telemetry/tracker.ts
@@ -1,0 +1,156 @@
+import { getDatabase } from '../persistence/db.js';
+
+export type TelemetryEvent =
+  | 'cache_hit'
+  | 'cache_miss'
+  | 'invalidation'
+  | 'force_reread'
+  | 'summary_served';
+
+export interface TelemetryEntry {
+  id: number;
+  timestamp: number;
+  eventType: TelemetryEvent;
+  filePath: string | null;
+  tokensEstimated: number | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface TelemetryRow {
+  id: number;
+  timestamp: number;
+  event_type: string;
+  file_path: string | null;
+  tokens_estimated: number | null;
+  metadata_json: string | null;
+}
+
+export class TelemetryTracker {
+  private readonly projectRoot: string;
+  private enabled: boolean;
+
+  constructor(projectRoot: string, enabled: boolean = true) {
+    this.projectRoot = projectRoot;
+    this.enabled = enabled;
+  }
+
+  trackEvent(
+    eventType: TelemetryEvent,
+    filePath?: string,
+    tokensEstimated?: number,
+    metadata?: Record<string, unknown>,
+  ): void {
+    if (!this.enabled) return;
+
+    const db = getDatabase(this.projectRoot);
+    db.prepare(
+      'INSERT INTO telemetry (timestamp, event_type, file_path, tokens_estimated, metadata_json) VALUES (?, ?, ?, ?, ?)',
+    ).run(
+      Date.now(),
+      eventType,
+      filePath ?? null,
+      tokensEstimated ?? null,
+      metadata ? JSON.stringify(metadata) : null,
+    );
+  }
+
+  getEvents(filter?: {
+    eventType?: TelemetryEvent;
+    since?: number;
+    limit?: number;
+  }): TelemetryEntry[] {
+    const db = getDatabase(this.projectRoot);
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filter?.eventType) {
+      conditions.push('event_type = ?');
+      params.push(filter.eventType);
+    }
+    if (filter?.since) {
+      conditions.push('timestamp >= ?');
+      params.push(filter.since);
+    }
+
+    let sql = 'SELECT * FROM telemetry';
+    if (conditions.length > 0) {
+      sql += ' WHERE ' + conditions.join(' AND ');
+    }
+    sql += ' ORDER BY timestamp DESC';
+    if (filter?.limit) {
+      sql += ' LIMIT ?';
+      params.push(filter.limit);
+    }
+
+    const rows = db.prepare(sql).all(...params) as TelemetryRow[];
+    return rows.map(this.rowToEntry);
+  }
+
+  getStats(since?: number): {
+    totalEvents: number;
+    cacheHits: number;
+    cacheMisses: number;
+    hitRatio: number;
+    totalTokensSaved: number;
+    eventsByType: Record<string, number>;
+  } {
+    const db = getDatabase(this.projectRoot);
+    const whereClause = since ? ' WHERE timestamp >= ?' : '';
+    const params = since ? [since] : [];
+
+    const countRows = db
+      .prepare(
+        `SELECT event_type, COUNT(*) as cnt FROM telemetry${whereClause} GROUP BY event_type`,
+      )
+      .all(...params) as Array<{ event_type: string; cnt: number }>;
+
+    const eventsByType: Record<string, number> = {};
+    let totalEvents = 0;
+    let cacheHits = 0;
+    let cacheMisses = 0;
+
+    for (const row of countRows) {
+      eventsByType[row.event_type] = row.cnt;
+      totalEvents += row.cnt;
+      if (row.event_type === 'cache_hit') cacheHits = row.cnt;
+      if (row.event_type === 'cache_miss') cacheMisses = row.cnt;
+    }
+
+    const hitTotal = cacheHits + cacheMisses;
+    const hitRatio = hitTotal > 0 ? cacheHits / hitTotal : 0;
+
+    const tokenRow = db
+      .prepare(
+        `SELECT COALESCE(SUM(tokens_estimated), 0) as total FROM telemetry WHERE event_type = 'cache_hit'${since ? ' AND timestamp >= ?' : ''}`,
+      )
+      .get(...params) as { total: number };
+
+    return {
+      totalEvents,
+      cacheHits,
+      cacheMisses,
+      hitRatio,
+      totalTokensSaved: tokenRow.total,
+      eventsByType,
+    };
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  private rowToEntry(row: TelemetryRow): TelemetryEntry {
+    return {
+      id: row.id,
+      timestamp: row.timestamp,
+      eventType: row.event_type as TelemetryEvent,
+      filePath: row.file_path,
+      tokensEstimated: row.tokens_estimated,
+      metadata: row.metadata_json ? JSON.parse(row.metadata_json) : null,
+    };
+  }
+}

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { TelemetryTracker } from '../../src/telemetry/tracker.js';
+
+describe('TelemetryTracker', () => {
+  let tempDir: string;
+  let tracker: TelemetryTracker;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-telemetry-'));
+    tracker = new TelemetryTracker(tempDir);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('tracks cache_hit event', () => {
+    tracker.trackEvent('cache_hit', 'src/foo.ts', 200);
+    const events = tracker.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe('cache_hit');
+    expect(events[0].filePath).toBe('src/foo.ts');
+    expect(events[0].tokensEstimated).toBe(200);
+  });
+
+  it('tracks cache_miss event', () => {
+    tracker.trackEvent('cache_miss', 'src/bar.ts', 150);
+    const events = tracker.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe('cache_miss');
+    expect(events[0].filePath).toBe('src/bar.ts');
+    expect(events[0].tokensEstimated).toBe(150);
+  });
+
+  it('getStats computes correct hit ratio', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 100);
+    tracker.trackEvent('cache_hit', 'c.ts', 100);
+    tracker.trackEvent('cache_miss', 'd.ts', 100);
+
+    const stats = tracker.getStats();
+    expect(stats.cacheHits).toBe(3);
+    expect(stats.cacheMisses).toBe(1);
+    expect(stats.hitRatio).toBe(0.75);
+  });
+
+  it('getStats computes total tokens saved', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 250);
+    tracker.trackEvent('cache_miss', 'c.ts', 300);
+
+    const stats = tracker.getStats();
+    expect(stats.totalTokensSaved).toBe(350);
+  });
+
+  it('disabled tracker does not record events', () => {
+    const disabledTracker = new TelemetryTracker(tempDir, false);
+    disabledTracker.trackEvent('cache_hit', 'a.ts', 100);
+
+    expect(disabledTracker.isEnabled()).toBe(false);
+    const events = disabledTracker.getEvents();
+    expect(events).toHaveLength(0);
+  });
+
+  it('filters by event type', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_miss', 'b.ts', 200);
+    tracker.trackEvent('invalidation', 'c.ts');
+
+    const hits = tracker.getEvents({ eventType: 'cache_hit' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].eventType).toBe('cache_hit');
+
+    const misses = tracker.getEvents({ eventType: 'cache_miss' });
+    expect(misses).toHaveLength(1);
+    expect(misses[0].eventType).toBe('cache_miss');
+  });
+
+  it('filters by timestamp', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+
+    const futureTimestamp = Date.now() + 10000;
+    const events = tracker.getEvents({ since: futureTimestamp });
+    expect(events).toHaveLength(0);
+
+    const pastEvents = tracker.getEvents({ since: 0 });
+    expect(pastEvents).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds migration v4 creating `telemetry` table with indexes on `event_type` and `timestamp`
- Implements `TelemetryTracker` class for recording cache hit/miss events and computing token savings statistics
- Adds 7 unit tests covering event tracking, stats computation, disabled state, and filtering

Closes #33

## Test plan

- [x] `npm run typecheck` passes
- [x] All 139 unit tests pass (including 7 new telemetry tests)
- [x] cache_hit and cache_miss event tracking verified
- [x] Hit ratio and token savings computation verified
- [x] Disabled tracker no-op behavior verified
- [x] Event type and timestamp filtering verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)