### PR TITLE
fix(infra): bump better-sqlite3 to ^12.10.0 for Node 26 prebuilts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "repo-memory",
-  "version": "0.1.0",
+  "name": "@blamechris/repo-memory",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "repo-memory",
-      "version": "0.1.0",
+      "name": "@blamechris/repo-memory",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.10.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -28,7 +28,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1593,9 +1593,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1603,7 +1603,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.10.0",
     "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
## Problem

`better-sqlite3@12.6.2` has no prebuilt binary for Node 26 and **cannot compile from source** there — its native C++ uses the V8 API `PropertyCallbackInfo::This`, which was removed in Node 26 (`error: no member named 'This'`). On a Node 26 machine this surfaces as either a from-source build failure or an ABI mismatch at load time:

```
Error: ... was compiled against a different Node.js version using
NODE_MODULE_VERSION 141. This version of Node.js requires
NODE_MODULE_VERSION 147.
```

## Fix

Bump to `^12.10.0`, which ships a Node 26 prebuilt. The native binary now loads without any from-source build.

## Notes

- `npm rebuild better-sqlite3` does **not** fix this on Node 26 (it forces the failing source compile and removes the working binary). `npm install` to fetch the prebuilt is the correct remediation.
- Verified: `node -e "new (require('better-sqlite3'))(':memory:')"` loads cleanly, and the MCP server completes an `initialize` handshake on Node 26.