### PR TITLE
feat(security): path traversal prevention and input validation

### DIFF
--- a/src/tools/force-reread.ts
+++ b/src/tools/force-reread.ts
@@ -4,11 +4,13 @@ import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
 import { summarizeFile } from '../indexer/summarizer.js';
 import type { FileSummary } from '../types.js';
+import { validatePath } from '../utils/validate-path.js';
 
 export async function forceReread(
   projectRoot: string,
   relativePath: string,
 ): Promise<{ path: string; hash: string; summary: FileSummary; reread: true }> {
+  relativePath = validatePath(projectRoot, relativePath);
   const absolutePath = join(projectRoot, relativePath);
   const contents = await readFile(absolutePath, 'utf-8');
   const hash = hashContents(contents);

--- a/src/tools/get-dependency-graph.ts
+++ b/src/tools/get-dependency-graph.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DependencyGraph } from '../graph/dependency-graph.js';
 import { scanProject } from '../indexer/scanner.js';
+import { validatePath } from '../utils/validate-path.js';
 
 export interface DependencyGraphResult {
   nodes: string[];
@@ -19,6 +20,9 @@ export async function getDependencyGraphTool(
   direction?: 'dependencies' | 'dependents' | 'both',
   depth?: number,
 ): Promise<DependencyGraphResult> {
+  if (path) {
+    path = validatePath(projectRoot, path);
+  }
   const graph = new DependencyGraph(projectRoot);
 
   // Index all files to build the graph

--- a/src/tools/get-file-summary.ts
+++ b/src/tools/get-file-summary.ts
@@ -4,11 +4,13 @@ import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
 import { summarizeFile } from '../indexer/summarizer.js';
 import type { FileSummary } from '../types.js';
+import { validatePath } from '../utils/validate-path.js';
 
 export async function getFileSummary(
   projectRoot: string,
   relativePath: string,
 ): Promise<{ path: string; hash: string; summary: FileSummary; fromCache: boolean }> {
+  relativePath = validatePath(projectRoot, relativePath);
   const store = new CacheStore(projectRoot);
   const absolutePath = join(projectRoot, relativePath);
 

--- a/src/tools/invalidate.ts
+++ b/src/tools/invalidate.ts
@@ -1,9 +1,13 @@
 import { CacheStore } from '../cache/store.js';
+import { validatePath } from '../utils/validate-path.js';
 
 export async function invalidateCache(
   projectRoot: string,
   path?: string,
 ): Promise<{ invalidated: string | 'all'; entriesRemoved: number }> {
+  if (path) {
+    path = validatePath(projectRoot, path);
+  }
   const store = new CacheStore(projectRoot);
 
   if (path) {

--- a/src/tools/task-context.ts
+++ b/src/tools/task-context.ts
@@ -1,4 +1,5 @@
 import { TaskMemory, type Task, type TaskFile } from '../memory/task.js';
+import { validatePath } from '../utils/validate-path.js';
 
 export interface TaskContextResult {
   task: Task;
@@ -50,6 +51,7 @@ export function markExploredTool(
   status?: 'explored' | 'skipped' | 'flagged',
   notes?: string,
 ): { marked: true; taskId: string; path: string; status: string } {
+  path = validatePath(projectRoot, path);
   const memory = new TaskMemory(projectRoot);
   memory.markExplored(taskId, path, status, notes);
   return { marked: true, taskId, path, status: status ?? 'explored' };

--- a/src/utils/validate-path.ts
+++ b/src/utils/validate-path.ts
@@ -1,0 +1,29 @@
+import { resolve, normalize, relative, sep } from 'node:path';
+
+/**
+ * Validates that a file path is safe and resolves within the project root.
+ * Throws an error if the path attempts traversal outside the project.
+ *
+ * @param projectRoot - The absolute path to the project root directory.
+ * @param filePath - The file path to validate (relative or absolute).
+ * @returns The validated relative path (relative to projectRoot).
+ */
+export function validatePath(projectRoot: string, filePath: string): string {
+  if (filePath.includes('\0')) {
+    throw new Error(`Invalid path: null byte detected in "${filePath}"`);
+  }
+
+  const normalizedRoot = normalize(resolve(projectRoot));
+  const resolvedPath = normalize(resolve(projectRoot, filePath));
+
+  if (
+    resolvedPath !== normalizedRoot &&
+    !resolvedPath.startsWith(normalizedRoot + sep)
+  ) {
+    throw new Error(
+      `Path traversal detected: ${filePath} resolves outside project root`,
+    );
+  }
+
+  return relative(normalizedRoot, resolvedPath);
+}

--- a/tests/unit/path-security.test.ts
+++ b/tests/unit/path-security.test.ts
@@ -1,0 +1,63 @@
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { getFileSummary } from '../../src/tools/get-file-summary.js';
+import { forceReread } from '../../src/tools/force-reread.js';
+import { markExploredTool } from '../../src/tools/task-context.js';
+
+describe('path security integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'repo-memory-security-'));
+    await mkdir(join(tempDir, 'src'), { recursive: true });
+    await writeFile(
+      join(tempDir, 'src/index.ts'),
+      'export const hello = "world";\n',
+      'utf-8',
+    );
+    // Initialize git repo (needed for scanner)
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git add .', { cwd: tempDir, stdio: 'ignore' });
+    execSync(
+      'git -c user.name="Test" -c user.email="test@test.com" commit -m "init"',
+      { cwd: tempDir, stdio: 'ignore' },
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('getFileSummary rejects path traversal', async () => {
+    await expect(
+      getFileSummary(tempDir, '../../etc/passwd'),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('forceReread rejects path traversal', async () => {
+    await expect(
+      forceReread(tempDir, '../../../tmp/evil'),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('markExploredTool rejects path traversal', () => {
+    expect(() =>
+      markExploredTool(tempDir, 'task-1', '../../outside'),
+    ).toThrow('Path traversal detected');
+  });
+
+  it('getFileSummary allows normal paths', async () => {
+    const result = await getFileSummary(tempDir, 'src/index.ts');
+    expect(result.path).toBe('src/index.ts');
+    expect(result.summary).toBeDefined();
+  });
+
+  it('forceReread allows normal paths', async () => {
+    const result = await forceReread(tempDir, 'src/index.ts');
+    expect(result.path).toBe('src/index.ts');
+    expect(result.reread).toBe(true);
+  });
+});

--- a/tests/unit/validate-path.test.ts
+++ b/tests/unit/validate-path.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { validatePath } from '../../src/utils/validate-path.js';
+
+describe('validatePath', () => {
+  const projectRoot = '/home/user/project';
+
+  it('passes a normal relative path', () => {
+    expect(validatePath(projectRoot, 'src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('normalizes a path with ../ that stays within project', () => {
+    expect(validatePath(projectRoot, 'src/../src/index.ts')).toBe(
+      'src/index.ts',
+    );
+  });
+
+  it('throws for path traversal outside project root', () => {
+    expect(() => validatePath(projectRoot, '../../etc/passwd')).toThrow(
+      'Path traversal detected',
+    );
+  });
+
+  it('throws for absolute path outside project root', () => {
+    expect(() => validatePath(projectRoot, '/etc/passwd')).toThrow(
+      'Path traversal detected',
+    );
+  });
+
+  it('passes for absolute path inside project root and returns relative', () => {
+    const absPath = join(projectRoot, 'src/index.ts');
+    expect(validatePath(projectRoot, absPath)).toBe('src/index.ts');
+  });
+
+  it('throws for null bytes in path', () => {
+    expect(() => validatePath(projectRoot, 'src/\0evil.ts')).toThrow(
+      'null byte',
+    );
+  });
+
+  it('returns empty string for empty path', () => {
+    // resolve(projectRoot, '') === projectRoot, so relative is ''
+    expect(validatePath(projectRoot, '')).toBe('');
+  });
+
+  it('throws for path with .. escaping', () => {
+    expect(() => validatePath(projectRoot, 'src/../../outside')).toThrow(
+      'Path traversal detected',
+    );
+  });
+
+  it('handles path that resolves to project root itself', () => {
+    expect(validatePath(projectRoot, '.')).toBe('');
+  });
+
+  it('handles deeply nested relative path', () => {
+    expect(validatePath(projectRoot, 'a/b/c/d/e.ts')).toBe('a/b/c/d/e.ts');
+  });
+});


### PR DESCRIPTION
## Summary

- Added `src/utils/validate-path.ts` utility that validates file paths resolve within the project root, rejects null bytes, and prevents directory traversal attacks (e.g., `../../etc/passwd`)
- Applied `validatePath()` to all 5 MCP tool functions that accept path parameters: `getFileSummary`, `forceReread`, `invalidateCache`, `getDependencyGraphTool`, and `markExploredTool`
- Added comprehensive unit tests (`tests/unit/validate-path.test.ts`) covering normal paths, traversal attempts, null bytes, absolute paths, and edge cases
- Added integration tests (`tests/unit/path-security.test.ts`) verifying actual tool functions reject traversal while still accepting valid paths

## Test plan

- [x] All 212 tests pass (`npx vitest run`)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] Path traversal attempts (e.g., `../../etc/passwd`) are rejected with descriptive errors
- [x] Normal relative paths continue to work correctly
- [x] Absolute paths inside project root are accepted and normalized to relative
- [x] Null bytes in paths are rejected

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)