### PR TITLE
feat: add symbol filter to dependency graph

### DIFF
--- a/src/graph/dependency-graph.ts
+++ b/src/graph/dependency-graph.ts
@@ -79,6 +79,31 @@ export class DependencyGraph {
     return sources ? [...sources] : [];
   }
 
+  /** Get edges where specifiers contain the given symbol. */
+  getEdgesBySymbol(symbol: string, sourcePath?: string): Array<{ source: string; target: string; specifiers: string[] }> {
+    const db = getDatabase(this.projectRoot);
+    let rows: Array<{ source: string; target: string; specifiers: string }>;
+
+    if (sourcePath) {
+      rows = db
+        .prepare('SELECT source, target, specifiers FROM imports WHERE (source = ? OR target = ?)')
+        .all(sourcePath, sourcePath) as Array<{ source: string; target: string; specifiers: string }>;
+    } else {
+      rows = db
+        .prepare('SELECT source, target, specifiers FROM imports')
+        .all() as Array<{ source: string; target: string; specifiers: string }>;
+    }
+
+    const results: Array<{ source: string; target: string; specifiers: string[] }> = [];
+    for (const row of rows) {
+      const specifiers: string[] = JSON.parse(row.specifiers);
+      if (specifiers.includes(symbol)) {
+        results.push({ source: row.source, target: row.target, specifiers });
+      }
+    }
+    return results;
+  }
+
   /** Get transitive dependencies using BFS with optional depth limit. */
   getTransitiveDependencies(path: string, maxDepth?: number): string[] {
     return this.bfs(path, this.outgoing, maxDepth);

--- a/src/server.ts
+++ b/src/server.ts
@@ -127,10 +127,11 @@ server.registerTool('get_dependency_graph', {
       .optional()
       .describe('Query direction (default: both)'),
     depth: z.number().optional().describe('Max traversal depth'),
+    symbol: z.string().optional().describe('Filter edges by import specifier (e.g., "UserService")'),
   },
-}, async ({ path, direction, depth }) => {
+}, async ({ path, direction, depth, symbol }) => {
   const projectRoot = process.cwd();
-  const result = await getDependencyGraphTool(projectRoot, path, direction, depth);
+  const result = await getDependencyGraphTool(projectRoot, path, direction, depth, symbol);
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result) }],
   };

--- a/src/tools/get-dependency-graph.ts
+++ b/src/tools/get-dependency-graph.ts
@@ -19,6 +19,7 @@ export async function getDependencyGraphTool(
   path?: string,
   direction?: 'dependencies' | 'dependents' | 'both',
   depth?: number,
+  symbol?: string,
 ): Promise<DependencyGraphResult> {
   if (path) {
     path = validatePath(projectRoot, path);
@@ -38,6 +39,10 @@ export async function getDependencyGraphTool(
     } catch {
       // Skip unreadable files
     }
+  }
+
+  if (symbol) {
+    return getSymbolEdges(graph, symbol, path);
   }
 
   if (path) {
@@ -75,6 +80,32 @@ function getNeighborhood(
       nodes.add(dep);
       edges.push({ from: dep, to: path });
     }
+  }
+
+  return {
+    nodes: [...nodes].sort(),
+    edges,
+    stats: {
+      totalFiles: nodes.size,
+      totalEdges: edges.length,
+      mostConnected: graph.getMostConnected(5),
+    },
+  };
+}
+
+function getSymbolEdges(
+  graph: DependencyGraph,
+  symbol: string,
+  path?: string,
+): DependencyGraphResult {
+  const matchingEdges = graph.getEdgesBySymbol(symbol, path);
+  const nodes = new Set<string>();
+  const edges: Array<{ from: string; to: string }> = [];
+
+  for (const edge of matchingEdges) {
+    nodes.add(edge.source);
+    nodes.add(edge.target);
+    edges.push({ from: edge.source, to: edge.target });
   }
 
   return {

--- a/tests/unit/get-dependency-graph.test.ts
+++ b/tests/unit/get-dependency-graph.test.ts
@@ -52,4 +52,36 @@ describe('getDependencyGraphTool', () => {
     expect(result.nodes).toContain('src/helper.js');
     // At depth 1, should not include transitive deps of helper
   });
+
+  describe('symbol filter', () => {
+    it('filters by symbol when path is given', async () => {
+      const result = await getDependencyGraphTool(tempDir, 'src/index.ts', undefined, undefined, 'helper');
+      expect(result.edges).toEqual([{ from: 'src/index.ts', to: 'src/helper.js' }]);
+      expect(result.nodes).toContain('src/index.ts');
+      expect(result.nodes).toContain('src/helper.js');
+    });
+
+    it('filters by symbol when path is NOT given (search all edges)', async () => {
+      const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'util');
+      expect(result.edges.some((e) => e.from === 'src/helper.ts' && e.to === 'src/util.js')).toBe(true);
+      expect(result.nodes).toContain('src/helper.ts');
+      expect(result.nodes).toContain('src/util.js');
+    });
+
+    it('returns empty results for non-existent symbol', async () => {
+      const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'NonExistent');
+      expect(result.nodes).toEqual([]);
+      expect(result.edges).toEqual([]);
+      expect(result.stats.totalFiles).toBe(0);
+      expect(result.stats.totalEdges).toBe(0);
+    });
+
+    it('uses case-sensitive matching', async () => {
+      const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'Helper');
+      expect(result.edges).toEqual([]);
+
+      const result2 = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'helper');
+      expect(result2.edges.length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds optional `symbol` parameter to `get_dependency_graph` tool
- Filters dependency edges by import specifier (e.g., "UserService")
- Works with or without a `path` parameter
- Zero new tools — enhances existing tool with ~15 tokens of schema overhead

## Test plan
- [x] 4 new tests: with path, without path, non-existent symbol, case-sensitive
- [x] All 274 tests pass
- [x] Typecheck clean

Closes #110