### PR TITLE
feat(server): add tool group config (tasks + telemetry off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The savings compound fast. An agent exploring a project touches the same files 3
 
 ## Tools
 
-Tools are organized into **groups**. The `navigation` group is always on; `summaries`, `tasks`, and `telemetry` are **off by default** — each MCP tool adds ~100 tokens/turn to the system prompt, so the default surface is kept lean. Enable the groups you want in `.repo-memory.json` (see [Configuration](#configuration)).
+Tools are organized into **groups**. `navigation` and `summaries` are **on by default** — together they deliver the core "understand the repo without re-reading" loop. `tasks` and `telemetry` are **off by default** (niche/meta features; each MCP tool adds ~100 tokens/turn, so the default surface stays lean). Toggle any group in `.repo-memory.json` (see [Configuration](#configuration)).
 
 **Navigation** — always on:
 
@@ -73,7 +73,7 @@ Tools are organized into **groups**. The `navigation` group is always on; `summa
 | `get_dependency_graph` | File dependency relationships |
 | `get_changed_files` | Files changed since last check |
 
-**Summaries** — off by default; enable with `"tools": { "summaries": true }`:
+**Summaries** — on by default (the core feature); disable with `"tools": { "summaries": false }`:
 
 | Tool | Description |
 |------|-------------|
@@ -185,14 +185,13 @@ Create a `.repo-memory.json` in your project root to customize behavior:
     "cacheMaxAgeDays": 30
   },
   "tools": {
-    "summaries": true,
     "tasks": true,
     "telemetry": true
   }
 }
 ```
 
-The `tools` block toggles optional tool groups. The `navigation` group is always on; `summaries`, `tasks`, and `telemetry` are **off by default** — set each to `true` to enable it. An invalid `.repo-memory.json` is ignored in full (built-in defaults apply) with a warning on stderr, rather than partially applied.
+The `tools` block toggles tool groups. `navigation` and `summaries` are **on by default** (set `"summaries": false` to drop the summary tools); `tasks` and `telemetry` are **off by default** (set them to `true` to enable). An invalid `.repo-memory.json` is ignored in full (built-in defaults apply) with a warning on stderr, rather than partially applied.
 
 ## Language Support
 

--- a/README.md
+++ b/README.md
@@ -62,19 +62,38 @@ The savings compound fast. An agent exploring a project touches the same files 3
 
 ## Tools
 
+Tools are organized into **groups**. The `navigation` group is always on; `summaries`, `tasks`, and `telemetry` are **off by default** — each MCP tool adds ~100 tokens/turn to the system prompt, so the default surface is kept lean. Enable the groups you want in `.repo-memory.json` (see [Configuration](#configuration)).
+
+**Navigation** — always on:
+
+| Tool | Description |
+|------|-------------|
+| `get_project_map` | Structural overview of project |
+| `get_related_files` | Find related files ranked by relevance |
+| `get_dependency_graph` | File dependency relationships |
+| `get_changed_files` | Files changed since last check |
+
+**Summaries** — off by default; enable with `"tools": { "summaries": true }`:
+
 | Tool | Description |
 |------|-------------|
 | `get_file_summary` | Cached file summary (exports, imports, purpose) |
 | `batch_file_summaries` | Get summaries for multiple files at once |
-| `get_changed_files` | Files changed since last check |
-| `get_project_map` | Structural overview of project |
 | `search_by_purpose` | Search files by purpose/exports keywords |
-| `get_related_files` | Find related files ranked by relevance |
-| `get_dependency_graph` | File dependency relationships |
-| `create_task` / `get_task_context` / `mark_explored` | Track investigation progress across turns |
-| `get_token_report` | Token usage and savings report |
 | `force_reread` | Force fresh summary generation |
 | `invalidate` | Clear cache entries |
+
+**Tasks** — off by default; enable with `"tools": { "tasks": true }`:
+
+| Tool | Description |
+|------|-------------|
+| `create_task` / `get_task_context` / `mark_explored` | Track investigation progress across turns |
+
+**Telemetry** — off by default; enable with `"tools": { "telemetry": true }`:
+
+| Tool | Description |
+|------|-------------|
+| `get_token_report` | Token usage and savings report |
 
 ## Token Savings Tracking
 
@@ -164,9 +183,16 @@ Create a `.repo-memory.json` in your project root to customize behavior:
   "maxFiles": 5000,
   "gc": {
     "cacheMaxAgeDays": 30
+  },
+  "tools": {
+    "summaries": true,
+    "tasks": true,
+    "telemetry": true
   }
 }
 ```
+
+The `tools` block toggles optional tool groups. The `navigation` group is always on; `summaries`, `tasks`, and `telemetry` are **off by default** — set each to `true` to enable it. An invalid `.repo-memory.json` is ignored in full (built-in defaults apply) with a warning on stderr, rather than partially applied.
 
 ## Language Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,12 @@ import { join } from 'path';
 
 const CONFIG_FILENAME = '.repo-memory.json';
 
+export interface ToolGroupConfig {
+  summaries?: boolean;
+  tasks?: boolean;
+  telemetry?: boolean;
+}
+
 export interface RepoMemoryConfig {
   ignore?: string[];
   maxFiles?: number;
@@ -11,6 +17,7 @@ export interface RepoMemoryConfig {
     taskMaxAgeDays?: number;
     telemetryMaxAgeDays?: number;
   };
+  tools?: ToolGroupConfig;
 }
 
 const configCache = new Map<string, RepoMemoryConfig>();
@@ -73,6 +80,23 @@ function validateConfig(raw: unknown): RepoMemoryConfig {
           throw new Error(`"gc.${key}" must be a positive number`);
         }
         config.gc[key] = gc[key];
+      }
+    }
+  }
+
+  if ('tools' in obj) {
+    if (typeof obj.tools !== 'object' || obj.tools === null || Array.isArray(obj.tools)) {
+      throw new Error('"tools" must be an object');
+    }
+    const tools = obj.tools as Record<string, unknown>;
+    config.tools = {};
+
+    for (const key of ['summaries', 'tasks', 'telemetry'] as const) {
+      if (key in tools) {
+        if (typeof tools[key] !== 'boolean') {
+          throw new Error(`"tools.${key}" must be a boolean`);
+        }
+        config.tools[key] = tools[key];
       }
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,258 +16,285 @@ import { batchFileSummaries } from './tools/batch-file-summaries.js';
 import { searchByPurpose } from './tools/search-by-purpose.js';
 import { runGC } from './cache/gc.js';
 import { SessionManager } from './memory/session.js';
-import { loadConfig } from './config.js';
+import { loadConfig, type RepoMemoryConfig } from './config.js';
 
 const server = new McpServer({
   name: 'repo-memory',
-  version: '0.5.0',
+  version: '0.6.0',
 });
 
-server.registerTool('get_file_summary', {
-  title: 'Get File Summary',
-  description:
-    'Returns a cached summary of a file. If the file has not changed since last read, returns the cached summary without re-reading. Use this instead of reading files directly to save tokens.',
-  inputSchema: {
-    path: z.string().describe('File path relative to project root'),
-  },
-}, async ({ path }) => {
-  try {
+function registerTools(server: McpServer, config: RepoMemoryConfig): void {
+  // === NAVIGATION GROUP (always on) ===
+
+  server.registerTool('get_project_map', {
+    title: 'Get Project Map',
+    description:
+      'Returns a structural overview of the project including directory tree, entry points, and key modules.',
+    inputSchema: {
+      project_root: z.string().describe('Absolute path to the project root'),
+      depth: z.number().optional().describe('Max directory depth to include'),
+    },
+  }, async ({ project_root, depth }) => {
+    const projectMap = await getProjectMap(project_root, depth);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(projectMap) }],
+    };
+  });
+
+  server.registerTool('get_related_files', {
+    title: 'Get Related Files',
+    description:
+      'Returns files related to the given file, ranked by dependency proximity and relevance. Useful for finding what else to look at when exploring a file.',
+    inputSchema: {
+      path: z.string().describe('File path relative to project root'),
+      limit: z.number().optional().describe('Max results (default: 10)'),
+      task_id: z.string().optional().describe('Task ID for context-aware ranking'),
+    },
+  }, async ({ path, limit, task_id }) => {
     const projectRoot = process.cwd();
-    const result = await getFileSummary(projectRoot, path);
+    const result = await getRelatedFiles(projectRoot, path, { limit, taskId: task_id });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const isNotFound =
-      error instanceof Error && 'code' in error && error.code === 'ENOENT';
+  });
+
+  server.registerTool('get_dependency_graph', {
+    title: 'Get Dependency Graph',
+    description:
+      'Returns dependency graph information. If a path is given, returns its dependencies/dependents. If no path, returns a summary of the most connected files.',
+    inputSchema: {
+      path: z.string().optional().describe('File path to query, or omit for full graph summary'),
+      direction: z
+        .enum(['dependencies', 'dependents', 'both'])
+        .optional()
+        .describe('Query direction (default: both)'),
+      depth: z.number().optional().describe('Max traversal depth'),
+      symbol: z.string().optional().describe('Filter edges by import specifier (e.g., "UserService")'),
+    },
+  }, async ({ path, direction, depth, symbol }) => {
+    const projectRoot = process.cwd();
+    const result = await getDependencyGraphTool(projectRoot, path, direction, depth, symbol);
     return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({
-            error: isNotFound ? 'file_not_found' : 'internal_error',
-            message,
-            path,
-          }),
-        },
-      ],
-      isError: true,
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };
+  });
+
+  server.registerTool('get_changed_files', {
+    title: 'Get Changed Files',
+    description:
+      'Returns files that have changed since the last check. Compares current file hashes against cached hashes.',
+    inputSchema: {
+      since: z.string().optional().describe('ISO timestamp or "last_check"'),
+    },
+  }, async ({ since }) => {
+    const projectRoot = process.cwd();
+    const result = await getChangedFiles(projectRoot, since);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    };
+  });
+
+  // === SUMMARIES GROUP (off by default) ===
+  if (config.tools?.summaries) {
+    server.registerTool('get_file_summary', {
+      title: 'Get File Summary',
+      description:
+        'Returns a cached summary of a file. If the file has not changed since last read, returns the cached summary without re-reading. Use this instead of reading files directly to save tokens.',
+      inputSchema: {
+        path: z.string().describe('File path relative to project root'),
+      },
+    }, async ({ path }) => {
+      try {
+        const projectRoot = process.cwd();
+        const result = await getFileSummary(projectRoot, path);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        const isNotFound =
+          error instanceof Error && 'code' in error && error.code === 'ENOENT';
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: isNotFound ? 'file_not_found' : 'internal_error',
+                message,
+                path,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    });
+
+    server.registerTool('batch_file_summaries', {
+      title: 'Batch File Summaries',
+      description: 'Get cached summaries for multiple files in one call. More efficient than calling get_file_summary repeatedly.',
+      inputSchema: {
+        paths: z.array(z.string()).describe('Array of file paths relative to project root'),
+      },
+    }, async ({ paths }) => {
+      const projectRoot = process.cwd();
+      const result = await batchFileSummaries(projectRoot, paths);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
+
+    server.registerTool('force_reread', {
+      title: 'Force Re-read',
+      description:
+        'Re-reads a file from disk, generates a fresh summary, and updates the cache. Use when you know a file has changed or want guaranteed-fresh data.',
+      inputSchema: {
+        path: z.string().describe('File path relative to project root'),
+      },
+    }, async ({ path }) => {
+      const projectRoot = process.cwd();
+      const result = await forceReread(projectRoot, path);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
+
+    server.registerTool('search_by_purpose', {
+      title: 'Search By Purpose',
+      description: 'Search cached file summaries by keyword. Matches against file purpose, exports, and declarations. Requires files to have been previously summarized.',
+      inputSchema: {
+        query: z.string().describe('Search keywords (e.g., "database", "auth middleware", "validation")'),
+        limit: z.number().optional().describe('Max results (default: 20)'),
+      },
+    }, async ({ query, limit }) => {
+      const projectRoot = process.cwd();
+      const result = searchByPurpose(projectRoot, query, limit);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
+
+    server.registerTool('invalidate', {
+      title: 'Invalidate Cache',
+      description:
+        'Invalidates cached entries. If a path is provided, only that entry is removed. If no path is provided, all entries are removed.',
+      inputSchema: {
+        path: z.string().optional().describe('File path to invalidate, or omit to invalidate all'),
+      },
+    }, async ({ path }) => {
+      const projectRoot = process.cwd();
+      const result = await invalidateCache(projectRoot, path);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
   }
-});
 
-server.registerTool('get_changed_files', {
-  title: 'Get Changed Files',
-  description:
-    'Returns files that have changed since the last check. Compares current file hashes against cached hashes.',
-  inputSchema: {
-    since: z.string().optional().describe('ISO timestamp or "last_check"'),
-  },
-}, async ({ since }) => {
-  const projectRoot = process.cwd();
-  const result = await getChangedFiles(projectRoot, since);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
+  // === TASKS GROUP (off by default) ===
+  if (config.tools?.tasks) {
+    server.registerTool('create_task', {
+      title: 'Create Task',
+      description: 'Creates a new investigation task for tracking file exploration.',
+      inputSchema: {
+        name: z.string().describe('Human-readable task name'),
+      },
+    }, async ({ name }) => {
+      const projectRoot = process.cwd();
+      const task = createTaskTool(projectRoot, name);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(task) }],
+      };
+    });
 
-server.registerTool('get_project_map', {
-  title: 'Get Project Map',
-  description:
-    'Returns a structural overview of the project including directory tree, entry points, and key modules.',
-  inputSchema: {
-    project_root: z.string().describe('Absolute path to the project root'),
-    depth: z.number().optional().describe('Max directory depth to include'),
-  },
-}, async ({ project_root, depth }) => {
-  const projectMap = await getProjectMap(project_root, depth);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(projectMap) }],
-  };
-});
+    server.registerTool('get_task_context', {
+      title: 'Get Task Context',
+      description:
+        'Returns task state, explored files, and frontier. If no task_id, returns list of all tasks.',
+      inputSchema: {
+        task_id: z.string().optional().describe('Task ID to query, or omit to list all tasks'),
+      },
+    }, async ({ task_id }) => {
+      const projectRoot = process.cwd();
+      const result = getTaskContext(projectRoot, task_id);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
 
-server.registerTool('force_reread', {
-  title: 'Force Re-read',
-  description:
-    'Re-reads a file from disk, generates a fresh summary, and updates the cache. Use when you know a file has changed or want guaranteed-fresh data.',
-  inputSchema: {
-    path: z.string().describe('File path relative to project root'),
-  },
-}, async ({ path }) => {
-  const projectRoot = process.cwd();
-  const result = await forceReread(projectRoot, path);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
+    server.registerTool('mark_explored', {
+      title: 'Mark Explored',
+      description: 'Marks a file as explored for a task, with optional status and notes.',
+      inputSchema: {
+        task_id: z.string().describe('Task ID'),
+        path: z.string().describe('File path relative to project root'),
+        status: z
+          .enum(['explored', 'skipped', 'flagged'])
+          .optional()
+          .describe('Exploration status (default: explored)'),
+        notes: z.string().optional().describe('Optional notes about the file'),
+      },
+    }, async ({ task_id, path, status, notes }) => {
+      const projectRoot = process.cwd();
+      const result = markExploredTool(projectRoot, task_id, path, status, notes);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
+  }
 
-server.registerTool('invalidate', {
-  title: 'Invalidate Cache',
-  description:
-    'Invalidates cached entries. If a path is provided, only that entry is removed. If no path is provided, all entries are removed.',
-  inputSchema: {
-    path: z.string().optional().describe('File path to invalidate, or omit to invalidate all'),
-  },
-}, async ({ path }) => {
-  const projectRoot = process.cwd();
-  const result = await invalidateCache(projectRoot, path);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('get_dependency_graph', {
-  title: 'Get Dependency Graph',
-  description:
-    'Returns dependency graph information. If a path is given, returns its dependencies/dependents. If no path, returns a summary of the most connected files.',
-  inputSchema: {
-    path: z.string().optional().describe('File path to query, or omit for full graph summary'),
-    direction: z
-      .enum(['dependencies', 'dependents', 'both'])
-      .optional()
-      .describe('Query direction (default: both)'),
-    depth: z.number().optional().describe('Max traversal depth'),
-    symbol: z.string().optional().describe('Filter edges by import specifier (e.g., "UserService")'),
-  },
-}, async ({ path, direction, depth, symbol }) => {
-  const projectRoot = process.cwd();
-  const result = await getDependencyGraphTool(projectRoot, path, direction, depth, symbol);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('create_task', {
-  title: 'Create Task',
-  description: 'Creates a new investigation task for tracking file exploration.',
-  inputSchema: {
-    name: z.string().describe('Human-readable task name'),
-  },
-}, async ({ name }) => {
-  const projectRoot = process.cwd();
-  const task = createTaskTool(projectRoot, name);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(task) }],
-  };
-});
-
-server.registerTool('get_task_context', {
-  title: 'Get Task Context',
-  description:
-    'Returns task state, explored files, and frontier. If no task_id, returns list of all tasks.',
-  inputSchema: {
-    task_id: z.string().optional().describe('Task ID to query, or omit to list all tasks'),
-  },
-}, async ({ task_id }) => {
-  const projectRoot = process.cwd();
-  const result = getTaskContext(projectRoot, task_id);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('mark_explored', {
-  title: 'Mark Explored',
-  description: 'Marks a file as explored for a task, with optional status and notes.',
-  inputSchema: {
-    task_id: z.string().describe('Task ID'),
-    path: z.string().describe('File path relative to project root'),
-    status: z
-      .enum(['explored', 'skipped', 'flagged'])
-      .optional()
-      .describe('Exploration status (default: explored)'),
-    notes: z.string().optional().describe('Optional notes about the file'),
-  },
-}, async ({ task_id, path, status, notes }) => {
-  const projectRoot = process.cwd();
-  const result = markExploredTool(projectRoot, task_id, path, status, notes);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('get_token_report', {
-  title: 'Get Token Report',
-  description:
-    'Get aggregated token usage telemetry report showing cache efficiency and token savings',
-  inputSchema: {
-    period: z
-      .enum(['session', 'all', 'last_n_hours'])
-      .optional()
-      .describe('Time period for the report'),
-    hours: z
-      .number()
-      .optional()
-      .describe('Number of hours to look back (only for last_n_hours period)'),
-    session_id: z
-      .string()
-      .optional()
-      .describe('Session ID (only for session period)'),
-    include_diagnostics: z
-      .boolean()
-      .optional()
-      .describe('Include cache health diagnostics'),
-  },
-}, async ({ period, hours, session_id, include_diagnostics }) => {
-  const projectRoot = process.cwd();
-  const report = getTokenReport(projectRoot, period, hours, session_id, include_diagnostics);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(report, null, 2) }],
-  };
-});
-
-server.registerTool('batch_file_summaries', {
-  title: 'Batch File Summaries',
-  description: 'Get cached summaries for multiple files in one call. More efficient than calling get_file_summary repeatedly.',
-  inputSchema: {
-    paths: z.array(z.string()).describe('Array of file paths relative to project root'),
-  },
-}, async ({ paths }) => {
-  const projectRoot = process.cwd();
-  const result = await batchFileSummaries(projectRoot, paths);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('get_related_files', {
-  title: 'Get Related Files',
-  description:
-    'Returns files related to the given file, ranked by dependency proximity and relevance. Useful for finding what else to look at when exploring a file.',
-  inputSchema: {
-    path: z.string().describe('File path relative to project root'),
-    limit: z.number().optional().describe('Max results (default: 10)'),
-    task_id: z.string().optional().describe('Task ID for context-aware ranking'),
-  },
-}, async ({ path, limit, task_id }) => {
-  const projectRoot = process.cwd();
-  const result = await getRelatedFiles(projectRoot, path, { limit, taskId: task_id });
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
-
-server.registerTool('search_by_purpose', {
-  title: 'Search By Purpose',
-  description: 'Search cached file summaries by keyword. Matches against file purpose, exports, and declarations. Requires files to have been previously summarized.',
-  inputSchema: {
-    query: z.string().describe('Search keywords (e.g., "database", "auth middleware", "validation")'),
-    limit: z.number().optional().describe('Max results (default: 20)'),
-  },
-}, async ({ query, limit }) => {
-  const projectRoot = process.cwd();
-  const result = searchByPurpose(projectRoot, query, limit);
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-  };
-});
+  // === TELEMETRY GROUP (off by default) ===
+  if (config.tools?.telemetry) {
+    server.registerTool('get_token_report', {
+      title: 'Get Token Report',
+      description:
+        'Get aggregated token usage telemetry report showing cache efficiency and token savings',
+      inputSchema: {
+        period: z
+          .enum(['session', 'all', 'last_n_hours'])
+          .optional()
+          .describe('Time period for the report'),
+        hours: z
+          .number()
+          .optional()
+          .describe('Number of hours to look back (only for last_n_hours period)'),
+        session_id: z
+          .string()
+          .optional()
+          .describe('Session ID (only for session period)'),
+        include_diagnostics: z
+          .boolean()
+          .optional()
+          .describe('Include cache health diagnostics'),
+      },
+    }, async ({ period, hours, session_id, include_diagnostics }) => {
+      const projectRoot = process.cwd();
+      const report = getTokenReport(projectRoot, period, hours, session_id, include_diagnostics);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(report, null, 2) }],
+      };
+    });
+  }
+}
 
 async function main() {
+  const projectRoot = process.cwd();
+
+  // Load config before tool registration
+  const config = loadConfig(projectRoot);
+
+  // Register tools based on config
+  registerTools(server, config);
+
+  // Connect transport
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  const projectRoot = process.cwd();
+  // Log enabled tool groups
+  const enabledGroups = ['navigation'];
+  if (config.tools?.summaries) enabledGroups.push('summaries');
+  if (config.tools?.tasks) enabledGroups.push('tasks');
+  if (config.tools?.telemetry) enabledGroups.push('telemetry');
+  process.stderr.write(`Tool groups: ${enabledGroups.join(', ')}\n`);
 
   // Auto-start session
   const sessionManager = new SessionManager(projectRoot);
@@ -285,9 +312,6 @@ async function main() {
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('beforeExit', cleanup);
-
-  // Load project config
-  const config = loadConfig(projectRoot);
 
   // Run GC in background on startup (non-blocking)
   runGC(projectRoot, config.gc).catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,8 +94,8 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
     };
   });
 
-  // === SUMMARIES GROUP (off by default) ===
-  if (config.tools?.summaries) {
+  // === SUMMARIES GROUP (on by default — the core feature; disable with "tools": { "summaries": false }) ===
+  if (config.tools?.summaries !== false) {
     server.registerTool('get_file_summary', {
       title: 'Get File Summary',
       description:
@@ -291,7 +291,7 @@ async function main() {
 
   // Log enabled tool groups
   const enabledGroups = ['navigation'];
-  if (config.tools?.summaries) enabledGroups.push('summaries');
+  if (config.tools?.summaries !== false) enabledGroups.push('summaries');
   if (config.tools?.tasks) enabledGroups.push('tasks');
   if (config.tools?.telemetry) enabledGroups.push('telemetry');
   process.stderr.write(`Tool groups: ${enabledGroups.join(', ')}\n`);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -101,4 +101,43 @@ describe('loadConfig', () => {
     const config = loadConfig(tempDir);
     expect(config.ignore).toEqual(['*.log']);
   });
+
+  it('loads tools config from config file', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ tools: { summaries: true, tasks: false } }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.tools).toEqual({ summaries: true, tasks: false });
+  });
+
+  it('defaults to no tools config when not specified', () => {
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ maxFiles: 100 }));
+    const config = loadConfig(tempDir);
+    expect(config.tools).toBeUndefined();
+  });
+
+  it('rejects invalid tools value (not object)', () => {
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ tools: true }));
+    const config = loadConfig(tempDir);
+    expect(config).toEqual({});
+  });
+
+  it('rejects invalid tools group value (not boolean)', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ tools: { summaries: 'yes' } }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config).toEqual({});
+  });
+
+  it('ignores unknown tool group keys', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ tools: { summaries: true, unknown: true } }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.tools).toEqual({ summaries: true });
+  });
 });


### PR DESCRIPTION
Adds tool-group configuration so the MCP tool surface can be tuned per repo via `.repo-memory.json`, and trims the default surface to what most sessions actually use.

## Defaults (after review)
- **navigation** — always on (project map, related files, dependency graph, changed files).
- **summaries** — **on by default** (get_file_summary, batch, search_by_purpose, force_reread, invalidate). This is the flagship feature, so it ships out of the box; opt out with `"tools": { "summaries": false }`.
- **tasks**, **telemetry** — **off by default** (niche/meta; ~400 tokens/turn saved). Enable with `"tools": { "tasks": true, "telemetry": true }`.

## What
- New `src/config.ts` tool-group config (extends `.repo-memory.json`), fail-safe validation (invalid config → built-in defaults + warning).
- `src/server.ts` registers tools per enabled group; logs enabled groups on startup.
- `tests/unit/config.test.ts`; README documents the groups + defaults.
- Version 0.5.0 → 0.6.0.

## Verification
- typecheck / lint / test (329) / build ✅
- Live MCP `tools/list` on a default install exposes 9 tools incl. `get_file_summary`; telemetry/tasks correctly absent.

Review: agent-review (Comment verdict, mechanically safe — all tools preserved, reversible, no cache-layer impact). Docs gap #131 fixed; #132 (strict config validation) left as a tracked design decision.