### PR TITLE
feat: larger benchmark tiers and timing data

### DIFF
--- a/tests/benchmarks/benchmark-utils.ts
+++ b/tests/benchmarks/benchmark-utils.ts
@@ -13,6 +13,7 @@ export interface BenchmarkReport {
   cacheMisses: number;
   hitRatio: number;
   estimatedTokensSaved: number;
+  durationMs?: number;       // wall-clock time in ms
 }
 
 /**
@@ -204,19 +205,25 @@ export function generateReport(reports: BenchmarkReport[]): string {
   lines.push('');
   lines.push(
     '| Scenario | Files | Raw Bytes | Summary Bytes | Compression | ' +
-      'Cache Hits | Hit Ratio | Est. Tokens Saved |',
+      'Cache Hits | Hit Ratio | Est. Tokens Saved | Duration | ms/file |',
   );
   lines.push(
     '|----------|-------|-----------|---------------|-------------|' +
-      '-----------|-----------|-------------------|',
+      '-----------|-----------|-------------------|----------|---------|',
   );
 
   for (const r of reports) {
+    const durationStr = r.durationMs != null ? `${r.durationMs} ms` : '-';
+    const msPerFile =
+      r.durationMs != null && r.fileCount > 0
+        ? `${(r.durationMs / r.fileCount).toFixed(1)}`
+        : '-';
     lines.push(
       `| ${r.scenario} | ${r.fileCount} | ${formatBytes(r.rawBytes)} | ` +
         `${formatBytes(r.summaryBytes)} | ${r.compressionRatio.toFixed(1)}x | ` +
         `${r.cacheHits}/${r.cacheHits + r.cacheMisses} | ` +
-        `${(r.hitRatio * 100).toFixed(0)}% | ${r.estimatedTokensSaved.toLocaleString()} |`,
+        `${(r.hitRatio * 100).toFixed(0)}% | ${r.estimatedTokensSaved.toLocaleString()} | ` +
+        `${durationStr} | ${msPerFile} |`,
     );
   }
 

--- a/tests/benchmarks/run-benchmarks.ts
+++ b/tests/benchmarks/run-benchmarks.ts
@@ -248,6 +248,8 @@ async function main(): Promise<void> {
   const sizes = [
     { label: 'small', count: 10 },
     { label: 'medium', count: 50 },
+    { label: 'large', count: 100 },
+    { label: 'xlarge', count: 200 },
   ];
 
   const reports: BenchmarkReport[] = [];
@@ -265,15 +267,30 @@ async function main(): Promise<void> {
 
     // Run scenarios
     console.log('  Running: Explore project...');
-    reports.push(await scenarioExploreProject(fixtureDir, size.count));
+    {
+      const start = performance.now();
+      const report = await scenarioExploreProject(fixtureDir, size.count);
+      report.durationMs = Math.round(performance.now() - start);
+      reports.push(report);
+    }
     closeDatabase();
 
     console.log('  Running: Investigate bug...');
-    reports.push(await scenarioInvestigateBug(fixtureDir, size.count));
+    {
+      const start = performance.now();
+      const report = await scenarioInvestigateBug(fixtureDir, size.count);
+      report.durationMs = Math.round(performance.now() - start);
+      reports.push(report);
+    }
     closeDatabase();
 
     console.log('  Running: Incremental change...');
-    reports.push(await scenarioIncrementalChange(fixtureDir, size.count));
+    {
+      const start = performance.now();
+      const report = await scenarioIncrementalChange(fixtureDir, size.count);
+      report.durationMs = Math.round(performance.now() - start);
+      reports.push(report);
+    }
     closeDatabase();
 
     console.log('');

--- a/tests/benchmarks/token-savings.bench.ts
+++ b/tests/benchmarks/token-savings.bench.ts
@@ -124,3 +124,57 @@ describe('token savings — medium project (50 files)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Large project benchmarks (100 files)
+// ---------------------------------------------------------------------------
+
+describe('token savings — large project (100 files)', () => {
+  beforeAll(() => {
+    fixtures['large'] = createBenchmarkFixture(100);
+  });
+
+  afterAll(() => {
+    closeDatabase();
+    if (fixtures['large']) {
+      rmSync(fixtures['large'], { recursive: true, force: true });
+    }
+  });
+
+  bench('explore project', async () => {
+    const dir = fixtures['large'];
+    await invalidateCache(dir);
+    const files = await scanProject(dir);
+    await buildProjectMap(dir);
+    for (const f of files) {
+      await getFileSummary(dir, f);
+    }
+  });
+
+  bench('investigate bug', async () => {
+    const dir = fixtures['large'];
+    await invalidateCache(dir);
+    const files = await scanProject(dir);
+    const task = createTaskTool(dir, 'bench-bug');
+    const count = Math.ceil(files.length * 0.6);
+    for (let i = 0; i < count; i++) {
+      await getFileSummary(dir, files[i]);
+      markExploredTool(dir, task.id, files[i]);
+    }
+    for (let i = 0; i < Math.min(5, count); i++) {
+      await getFileSummary(dir, files[i]);
+    }
+  });
+
+  bench('incremental change', async () => {
+    const dir = fixtures['large'];
+    await invalidateCache(dir);
+    const files = await scanProject(dir);
+    for (const f of files) {
+      await getFileSummary(dir, f);
+    }
+    for (const f of files) {
+      await getFileSummary(dir, f);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added 100-file and 200-file tiers to the benchmark harness
- Added wall-clock timing (`durationMs`) and per-file averages (`ms/file`) to benchmark reports
- Updated benchmark report table to include timing columns

Closes #102

## Test plan
- [ ] `npm run benchmark` runs all 4 tiers (10, 50, 100, 200 files)
- [ ] Timing data shows in report output
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)