### PR TITLE
feat: get_related_files tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { invalidateCache } from './tools/invalidate.js';
 import { getDependencyGraphTool } from './tools/get-dependency-graph.js';
 import { createTaskTool, getTaskContext, markExploredTool } from './tools/task-context.js';
 import { getTokenReport } from './tools/get-token-report.js';
+import { getRelatedFiles } from './tools/get-related-files.js';
 
 const server = new McpServer({
   name: 'repo-memory',
@@ -203,6 +204,23 @@ server.registerTool('get_token_report', {
   const report = getTokenReport(projectRoot, period, hours, session_id);
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(report, null, 2) }],
+  };
+});
+
+server.registerTool('get_related_files', {
+  title: 'Get Related Files',
+  description:
+    'Returns files related to the given file, ranked by dependency proximity and relevance. Useful for finding what else to look at when exploring a file.',
+  inputSchema: {
+    path: z.string().describe('File path relative to project root'),
+    limit: z.number().optional().describe('Max results (default: 10)'),
+    task_id: z.string().optional().describe('Task ID for context-aware ranking'),
+  },
+}, async ({ path, limit, task_id }) => {
+  const projectRoot = process.cwd();
+  const result = await getRelatedFiles(projectRoot, path, { limit, taskId: task_id });
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
   };
 });
 

--- a/src/tools/get-related-files.ts
+++ b/src/tools/get-related-files.ts
@@ -1,0 +1,154 @@
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { DependencyGraph } from '../graph/dependency-graph.js';
+import { scanProject } from '../indexer/scanner.js';
+import { validatePath } from '../utils/validate-path.js';
+import { rankFiles } from '../cache/ranking.js';
+import { getTaskContext, type TaskContextResult } from '../tools/task-context.js';
+
+export interface RelatedFilesResult {
+  path: string;
+  relatedFiles: Array<{
+    path: string;
+    score: number;
+    relationship: string; // "imports", "imported-by", "same-directory", "similar-purpose"
+  }>;
+}
+
+export async function getRelatedFiles(
+  projectRoot: string,
+  relativePath: string,
+  options?: { limit?: number; taskId?: string },
+): Promise<RelatedFilesResult> {
+  const validated = validatePath(projectRoot, relativePath);
+  const limit = options?.limit ?? 10;
+
+  // Build the dependency graph
+  const graph = new DependencyGraph(projectRoot);
+  const files = await scanProject(projectRoot);
+
+  for (const file of files) {
+    if (
+      !file.endsWith('.ts') &&
+      !file.endsWith('.js') &&
+      !file.endsWith('.tsx') &&
+      !file.endsWith('.jsx') &&
+      !file.endsWith('.mjs') &&
+      !file.endsWith('.cjs')
+    ) {
+      continue;
+    }
+    try {
+      const contents = await readFile(join(projectRoot, file), 'utf-8');
+      graph.updateFile(file, contents);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  // The graph may store paths with .js extension (from import specifiers) while
+  // actual files have .ts extension. Query both variants to get complete results.
+  const variants = getPathVariants(validated);
+
+  // Get direct dependencies and dependents across all path variants
+  const dependencies = new Set<string>();
+  const dependents = new Set<string>();
+  for (const v of variants) {
+    for (const d of graph.getDependencies(v)) dependencies.add(d);
+    for (const d of graph.getDependents(v)) dependents.add(d);
+  }
+
+  // Get transitive dependencies (depth 2) for "transitive-dependency" classification
+  const transitiveDeps = new Set<string>();
+  const transitiveDependents = new Set<string>();
+  for (const v of variants) {
+    for (const d of graph.getTransitiveDependencies(v, 2)) transitiveDeps.add(d);
+    for (const d of graph.getTransitiveDependents(v, 2)) transitiveDependents.add(d);
+  }
+
+  // Determine same-directory files
+  const fileDir = dirname(validated);
+  const sameDirFiles = new Set(
+    files.filter((f) => f !== validated && dirname(f) === fileDir),
+  );
+
+  // Collect all candidate related files (excluding the file itself)
+  const candidates = new Set<string>();
+  for (const d of dependencies) candidates.add(d);
+  for (const d of dependents) candidates.add(d);
+  for (const d of transitiveDeps) candidates.add(d);
+  for (const d of transitiveDependents) candidates.add(d);
+  for (const d of sameDirFiles) candidates.add(d);
+
+  // Remove the file itself (all variants)
+  for (const v of variants) candidates.delete(v);
+
+  if (candidates.size === 0) {
+    return { path: validated, relatedFiles: [] };
+  }
+
+  // Classify relationships
+  const relationshipMap = new Map<string, string>();
+  for (const c of candidates) {
+    if (dependencies.has(c)) {
+      relationshipMap.set(c, 'imports');
+    } else if (dependents.has(c)) {
+      relationshipMap.set(c, 'imported-by');
+    } else if (transitiveDeps.has(c) || transitiveDependents.has(c)) {
+      relationshipMap.set(c, 'transitive-dependency');
+    } else if (sameDirFiles.has(c)) {
+      relationshipMap.set(c, 'same-directory');
+    }
+  }
+
+  // Get task context for ranking if taskId provided
+  let exploredFiles: string[] = [];
+  let flaggedFiles: string[] = [];
+
+  if (options?.taskId) {
+    try {
+      const ctx = getTaskContext(projectRoot, options.taskId) as TaskContextResult;
+      exploredFiles = ctx.exploredFiles.map((f) => f.filePath);
+      flaggedFiles = ctx.exploredFiles
+        .filter((f) => f.status === 'flagged')
+        .map((f) => f.filePath);
+    } catch {
+      // Task not found — proceed without context
+    }
+  }
+
+  // Rank candidates
+  const candidateArray = [...candidates];
+  const ranked = rankFiles(candidateArray, {
+    projectRoot,
+    exploredFiles,
+    flaggedFiles,
+    graph,
+    limit,
+  });
+
+  const relatedFiles = ranked.map((r) => ({
+    path: r.path,
+    score: r.score,
+    relationship: relationshipMap.get(r.path) ?? 'same-directory',
+  }));
+
+  return { path: validated, relatedFiles };
+}
+
+/** Get path variants to handle .ts/.js extension mismatch in the dependency graph. */
+function getPathVariants(filePath: string): string[] {
+  const variants = [filePath];
+  if (filePath.endsWith('.ts')) {
+    variants.push(filePath.replace(/\.ts$/, '.js'));
+  } else if (filePath.endsWith('.tsx')) {
+    variants.push(filePath.replace(/\.tsx$/, '.js'));
+    variants.push(filePath.replace(/\.tsx$/, '.jsx'));
+  } else if (filePath.endsWith('.js')) {
+    variants.push(filePath.replace(/\.js$/, '.ts'));
+    variants.push(filePath.replace(/\.js$/, '.tsx'));
+  } else if (filePath.endsWith('.jsx')) {
+    variants.push(filePath.replace(/\.jsx$/, '.tsx'));
+  }
+  return variants;
+}

--- a/tests/unit/get-related-files.test.ts
+++ b/tests/unit/get-related-files.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getRelatedFiles } from '../../src/tools/get-related-files.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+
+describe('getRelatedFiles', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'related-files-'));
+    mkdirSync(join(tempDir, 'src'), { recursive: true });
+    mkdirSync(join(tempDir, 'src', 'utils'), { recursive: true });
+
+    writeFileSync(
+      join(tempDir, 'src', 'index.ts'),
+      `import { helper } from './helper.js';\nexport function main() { helper(); }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'helper.ts'),
+      `import { util } from './util.js';\nexport function helper() { util(); }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'util.ts'),
+      `export function util() { return 42; }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'other.ts'),
+      `export function other() { return 'other'; }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'utils', 'format.ts'),
+      `export function format(s: string) { return s.trim(); }\n`,
+    );
+
+    execFileSync('git', ['init'], { cwd: tempDir });
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns direct dependencies as related', async () => {
+    const result = await getRelatedFiles(tempDir, 'src/index.ts');
+    const paths = result.relatedFiles.map((f) => f.path);
+    expect(paths).toContain('src/helper.js');
+  });
+
+  it('returns direct dependents as related', async () => {
+    const result = await getRelatedFiles(tempDir, 'src/helper.ts');
+    const paths = result.relatedFiles.map((f) => f.path);
+    expect(paths).toContain('src/index.ts');
+  });
+
+  it('classifies relationships correctly', async () => {
+    const result = await getRelatedFiles(tempDir, 'src/index.ts');
+    const helperEntry = result.relatedFiles.find((f) => f.path === 'src/helper.js');
+    expect(helperEntry).toBeDefined();
+    expect(helperEntry!.relationship).toBe('imports');
+
+    const result2 = await getRelatedFiles(tempDir, 'src/helper.ts');
+    const indexEntry = result2.relatedFiles.find((f) => f.path === 'src/index.ts');
+    expect(indexEntry).toBeDefined();
+    expect(indexEntry!.relationship).toBe('imported-by');
+
+    // same-directory files
+    const otherEntry = result2.relatedFiles.find((f) => f.path === 'src/other.ts');
+    if (otherEntry) {
+      expect(otherEntry.relationship).toBe('same-directory');
+    }
+  });
+
+  it('respects limit parameter', async () => {
+    const result = await getRelatedFiles(tempDir, 'src/helper.ts', { limit: 2 });
+    expect(result.relatedFiles.length).toBeLessThanOrEqual(2);
+  });
+
+  it('works without task context', async () => {
+    const result = await getRelatedFiles(tempDir, 'src/index.ts');
+    expect(result.path).toBe('src/index.ts');
+    expect(result.relatedFiles).toBeDefined();
+    expect(Array.isArray(result.relatedFiles)).toBe(true);
+    for (const f of result.relatedFiles) {
+      expect(f).toHaveProperty('path');
+      expect(f).toHaveProperty('score');
+      expect(f).toHaveProperty('relationship');
+      expect(typeof f.score).toBe('number');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `get_related_files` MCP tool that returns files related to a given file
- Ranks results by dependency proximity, task context relevance, and file type
- Supports optional `task_id` for context-aware ranking
- Classifies relationships: "imports", "imported-by", "same-directory", "transitive"

Closes #96

## Test plan
- [ ] Returns direct dependencies as related files
- [ ] Returns direct dependents as related files
- [ ] Classifies relationships correctly
- [ ] Respects limit parameter
- [ ] Works with and without task context
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)