### PR TITLE
feat(tools): implement get_token_report MCP tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import { forceReread } from './tools/force-reread.js';
 import { invalidateCache } from './tools/invalidate.js';
 import { getDependencyGraphTool } from './tools/get-dependency-graph.js';
 import { createTaskTool, getTaskContext, markExploredTool } from './tools/task-context.js';
+import { getTokenReport } from './tools/get-token-report.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -176,6 +177,32 @@ server.registerTool('mark_explored', {
   const result = markExploredTool(projectRoot, task_id, path, status, notes);
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+  };
+});
+
+server.registerTool('get_token_report', {
+  title: 'Get Token Report',
+  description:
+    'Get aggregated token usage telemetry report showing cache efficiency and token savings',
+  inputSchema: {
+    period: z
+      .enum(['session', 'all', 'last_n_hours'])
+      .optional()
+      .describe('Time period for the report'),
+    hours: z
+      .number()
+      .optional()
+      .describe('Number of hours to look back (only for last_n_hours period)'),
+    session_id: z
+      .string()
+      .optional()
+      .describe('Session ID (only for session period)'),
+  },
+}, async ({ period, hours, session_id }) => {
+  const projectRoot = process.cwd();
+  const report = getTokenReport(projectRoot, period, hours, session_id);
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(report, null, 2) }],
   };
 });
 

--- a/src/tools/get-token-report.ts
+++ b/src/tools/get-token-report.ts
@@ -1,0 +1,64 @@
+import { TelemetryTracker } from '../telemetry/tracker.js';
+import { SessionManager } from '../memory/session.js';
+
+export interface TokenReport {
+  period: string;
+  totalEvents: number;
+  cacheHits: number;
+  cacheMisses: number;
+  cacheHitRatio: number;
+  estimatedTokensSaved: number;
+  topFiles: Array<{ path: string; accessCount: number; tokensEstimated: number }>;
+  eventBreakdown: Record<string, number>;
+}
+
+export function getTokenReport(
+  projectRoot: string,
+  period?: 'session' | 'all' | 'last_n_hours',
+  hours?: number,
+  sessionId?: string,
+): TokenReport {
+  const tracker = new TelemetryTracker(projectRoot);
+  const effectivePeriod = period ?? 'all';
+
+  let since: number | undefined;
+
+  if (effectivePeriod === 'session' && sessionId) {
+    const sessionManager = new SessionManager(projectRoot);
+    const session = sessionManager.getSession(sessionId);
+    if (session) {
+      since = session.startedAt;
+    }
+  } else if (effectivePeriod === 'last_n_hours' && hours != null) {
+    since = Date.now() - hours * 3600000;
+  }
+
+  const events = tracker.getEvents({ since });
+  const stats = tracker.getStats(since);
+
+  // Aggregate top files by access count and tokens
+  const fileMap = new Map<string, { accessCount: number; tokensEstimated: number }>();
+  for (const event of events) {
+    if (!event.filePath) continue;
+    const entry = fileMap.get(event.filePath) ?? { accessCount: 0, tokensEstimated: 0 };
+    entry.accessCount++;
+    entry.tokensEstimated += event.tokensEstimated ?? 0;
+    fileMap.set(event.filePath, entry);
+  }
+
+  const topFiles = [...fileMap.entries()]
+    .map(([path, data]) => ({ path, ...data }))
+    .sort((a, b) => b.accessCount - a.accessCount)
+    .slice(0, 10);
+
+  return {
+    period: effectivePeriod,
+    totalEvents: stats.totalEvents,
+    cacheHits: stats.cacheHits,
+    cacheMisses: stats.cacheMisses,
+    cacheHitRatio: stats.hitRatio,
+    estimatedTokensSaved: stats.totalTokensSaved,
+    topFiles,
+    eventBreakdown: stats.eventsByType,
+  };
+}

--- a/tests/unit/get-token-report.test.ts
+++ b/tests/unit/get-token-report.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
+import { TelemetryTracker } from '../../src/telemetry/tracker.js';
+import { SessionManager } from '../../src/memory/session.js';
+import { getTokenReport } from '../../src/tools/get-token-report.js';
+
+describe('getTokenReport', () => {
+  let tempDir: string;
+  let tracker: TelemetryTracker;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-token-report-'));
+    tracker = new TelemetryTracker(tempDir);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns empty/zero report when no telemetry data', () => {
+    const report = getTokenReport(tempDir);
+    expect(report.period).toBe('all');
+    expect(report.totalEvents).toBe(0);
+    expect(report.cacheHits).toBe(0);
+    expect(report.cacheMisses).toBe(0);
+    expect(report.cacheHitRatio).toBe(0);
+    expect(report.estimatedTokensSaved).toBe(0);
+    expect(report.topFiles).toEqual([]);
+    expect(report.eventBreakdown).toEqual({});
+  });
+
+  it('correctly counts cache hits and misses', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 200);
+    tracker.trackEvent('cache_miss', 'c.ts', 300);
+
+    const report = getTokenReport(tempDir);
+    expect(report.cacheHits).toBe(2);
+    expect(report.cacheMisses).toBe(1);
+  });
+
+  it('calculates cache hit ratio', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 100);
+    tracker.trackEvent('cache_hit', 'c.ts', 100);
+    tracker.trackEvent('cache_miss', 'd.ts', 100);
+
+    const report = getTokenReport(tempDir);
+    expect(report.cacheHitRatio).toBe(0.75);
+  });
+
+  it('estimates tokens saved from cache hits', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 250);
+    tracker.trackEvent('cache_miss', 'c.ts', 300);
+
+    const report = getTokenReport(tempDir);
+    expect(report.estimatedTokensSaved).toBe(350);
+  });
+
+  it('lists top accessed files sorted by access count', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 200);
+    tracker.trackEvent('cache_miss', 'c.ts', 50);
+
+    const report = getTokenReport(tempDir);
+    expect(report.topFiles).toHaveLength(3);
+    expect(report.topFiles[0].path).toBe('a.ts');
+    expect(report.topFiles[0].accessCount).toBe(3);
+    expect(report.topFiles[0].tokensEstimated).toBe(300);
+    // b.ts and c.ts both have accessCount 1, so just check they are present
+    const remainingPaths = report.topFiles.slice(1).map((f) => f.path);
+    expect(remainingPaths).toContain('b.ts');
+    expect(remainingPaths).toContain('c.ts');
+    expect(report.topFiles[1].accessCount).toBe(1);
+  });
+
+  it('limits top files to 10', () => {
+    for (let i = 0; i < 15; i++) {
+      tracker.trackEvent('cache_hit', `file${i}.ts`, 100);
+    }
+
+    const report = getTokenReport(tempDir);
+    expect(report.topFiles).toHaveLength(10);
+  });
+
+  it('filters by time period (last_n_hours)', () => {
+    // Insert an event 2 hours in the past via raw SQL
+    const db = getDatabase(tempDir);
+    const twoHoursAgo = Date.now() - 2 * 3600000;
+    db.prepare(
+      'INSERT INTO telemetry (timestamp, event_type, file_path, tokens_estimated) VALUES (?, ?, ?, ?)',
+    ).run(twoHoursAgo, 'cache_hit', 'old.ts', 100);
+
+    // Record a recent event
+    tracker.trackEvent('cache_hit', 'new.ts', 200);
+
+    // Looking back 1 hour should only find the recent event
+    const report = getTokenReport(tempDir, 'last_n_hours', 1);
+    expect(report.period).toBe('last_n_hours');
+    expect(report.totalEvents).toBe(1);
+    expect(report.topFiles[0].path).toBe('new.ts');
+
+    // Looking back 3 hours should find both events
+    const fullReport = getTokenReport(tempDir, 'last_n_hours', 3);
+    expect(fullReport.totalEvents).toBe(2);
+  });
+
+  it('session-scoped report works', () => {
+    // Record an event well in the past
+    const db = getDatabase(tempDir);
+    const pastTimestamp = Date.now() - 60000;
+    db.prepare(
+      'INSERT INTO telemetry (timestamp, event_type, file_path, tokens_estimated) VALUES (?, ?, ?, ?)',
+    ).run(pastTimestamp, 'cache_hit', 'before.ts', 100);
+
+    const sessionManager = new SessionManager(tempDir);
+    const session = sessionManager.startSession();
+
+    // Record events after session starts
+    tracker.trackEvent('cache_hit', 'after.ts', 200);
+    tracker.trackEvent('cache_miss', 'after2.ts', 150);
+
+    const report = getTokenReport(tempDir, 'session', undefined, session.id);
+    expect(report.period).toBe('session');
+    expect(report.totalEvents).toBe(2);
+    expect(report.cacheHits).toBe(1);
+    expect(report.cacheMisses).toBe(1);
+    expect(report.estimatedTokensSaved).toBe(200);
+  });
+
+  it('event breakdown by type', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('cache_hit', 'b.ts', 200);
+    tracker.trackEvent('cache_miss', 'c.ts', 300);
+    tracker.trackEvent('invalidation', 'd.ts');
+    tracker.trackEvent('force_reread', 'e.ts', 500);
+
+    const report = getTokenReport(tempDir);
+    expect(report.eventBreakdown).toEqual({
+      cache_hit: 2,
+      cache_miss: 1,
+      invalidation: 1,
+      force_reread: 1,
+    });
+  });
+
+  it('defaults to "all" period when none specified', () => {
+    const report = getTokenReport(tempDir);
+    expect(report.period).toBe('all');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `get_token_report` MCP tool that provides aggregated token usage telemetry reports
- Reports cache hit/miss ratio, estimated tokens saved, top accessed files, and event breakdowns
- Supports three time periods: `all` (default), `last_n_hours`, and `session`-scoped filtering
- 10 unit tests covering all report scenarios

## Test plan
- [x] All 10 new unit tests pass (`npx vitest run tests/unit/get-token-report.test.ts`)
- [x] All 170 existing tests still pass (`npx vitest run`)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)