### PR TITLE
feat(memory): cross-session persistence

### DIFF
--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '../persistence/db.js';
+
+export interface Session {
+  id: string;
+  startedAt: number;
+  endedAt: number | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface SessionRow {
+  id: string;
+  started_at: number;
+  ended_at: number | null;
+  metadata_json: string | null;
+}
+
+function rowToSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    metadata: row.metadata_json
+      ? (JSON.parse(row.metadata_json) as Record<string, unknown>)
+      : null,
+  };
+}
+
+export class SessionManager {
+  private readonly projectRoot: string;
+  private currentSessionId: string | null = null;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+  }
+
+  startSession(metadata?: Record<string, unknown>): Session {
+    const db = getDatabase(this.projectRoot);
+    const id = randomUUID();
+    const now = Date.now();
+    const metadataJson = metadata ? JSON.stringify(metadata) : null;
+
+    db.prepare(
+      `INSERT INTO sessions (id, started_at, ended_at, metadata_json)
+       VALUES (?, ?, NULL, ?)`,
+    ).run(id, now, metadataJson);
+
+    this.currentSessionId = id;
+
+    return {
+      id,
+      startedAt: now,
+      endedAt: null,
+      metadata: metadata ?? null,
+    };
+  }
+
+  endSession(sessionId: string): void {
+    const db = getDatabase(this.projectRoot);
+    const now = Date.now();
+
+    db.prepare('UPDATE sessions SET ended_at = ? WHERE id = ?').run(now, sessionId);
+
+    if (this.currentSessionId === sessionId) {
+      this.currentSessionId = null;
+    }
+  }
+
+  getCurrentSession(): Session | null {
+    if (!this.currentSessionId) {
+      return null;
+    }
+    return this.getSession(this.currentSessionId);
+  }
+
+  getSession(id: string): Session | null {
+    const db = getDatabase(this.projectRoot);
+    const row = db
+      .prepare('SELECT * FROM sessions WHERE id = ?')
+      .get(id) as SessionRow | undefined;
+
+    return row ? rowToSession(row) : null;
+  }
+
+  listSessions(limit?: number): Session[] {
+    const db = getDatabase(this.projectRoot);
+    const effectiveLimit = limit ?? 100;
+
+    const rows = db
+      .prepare('SELECT * FROM sessions ORDER BY started_at DESC LIMIT ?')
+      .all(effectiveLimit) as SessionRow[];
+
+    return rows.map(rowToSession);
+  }
+
+  getStaleFiles(sessionId: string): string[] {
+    const db = getDatabase(this.projectRoot);
+    const session = this.getSession(sessionId);
+    if (!session) {
+      return [];
+    }
+
+    const rows = db
+      .prepare('SELECT path FROM files WHERE last_checked < ?')
+      .all(session.startedAt) as Array<{ path: string }>;
+
+    return rows.map((r) => r.path);
+  }
+}

--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -63,6 +63,19 @@ const MIGRATIONS: Array<{ version: number; up: (db: Database.Database) => void }
       `);
     },
   },
+  {
+    version: 4,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS sessions (
+          id TEXT PRIMARY KEY,
+          started_at INTEGER NOT NULL,
+          ended_at INTEGER,
+          metadata_json TEXT
+        );
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database.Database): void {

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SessionManager } from '../../src/memory/session.js';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
+
+describe('SessionManager', () => {
+  let tempDir: string;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'session-test-'));
+    manager = new SessionManager(tempDir);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('startSession and endSession', () => {
+    it('starts a session with generated id and timestamps', () => {
+      const session = manager.startSession();
+
+      expect(session.id).toBeDefined();
+      expect(session.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(session.startedAt).toBeGreaterThan(0);
+      expect(session.endedAt).toBeNull();
+      expect(session.metadata).toBeNull();
+    });
+
+    it('starts a session with metadata', () => {
+      const meta = { agent: 'claude', version: '4.0' };
+      const session = manager.startSession(meta);
+
+      expect(session.metadata).toEqual(meta);
+
+      const retrieved = manager.getSession(session.id);
+      expect(retrieved?.metadata).toEqual(meta);
+    });
+
+    it('ends a session by setting ended_at', () => {
+      const session = manager.startSession();
+      manager.endSession(session.id);
+
+      const ended = manager.getSession(session.id);
+      expect(ended).not.toBeNull();
+      expect(ended!.endedAt).not.toBeNull();
+      expect(ended!.endedAt).toBeGreaterThanOrEqual(ended!.startedAt);
+    });
+  });
+
+  describe('getCurrentSession', () => {
+    it('returns null when no session started', () => {
+      expect(manager.getCurrentSession()).toBeNull();
+    });
+
+    it('returns the active session', () => {
+      const session = manager.startSession();
+      const current = manager.getCurrentSession();
+
+      expect(current).not.toBeNull();
+      expect(current!.id).toBe(session.id);
+    });
+
+    it('returns null after session ends', () => {
+      const session = manager.startSession();
+      manager.endSession(session.id);
+
+      expect(manager.getCurrentSession()).toBeNull();
+    });
+
+    it('tracks the most recently started session', () => {
+      const s1 = manager.startSession();
+      manager.endSession(s1.id);
+
+      const s2 = manager.startSession();
+      const current = manager.getCurrentSession();
+
+      expect(current!.id).toBe(s2.id);
+    });
+  });
+
+  describe('listSessions', () => {
+    it('returns sessions in reverse chronological order', () => {
+      // Insert sessions with explicit distinct timestamps to avoid
+      // same-millisecond ordering issues
+      const db = getDatabase(tempDir);
+      const now = Date.now();
+
+      const ids = ['aaa', 'bbb', 'ccc'];
+      db.prepare(
+        'INSERT INTO sessions (id, started_at, ended_at, metadata_json) VALUES (?, ?, NULL, NULL)',
+      ).run(ids[0], now - 2000);
+      db.prepare(
+        'INSERT INTO sessions (id, started_at, ended_at, metadata_json) VALUES (?, ?, NULL, NULL)',
+      ).run(ids[1], now - 1000);
+      db.prepare(
+        'INSERT INTO sessions (id, started_at, ended_at, metadata_json) VALUES (?, ?, NULL, NULL)',
+      ).run(ids[2], now);
+
+      const sessions = manager.listSessions();
+
+      expect(sessions).toHaveLength(3);
+      expect(sessions[0].id).toBe('ccc');
+      expect(sessions[1].id).toBe('bbb');
+      expect(sessions[2].id).toBe('aaa');
+    });
+
+    it('respects limit parameter', () => {
+      manager.startSession();
+      manager.startSession();
+      manager.startSession();
+
+      const sessions = manager.listSessions(2);
+      expect(sessions).toHaveLength(2);
+    });
+
+    it('returns empty array when no sessions exist', () => {
+      expect(manager.listSessions()).toHaveLength(0);
+    });
+  });
+
+  describe('getSession', () => {
+    it('returns null for non-existent id', () => {
+      expect(manager.getSession('non-existent')).toBeNull();
+    });
+
+    it('retrieves a session by id', () => {
+      const created = manager.startSession({ key: 'value' });
+      const retrieved = manager.getSession(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.id).toBe(created.id);
+      expect(retrieved!.startedAt).toBe(created.startedAt);
+      expect(retrieved!.metadata).toEqual({ key: 'value' });
+    });
+  });
+
+  describe('getStaleFiles', () => {
+    it('detects files checked before session start', () => {
+      const db = getDatabase(tempDir);
+
+      // Insert a file with last_checked in the past
+      const pastTime = Date.now() - 60_000;
+      db.prepare(
+        'INSERT INTO files (path, hash, last_checked) VALUES (?, ?, ?)',
+      ).run('src/old.ts', 'abc123', pastTime);
+      db.prepare(
+        'INSERT INTO files (path, hash, last_checked) VALUES (?, ?, ?)',
+      ).run('src/ancient.ts', 'def456', pastTime - 10_000);
+
+      // Start a new session (its started_at will be > pastTime)
+      const session = manager.startSession();
+
+      const stale = manager.getStaleFiles(session.id);
+      expect(stale).toContain('src/old.ts');
+      expect(stale).toContain('src/ancient.ts');
+      expect(stale).toHaveLength(2);
+    });
+
+    it('does not include files checked after session start', () => {
+      const session = manager.startSession();
+
+      const db = getDatabase(tempDir);
+      // Insert a file checked after the session started
+      const futureTime = Date.now() + 60_000;
+      db.prepare(
+        'INSERT INTO files (path, hash, last_checked) VALUES (?, ?, ?)',
+      ).run('src/fresh.ts', 'xyz789', futureTime);
+
+      const stale = manager.getStaleFiles(session.id);
+      expect(stale).not.toContain('src/fresh.ts');
+    });
+
+    it('returns empty array for non-existent session', () => {
+      expect(manager.getStaleFiles('non-existent')).toHaveLength(0);
+    });
+  });
+
+  describe('multiple sessions', () => {
+    it('tracks sessions independently', () => {
+      const s1 = manager.startSession({ name: 'session-1' });
+      manager.endSession(s1.id);
+
+      const s2 = manager.startSession({ name: 'session-2' });
+
+      const retrieved1 = manager.getSession(s1.id);
+      const retrieved2 = manager.getSession(s2.id);
+
+      expect(retrieved1).not.toBeNull();
+      expect(retrieved2).not.toBeNull();
+      expect(retrieved1!.endedAt).not.toBeNull();
+      expect(retrieved2!.endedAt).toBeNull();
+      expect(retrieved1!.metadata).toEqual({ name: 'session-1' });
+      expect(retrieved2!.metadata).toEqual({ name: 'session-2' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds v4 migration creating `sessions` table for tracking server session lifecycles
- Implements `SessionManager` class with start/end session, listing, and stale file detection
- Stale file detection identifies files not checked since the current session began, enabling re-validation across session boundaries

Closes #31

## Test plan
- [x] Start and end session with timestamps
- [x] List sessions in reverse chronological order
- [x] Get current session tracking
- [x] Stale files detected (files checked before session start)
- [x] Multiple sessions tracked independently
- [x] All 148 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)