### PR TITLE
chore(release): bump to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Version bump for the 0.7.0 release. `0.6.0` is already on npm, so the tool-group config feature (#130) and the better-sqlite3 Node 26 fix (#126) ship as **0.7.0** (minor — new feature).

This is the PR-based bump step of the release flow: merge this, then publish from the updated main and tag `v0.7.0` (the repo has no tags yet — this starts tagging releases).

Gates: typecheck / lint / test / build all ✓.