### PR TITLE
feat: auto-GC on startup and session auto-management

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,8 @@ import { invalidateCache } from './tools/invalidate.js';
 import { getDependencyGraphTool } from './tools/get-dependency-graph.js';
 import { createTaskTool, getTaskContext, markExploredTool } from './tools/task-context.js';
 import { getTokenReport } from './tools/get-token-report.js';
+import { runGC } from './cache/gc.js';
+import { SessionManager } from './memory/session.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -209,6 +211,30 @@ server.registerTool('get_token_report', {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  const projectRoot = process.cwd();
+
+  // Auto-start session
+  const sessionManager = new SessionManager(projectRoot);
+  const session = sessionManager.startSession({ source: 'mcp-connect' });
+  process.stderr.write(`Session started: ${session.id}\n`);
+
+  // End session on exit
+  const cleanup = () => {
+    try {
+      sessionManager.endSession(session.id);
+    } catch {
+      // ignore errors during cleanup
+    }
+  };
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+  process.on('beforeExit', cleanup);
+
+  // Run GC in background on startup (non-blocking)
+  runGC(projectRoot).catch((err) => {
+    process.stderr.write(`GC warning: ${err instanceof Error ? err.message : String(err)}\n`);
+  });
 }
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
## Summary
- Run garbage collection automatically when MCP server starts (non-blocking)
- Auto-start a session on connect, auto-end on SIGINT/SIGTERM/beforeExit
- Logs session ID and GC warnings to stderr

Closes #98, closes #99

## Test plan
- [ ] Server starts without errors
- [ ] GC runs in background on startup
- [ ] Session is created on connect
- [ ] Session ends on process exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)