### PR TITLE
feat(cache): stale summary invalidation and GC

### DIFF
--- a/src/cache/gc.ts
+++ b/src/cache/gc.ts
@@ -1,0 +1,117 @@
+import { getDatabase } from '../persistence/db.js';
+import { CacheStore } from './store.js';
+import { scanProject } from '../indexer/scanner.js';
+
+export interface GCOptions {
+  cacheMaxAgeDays?: number;
+  taskMaxAgeDays?: number;
+  telemetryMaxAgeDays?: number;
+  dryRun?: boolean;
+}
+
+export interface GCResult {
+  removedCacheEntries: string[];
+  removedTasks: string[];
+  removedTelemetryCount: number;
+  removedOrphanImports: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export async function runGC(
+  projectRoot: string,
+  options?: GCOptions,
+): Promise<GCResult> {
+  const cacheMaxAgeDays = options?.cacheMaxAgeDays ?? 30;
+  const taskMaxAgeDays = options?.taskMaxAgeDays ?? 30;
+  const telemetryMaxAgeDays = options?.telemetryMaxAgeDays ?? 90;
+  const dryRun = options?.dryRun ?? false;
+
+  const db = getDatabase(projectRoot);
+  const store = new CacheStore(projectRoot);
+
+  const result: GCResult = {
+    removedCacheEntries: [],
+    removedTasks: [],
+    removedTelemetryCount: 0,
+    removedOrphanImports: 0,
+  };
+
+  // 1. Remove cache entries for deleted files
+  const currentFiles = new Set(await scanProject(projectRoot));
+  const allEntries = store.getAllEntries();
+  const deletedFilePaths = allEntries
+    .filter((entry) => !currentFiles.has(entry.path))
+    .map((entry) => entry.path);
+
+  result.removedCacheEntries.push(...deletedFilePaths);
+
+  // 2. Remove old cache entries (by lastChecked age)
+  const cacheCutoff = Date.now() - cacheMaxAgeDays * MS_PER_DAY;
+  const staleEntries = store.getStaleEntries(cacheMaxAgeDays * MS_PER_DAY);
+  const stalePaths = staleEntries
+    .filter((entry) => !result.removedCacheEntries.includes(entry.path))
+    .map((entry) => entry.path);
+
+  result.removedCacheEntries.push(...stalePaths);
+
+  if (!dryRun) {
+    for (const path of result.removedCacheEntries) {
+      store.deleteEntry(path);
+    }
+  }
+
+  // 3. Remove old completed/archived tasks
+  const taskCutoff = Date.now() - taskMaxAgeDays * MS_PER_DAY;
+  const oldTasks = db
+    .prepare(
+      `SELECT id FROM tasks
+       WHERE state IN ('completed', 'archived')
+         AND updated_at < ?`,
+    )
+    .all(taskCutoff) as Array<{ id: string }>;
+
+  result.removedTasks = oldTasks.map((t) => t.id);
+
+  if (!dryRun && result.removedTasks.length > 0) {
+    const deleteTaskFiles = db.prepare('DELETE FROM task_files WHERE task_id = ?');
+    const deleteTask = db.prepare('DELETE FROM tasks WHERE id = ?');
+    const deleteTasks = db.transaction(() => {
+      for (const id of result.removedTasks) {
+        deleteTaskFiles.run(id);
+        deleteTask.run(id);
+      }
+    });
+    deleteTasks();
+  }
+
+  // 4. Remove old telemetry events
+  const telemetryCutoff = Date.now() - telemetryMaxAgeDays * MS_PER_DAY;
+  const telemetryCount = db
+    .prepare('SELECT COUNT(*) as count FROM telemetry WHERE timestamp < ?')
+    .get(telemetryCutoff) as { count: number };
+
+  result.removedTelemetryCount = telemetryCount.count;
+
+  if (!dryRun && result.removedTelemetryCount > 0) {
+    db.prepare('DELETE FROM telemetry WHERE timestamp < ?').run(telemetryCutoff);
+  }
+
+  // 5. Remove orphan import records (source not in files table)
+  const orphanCount = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM imports
+       WHERE source NOT IN (SELECT path FROM files)`,
+    )
+    .get() as { count: number };
+
+  result.removedOrphanImports = orphanCount.count;
+
+  if (!dryRun && result.removedOrphanImports > 0) {
+    db.prepare(
+      'DELETE FROM imports WHERE source NOT IN (SELECT path FROM files)',
+    ).run();
+  }
+
+  return result;
+}

--- a/tests/unit/gc.test.ts
+++ b/tests/unit/gc.test.ts
@@ -1,0 +1,241 @@
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runGC } from '../../src/cache/gc.js';
+import { CacheStore } from '../../src/cache/store.js';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
+import type Database from 'better-sqlite3';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+describe('runGC', () => {
+  let tempDir: string;
+  let store: CacheStore;
+  let db: Database.Database;
+
+  function initGitRepo(dir: string): void {
+    execSync('git init', { cwd: dir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: dir, stdio: 'ignore' });
+  }
+
+  function createFile(name: string, content = 'export {};\n'): void {
+    const filePath = join(tempDir, name);
+    const dir = join(filePath, '..');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, content);
+    execSync(`git add "${name}"`, { cwd: tempDir, stdio: 'ignore' });
+    execSync('git commit -m "add file" --allow-empty', { cwd: tempDir, stdio: 'ignore' });
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'repo-memory-gc-test-'));
+    initGitRepo(tempDir);
+    // Create at least one file so git repo is valid
+    createFile('src/keep.ts');
+    store = new CacheStore(tempDir);
+    db = getDatabase(tempDir);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('removes cache entries for files that no longer exist on disk', async () => {
+    // Add entries for existing and non-existing files
+    store.setEntry('src/keep.ts', 'hash1', null);
+    store.setEntry('src/deleted.ts', 'hash2', null);
+
+    const result = await runGC(tempDir);
+
+    expect(result.removedCacheEntries).toContain('src/deleted.ts');
+    expect(result.removedCacheEntries).not.toContain('src/keep.ts');
+    expect(store.getEntry('src/deleted.ts')).toBeNull();
+    expect(store.getEntry('src/keep.ts')).not.toBeNull();
+  });
+
+  it('removes cache entries older than threshold', async () => {
+    store.setEntry('src/keep.ts', 'hash1', null);
+    // Make entry old
+    const oldTimestamp = Date.now() - 31 * MS_PER_DAY;
+    db.prepare('UPDATE files SET last_checked = ? WHERE path = ?').run(
+      oldTimestamp,
+      'src/keep.ts',
+    );
+
+    const result = await runGC(tempDir, { cacheMaxAgeDays: 30 });
+
+    expect(result.removedCacheEntries).toContain('src/keep.ts');
+    expect(store.getEntry('src/keep.ts')).toBeNull();
+  });
+
+  it('keeps recent cache entries', async () => {
+    store.setEntry('src/keep.ts', 'hash1', null);
+
+    const result = await runGC(tempDir, { cacheMaxAgeDays: 30 });
+
+    expect(result.removedCacheEntries).not.toContain('src/keep.ts');
+    expect(store.getEntry('src/keep.ts')).not.toBeNull();
+  });
+
+  it('removes completed tasks older than threshold', async () => {
+    const oldTimestamp = Date.now() - 31 * MS_PER_DAY;
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-old-completed', 'Old completed task', 'completed', oldTimestamp, oldTimestamp);
+
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-old-archived', 'Old archived task', 'archived', oldTimestamp, oldTimestamp);
+
+    const result = await runGC(tempDir, { taskMaxAgeDays: 30 });
+
+    expect(result.removedTasks).toContain('task-old-completed');
+    expect(result.removedTasks).toContain('task-old-archived');
+
+    const remaining = db.prepare('SELECT id FROM tasks').all();
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('does NOT remove active tasks regardless of age', async () => {
+    const oldTimestamp = Date.now() - 365 * MS_PER_DAY;
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-active', 'Active task', 'active', oldTimestamp, oldTimestamp);
+
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-created', 'Created task', 'created', oldTimestamp, oldTimestamp);
+
+    const result = await runGC(tempDir, { taskMaxAgeDays: 1 });
+
+    expect(result.removedTasks).not.toContain('task-active');
+    expect(result.removedTasks).not.toContain('task-created');
+
+    const remaining = db.prepare('SELECT id FROM tasks').all() as Array<{ id: string }>;
+    expect(remaining).toHaveLength(2);
+  });
+
+  it('removes old telemetry events', async () => {
+    const oldTimestamp = Date.now() - 91 * MS_PER_DAY;
+    const recentTimestamp = Date.now();
+
+    db.prepare(
+      `INSERT INTO telemetry (timestamp, event_type, file_path, tokens_estimated)
+       VALUES (?, ?, ?, ?)`,
+    ).run(oldTimestamp, 'summarize', 'src/old.ts', 100);
+
+    db.prepare(
+      `INSERT INTO telemetry (timestamp, event_type, file_path, tokens_estimated)
+       VALUES (?, ?, ?, ?)`,
+    ).run(recentTimestamp, 'summarize', 'src/new.ts', 200);
+
+    const result = await runGC(tempDir, { telemetryMaxAgeDays: 90 });
+
+    expect(result.removedTelemetryCount).toBe(1);
+
+    const remaining = db.prepare('SELECT * FROM telemetry').all();
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('removes orphan import records', async () => {
+    // Add a file entry and an import from it
+    store.setEntry('src/keep.ts', 'hash1', null);
+    db.prepare(
+      `INSERT INTO imports (source, target, specifiers, import_type)
+       VALUES (?, ?, ?, ?)`,
+    ).run('src/keep.ts', 'src/other.ts', 'foo', 'static');
+
+    // Add an orphan import (source not in files table)
+    db.prepare(
+      `INSERT INTO imports (source, target, specifiers, import_type)
+       VALUES (?, ?, ?, ?)`,
+    ).run('src/deleted.ts', 'src/other.ts', 'bar', 'static');
+
+    const result = await runGC(tempDir);
+
+    expect(result.removedOrphanImports).toBe(1);
+
+    const remaining = db
+      .prepare('SELECT source FROM imports')
+      .all() as Array<{ source: string }>;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].source).toBe('src/keep.ts');
+  });
+
+  it('dry run returns results without deleting', async () => {
+    store.setEntry('src/keep.ts', 'hash1', null);
+    store.setEntry('src/deleted.ts', 'hash2', null);
+
+    const oldTimestamp = Date.now() - 91 * MS_PER_DAY;
+    db.prepare(
+      `INSERT INTO telemetry (timestamp, event_type) VALUES (?, ?)`,
+    ).run(oldTimestamp, 'summarize');
+
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-old', 'Old task', 'completed', oldTimestamp, oldTimestamp);
+
+    const result = await runGC(tempDir, { dryRun: true });
+
+    expect(result.removedCacheEntries).toContain('src/deleted.ts');
+    expect(result.removedTasks).toContain('task-old');
+    expect(result.removedTelemetryCount).toBe(1);
+
+    // Nothing actually deleted
+    expect(store.getEntry('src/deleted.ts')).not.toBeNull();
+    expect(db.prepare('SELECT * FROM telemetry').all()).toHaveLength(1);
+    expect(db.prepare('SELECT * FROM tasks').all()).toHaveLength(1);
+  });
+
+  it('default thresholds work correctly', async () => {
+    // Entry at 29 days should be kept with default 30-day threshold
+    const recentOldTimestamp = Date.now() - 29 * MS_PER_DAY;
+    store.setEntry('src/keep.ts', 'hash1', null);
+    db.prepare('UPDATE files SET last_checked = ? WHERE path = ?').run(
+      recentOldTimestamp,
+      'src/keep.ts',
+    );
+
+    const result = await runGC(tempDir);
+
+    expect(result.removedCacheEntries).not.toContain('src/keep.ts');
+  });
+
+  it('custom thresholds work', async () => {
+    // Entry at 3 days old, with 2-day threshold should be removed
+    const timestamp = Date.now() - 3 * MS_PER_DAY;
+    store.setEntry('src/keep.ts', 'hash1', null);
+    db.prepare('UPDATE files SET last_checked = ? WHERE path = ?').run(
+      timestamp,
+      'src/keep.ts',
+    );
+
+    db.prepare(
+      `INSERT INTO tasks (id, name, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('task-1', 'Task', 'completed', timestamp, timestamp);
+
+    db.prepare(
+      `INSERT INTO telemetry (timestamp, event_type) VALUES (?, ?)`,
+    ).run(timestamp, 'summarize');
+
+    const result = await runGC(tempDir, {
+      cacheMaxAgeDays: 2,
+      taskMaxAgeDays: 2,
+      telemetryMaxAgeDays: 2,
+    });
+
+    expect(result.removedCacheEntries).toContain('src/keep.ts');
+    expect(result.removedTasks).toContain('task-1');
+    expect(result.removedTelemetryCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/cache/gc.ts` with `runGC()` function that performs garbage collection on stale/orphaned database entries
- Cleans up: deleted file cache entries, old cache entries, completed/archived tasks past retention, old telemetry events, and orphan import records
- Supports configurable thresholds (`cacheMaxAgeDays`, `taskMaxAgeDays`, `telemetryMaxAgeDays`) and dry-run mode
- Add comprehensive test suite with 10 test cases covering all GC operations

## Test plan

- [x] All 10 new GC tests pass (`npx vitest run tests/unit/gc.test.ts`)
- [x] All 207 existing tests still pass (`npx vitest run`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)