### PR TITLE
feat: add file size, mtime, and confidence to project map

### DIFF
--- a/src/indexer/project-map.ts
+++ b/src/indexer/project-map.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { join, dirname, basename, extname } from 'node:path';
 import { scanProject } from './scanner.js';
 import { summarizeFile } from './summarizer.js';
@@ -9,7 +9,13 @@ import type { FileSummary } from '../types.js';
 export interface DirectoryNode {
   name: string;
   path: string;
-  files: Array<{ name: string; purpose: string }>;
+  files: Array<{
+    name: string;
+    purpose: string;
+    confidence: string;
+    size: number;
+    lastModified: number;
+  }>;
   children: DirectoryNode[];
   fileCount: number;
 }
@@ -24,6 +30,8 @@ export interface ProjectMap {
 interface FileSummaryEntry {
   relativePath: string;
   summary: FileSummary;
+  size: number;
+  lastModified: number;
 }
 
 async function getSummaries(
@@ -34,13 +42,18 @@ async function getSummaries(
   const entries: FileSummaryEntry[] = [];
 
   for (const relativePath of files) {
+    const absolutePath = join(projectRoot, relativePath);
     const cached = cache.getEntry(relativePath);
     if (cached?.summary) {
-      entries.push({ relativePath, summary: cached.summary });
+      try {
+        const stats = await stat(absolutePath);
+        entries.push({ relativePath, summary: cached.summary, size: stats.size, lastModified: stats.mtimeMs });
+      } catch {
+        entries.push({ relativePath, summary: cached.summary, size: 0, lastModified: 0 });
+      }
       continue;
     }
 
-    const absolutePath = join(projectRoot, relativePath);
     let contents: string;
     try {
       contents = await readFile(absolutePath, 'utf-8');
@@ -51,7 +64,8 @@ async function getSummaries(
     const summary = summarizeFile(relativePath, contents);
     const hash = hashContents(contents);
     cache.setEntry(relativePath, hash, summary);
-    entries.push({ relativePath, summary });
+    const stats = await stat(absolutePath);
+    entries.push({ relativePath, summary, size: stats.size, lastModified: stats.mtimeMs });
   }
 
   return entries;
@@ -107,6 +121,9 @@ function buildTree(
     dir.files.push({
       name: basename(entry.relativePath),
       purpose: entry.summary.purpose,
+      confidence: entry.summary.confidence,
+      size: entry.size,
+      lastModified: entry.lastModified,
     });
   }
 

--- a/tests/unit/project-map.test.ts
+++ b/tests/unit/project-map.test.ts
@@ -96,6 +96,31 @@ describe('buildProjectMap', () => {
     expect(map.tree.fileCount).toBe(9);
   });
 
+  it('should include size, lastModified, and confidence on file entries', async () => {
+    const map = await buildProjectMap(tempDir);
+
+    // Collect all file entries from the tree
+    function collectFiles(node: typeof map.tree): typeof map.tree.files {
+      let files = [...node.files];
+      for (const child of node.children) {
+        files = files.concat(collectFiles(child));
+      }
+      return files;
+    }
+
+    const allFiles = collectFiles(map.tree);
+    expect(allFiles.length).toBeGreaterThan(0);
+
+    for (const file of allFiles) {
+      // size should be a positive number
+      expect(file.size).toBeGreaterThan(0);
+      // lastModified should be a valid epoch timestamp (after 2020-01-01)
+      expect(file.lastModified).toBeGreaterThan(1577836800000);
+      // confidence should be one of the known values
+      expect(['high', 'medium', 'low']).toContain(file.confidence);
+    }
+  });
+
   it('should reuse cached summaries on repeated calls', async () => {
     const map1 = await buildProjectMap(tempDir);
     const map2 = await buildProjectMap(tempDir);


### PR DESCRIPTION
## Summary
- Project map file entries now include `size` (bytes), `lastModified` (epoch ms), and `confidence` level
- Agents can prioritize which files to explore based on this metadata
- Stats obtained via `fs.stat()` for both cached and uncached paths

Closes #100

## Test plan
- [ ] Project map includes size, lastModified, confidence for each file
- [ ] Build passes
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)