### PR TITLE
chore: add skill-profile skill + generate the repo's profile

### DIFF
--- a/.claude/commands/skill-profile.md
+++ b/.claude/commands/skill-profile.md
@@ -1,0 +1,90 @@
+# /skill-profile
+
+Generate or refresh this repo's `.claude/skill-profile.md` — the self-description the `/skill` client reads to tailor generic skill templates for *this* repo at install time. Run it once when a repo starts using skills (and again after conventions change) so every `skill add` / `skill update` customizes sharply and deterministically instead of re-inferring the repo from scratch each time.
+
+This skill **writes** the profile; `/skill` **reads** it. The profile is optional — without it, installs still work by inferring from `CLAUDE.md` and the layout — but a profile makes them sharper, more consistent, and cheaper.
+
+## Arguments
+
+- `$ARGUMENTS` — optional:
+  - `--check` — report how the profile would change vs the current repo state (drift), but write nothing.
+  - `--print` — print the composed profile to stdout instead of writing the file.
+  - With no argument, write/update `.claude/skill-profile.md` in place.
+
+## Instructions
+
+### 1. Read the current state
+
+- Read `.claude/skill-profile.md` if it exists (you are refreshing, not blindly overwriting — preserve hand-written nuance that's still accurate).
+- List `.claude/commands/*.md` to see which skills this repo uses — the profile carries a tailoring section for the ones that need repo-specific values. (Installed copies have already had their `{{CUSTOMIZE}}` markers filled in at install time; the *registry templates* are where you read what each skill needs — see step 2.)
+
+### 2. Gather repo facts (real values only)
+
+Discover, don't assume. Pull from the repo itself:
+
+- **Tech / build system** — from the manifest (`package.json` / `Cargo.toml` / `go.mod` / `pyproject.toml` / …) and `CLAUDE.md`.
+- **Repo + branch** — `gh repo view --json nameWithOwner,defaultBranchRef` (or `git remote`).
+- **CI / required checks** — `.github/workflows/*` and, if available, `gh api repos/{owner}/{repo}/branches/{main}/protection`. If there are none, record "none — build is the gate".
+- **Build / test / lint commands** — the manifest's scripts and `CLAUDE.md`. Capture the *exact* commands.
+- **Conventions** — branch naming, commit style + scope list, source-file globs — from `CLAUDE.md` and recent `git log`.
+- **Hard requirements / invariants** — non-negotiables from `CLAUDE.md` (e.g. "never return stale data", "ESM only", a zero-attribution policy).
+- **Labels** — `gh label list` (for skills that file issues). Record the real label families; never invent.
+- **Per-skill needs** — for each skill this repo uses, read its **registry template** (`generic/<name>.md` in the resolved registry — see `/skill`'s "Resolving the registry") to learn what its `{{CUSTOMIZE}}` markers ask for (persona, review criteria, audit focus, required-check names, test conventions, label scheme, publish footguns, …). The installed `.claude/commands/<name>.md` has already had its markers filled, so the **template** is the source of truth for what needs a value — then decide whether this repo has a real, specific one.
+
+### 3. Compose the profile
+
+Write markdown in this structure (the schema `/skill` expects). The first three sections are repo-wide; then one `## <skill-name> Customizations` section per installed skill that genuinely needs more than the generic template.
+
+```markdown
+# <repo> skill profile
+
+## Project Context
+- Tech: <languages, frameworks, platform>
+- Build system: <how it builds>
+- Repo: <owner/name>
+- Main branch: <main>
+- CI: <required checks, or "none — build is the gate">
+- Status: <one line>
+- Hard requirements (never regress): <invariants>
+
+## Build / Test Commands
+- Build (the gate): <exact command>
+- Test: <exact command, or "no test target yet">
+- Lint/typecheck: <command, or how it's covered>
+
+## Conventions
+- Branch prefix / naming: <e.g. auto/<number>-<slug>>
+- Commit style + scopes: <conventional commits; scope list>
+- Source file patterns: <globs the skills should target>
+
+## <skill-name> Customizations
+<Exactly what that skill's customization markers need — persona, labels, review
+criteria, audit focus, required-check names, publish footguns, etc. Head each
+section with the skill's exact name + the literal " Customizations" suffix.>
+```
+
+### 4. Rules (match the registry's profile contract)
+
+- **Use real values, never invent.** No label set, test command, or persona for a spot? Omit it — at install time the agent drops the corresponding marker rather than fabricate a value. Placeholder *shapes* (`scope`, `path/to/file:<line>`) are fine; fabricated specifics are not.
+- **One section per skill that needs it**, headed `## <skill-name> Customizations` (exact skill name + literal ` Customizations`). Skills with no repo-specific needs get no section — they just use the generic template.
+- **No secrets.** The profile is committed. Keys, tokens, OTP secrets never go here (a publish footgun like "OTP is interactive, don't retry" is fine — a *value* is not).
+- **Capture hard-won footguns.** If a skill has bitten this repo before (a release OTP quirk, a native-module/runtime constraint, a lint-vs-typecheck gap), record it in that skill's section — that is the highest-value content a profile carries.
+- **Keep it tight.** The profile is read on every install; favor specifics over prose.
+
+### 5. Write / report
+
+- Default: write `.claude/skill-profile.md` (create `.claude/` if needed).
+- `--check`: report the diff vs the existing profile (added/changed/removed sections) and exit without writing.
+- `--print`: print the composed profile; write nothing.
+
+### 6. Report to the user
+
+State: the sections written, which installed skills got a `Customizations` section (and which were left to the generic template), and anything deliberately omitted for lack of a real value. If a profile already existed, summarize what changed.
+
+## Notes
+
+- **Run after `skill add`s settle.** The profile is most useful once a repo has installed the skills it uses — then the per-skill sections target real markers. Re-run after installing new skills or changing conventions.
+- **`profileHash`.** `/skill` records the profile's hash in `.claude/skills.lock`; `skill outdated` flags skills tailored against an older profile, so refreshing the profile and running `skill update` re-tailors them. Updating the profile is how you push a convention change out to every installed skill.
+- **Idempotent.** Re-running reproduces the same profile from the same repo state; it only changes when the repo does.
+
+<!-- skill-templates: skill-profile ecb5d01 2026-06-09 -->

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -20,7 +20,7 @@
 - Commit style: conventional commits `type(scope): description`. Types: feat, fix, refactor, test, docs, chore. Scopes: `server, cache, indexer, memory, graph, telemetry, infra`.
 - Flow: PR-based on `main`, branch protection, **squash merges**, **conversation resolution required**; no direct pushes or force-pushes to main.
 - Source patterns: `src/**/*.ts`; tests `tests/unit/*.test.ts` + `tests/integration/*.test.ts`; fixtures `tests/fixtures/`; benchmarks `tests/benchmarks/`. Git worktrees under `.claude/worktrees/`.
-- Labels: `epic:{infra,cache-engine,mcp-server,indexer,task-memory,graph,persistence,telemetry,dx}`, `complexity:{low,medium,high}`, `testing:{low,medium,high}`, plus `bug`, `enhancement`, `good first issue`, `help wanted`, `wontfix`, `design-spike`, `from-review`.
+- Labels: `epic:{infra,cache-engine,mcp-server,indexer,task-memory,graph,persistence,telemetry,dx}`, `complexity:{low,medium,high}`, `testing:{low,medium,high}`, plus `bug`, `enhancement`, `good first issue`, `help wanted`, `wontfix`, `design-spike`, `from-review`, and the GitHub defaults (`documentation`, `duplicate`, `invalid`, `question`).
 - Design ethos: prefer enhancing existing MCP tools (optional params) over adding new tools — each tool costs ~100 tokens/turn in the system prompt.
 
 ## release Customizations
@@ -52,23 +52,50 @@
 - Criteria emphasis: TS strict/ESM/no-`console.log`; cache correctness (never stale); prefer optional params over new MCP tools; DB changes via `src/persistence/` migrations.
 - Issues: label `enhancement` + `from-review`; `type(scope)` titles with the scope list above.
 
-## project-audit / swarm-audit / agentic-audit Customizations
-- Add domain auditor/reviewer personas: **Cache Correctness** (stale-data, hash determinism, invalidation paths) and **MCP Protocol** (tool contracts, stdio transport, tool-count/token ROI). Sentinel security lens = filesystem + SQLite attack surface, not web vulns.
-- Grading: treat cache correctness and SHA-256 determinism as gating/Critical.
+## project-audit Customizations
+- Auditor personas to add: **Cache Correctness** (stale-data, hash determinism, invalidation paths) and **MCP Protocol** (tool contracts, stdio transport, tool-count/token ROI). Security lens = filesystem + SQLite attack surface, not web vulns. Treat cache correctness and SHA-256 determinism as gating/Critical.
+
+## swarm-audit Customizations
+- Add the **Cache Correctness** and **MCP Protocol** personas (as in project-audit). Grading caps on stale-data risk and hashing determinism.
+
+## agentic-audit Customizations
+- Add **Cache Correctness** and **MCP Protocol** reviewer personas to the PR-review roster; emphasize never-stale-data and MCP stdio/tool-contract correctness.
 
 ## bug-hunt Customizations
 - Bias hunters toward stale-cache/invalidation correctness in `src/cache`, `src/indexer`, `src/persistence` (the project's hard invariant). Labels: `bug` + the `epic:*`/`complexity:*`/`testing:*` families.
 
-## create-issue / create-pr / decompose-issue / start-working / tackle-issues Customizations
-- Use the real label taxonomy above (`epic:*`, `complexity:*`, `testing:*`, `from-review`). PR bodies auto-detect issue closures (`Closes #N`); zero attribution in bodies. Work sources: GitHub issues + open PRs; design docs under `docs/planning/`.
+## create-issue Customizations
+- Use the real label taxonomy (`epic:*`, `complexity:*`, `testing:*`, plus `from-review` for review-spawned issues). Zero attribution in bodies.
 
-## merge / batch-merge / merge-gate / fix-ci Customizations
-- Required CI check name: **`ci`** (the single job in `ci.yml`). Merge via **squash**; branch protection requires conversations resolved before merge.
-- Never `npm publish` from a merge — publishing is a separate OTP-gated manual step (see release).
-- fix-ci: typecheck-passes-while-lint-fails is a known failure mode (check lint separately); better-sqlite3 native ABI on a new Node major → reinstall for a matching prebuilt, not source rebuild.
+## create-pr Customizations
+- Squash-merge target `main`; PR bodies auto-detect issue closures (`Closes #N`); zero attribution in titles/bodies. Label with `from-review` when applicable.
 
-## parallel-dev / autonomous-dev-flow Customizations
-- Per-agent verification = the full gate `npm run typecheck && npm run lint && npm test && npm run build`. Worktrees live under `.claude/worktrees/`. Worktree agents commonly leave unused vars that pass typecheck but fail lint — always run lint independently.
+## decompose-issue Customizations
+- Sub-issue labels from the real taxonomy (`enhancement` + `complexity:*`); sub-task titles follow `type(scope): description` with the repo scope list.
+
+## start-working Customizations
+- Work sources: open GitHub issues + open PRs; design docs under `docs/planning/`. Ready signals: `complexity:low`/`complexity:medium`, `good first issue`, `help wanted`. Blocked signals: `wontfix`, `design-spike`.
+
+## tackle-issues Customizations
+- Branch prefix `auto/`; worktrees under `.claude/worktrees/`. Per-issue verification = the full gate; run `npm run lint` independently (worktree agents leave unused vars that pass typecheck but fail lint).
+
+## merge Customizations
+- Required CI check: **`ci`** (single job in `ci.yml`). Merge via **squash**; conversations must be resolved (branch protection). Never `npm publish` from a merge — publishing is a separate OTP-gated manual step (see release).
+
+## batch-merge Customizations
+- Required check `ci`; squash-merge; conversation resolution required before merge.
+
+## merge-gate Customizations
+- The common merge blocker is **unresolved conversations** (branch protection); resolve threads via GraphQL. Squash-merge.
+
+## fix-ci Customizations
+- CI = the `ci` job in `ci.yml` (Node 20.x). Known failure mode: typecheck passes while lint fails (unused vars) — check lint separately. better-sqlite3 native ABI on a new Node major → reinstall for a matching prebuilt, not a source rebuild.
+
+## parallel-dev Customizations
+- Per-agent verification = the full gate `npm run typecheck && npm run lint && npm test && npm run build`. Worktrees under `.claude/worktrees/`; run lint independently (typecheck-passes/lint-fails footgun).
+
+## autonomous-dev-flow Customizations
+- Full-gate verification per agent; worktrees under `.claude/worktrees/`; lint independently. Decompose only issues genuinely too large to implement directly.
 
 ## smoke-test Customizations
 - This is a **headless MCP stdio server — no browser/UI**. A smoke test = build → spawn `node dist/server.js` → MCP `initialize` (assert `serverInfo.name === "repo-memory"`) → `tools/list`. No screenshots/aria/URLs.

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -1,0 +1,74 @@
+# repo-memory skill profile
+
+## Project Context
+- Tech: TypeScript (strict, ES2022, NodeNext ESM), Node.js 20+ (dev machine on Node 26), MCP SDK (`@modelcontextprotocol/sdk`), SQLite via `better-sqlite3`, `zod`.
+- Build system: `tsc` → `dist/` (ESM only); npm with `package-lock.json`.
+- Repo: blamechris/repo-memory
+- Main branch: main
+- CI: GitHub Actions (`.github/workflows/ci.yml`), single required job **`ci`** — runs typecheck + lint + test + build on Node 20.x.
+- Status: headless MCP server published to npm as `@blamechris/repo-memory`. A `.repo-memory/cache.db` (SQLite) lives in each target project root.
+- Hard requirements (never regress): cache correctness over performance — **never return stale data**; deterministic SHA-256 file hashing; ESM only; no `console.log` in production (structured logging via MCP); **zero attribution** — no AI/Claude mentions in commits, PRs, issues, or files (the user is the sole author).
+
+## Build / Test Commands
+- Build (the gate): `npm run build` (`tsc` → `dist/`)
+- Test: `npm test` (vitest); integration `npm run test:integration`; coverage `npm run test:coverage`
+- Lint / typecheck: `npm run typecheck` (`tsc --noEmit`) and `npm run lint` (ESLint). **Run lint independently — typecheck passing has repeatedly masked lint failures (unused vars).**
+- Full pre-merge/pre-release gate: `npm run typecheck && npm run lint && npm test && npm run build`
+
+## Conventions
+- Branch naming: `auto/<number>-<slug>` for automated work; otherwise `feat|fix|chore|refactor|test|docs/<slug>`.
+- Commit style: conventional commits `type(scope): description`. Types: feat, fix, refactor, test, docs, chore. Scopes: `server, cache, indexer, memory, graph, telemetry, infra`.
+- Flow: PR-based on `main`, branch protection, **squash merges**, **conversation resolution required**; no direct pushes or force-pushes to main.
+- Source patterns: `src/**/*.ts`; tests `tests/unit/*.test.ts` + `tests/integration/*.test.ts`; fixtures `tests/fixtures/`; benchmarks `tests/benchmarks/`. Git worktrees under `.claude/worktrees/`.
+- Labels: `epic:{infra,cache-engine,mcp-server,indexer,task-memory,graph,persistence,telemetry,dx}`, `complexity:{low,medium,high}`, `testing:{low,medium,high}`, plus `bug`, `enhancement`, `good first issue`, `help wanted`, `wontfix`, `design-spike`, `from-review`.
+- Design ethos: prefer enhancing existing MCP tools (optional params) over adding new tools — each tool costs ~100 tokens/turn in the system prompt.
+
+## release Customizations
+- Publish: `npm publish --access public` (package `@blamechris/repo-memory`). Auth: `npm whoami`; publish needs an **interactive OTP via browser**.
+- Footguns (hard-won): after OTP the publish **usually succeeds on the first attempt — do NOT retry** (retry fails "already published"). Always show the **FULL** publish output (never `tail`) so the OTP URL is visible. Run `npm run lint` **independently** before publishing.
+- Version bump: `npm version <type> --no-git-tag-version` (no local tag — PR-based, no direct push). Bump lands via PR; after merge, tag the merged commit and push **only the tag**.
+- Release notes: invoke `/changelog --output=release` — repo keeps **no `CHANGELOG.md`**; notes live only as GitHub releases.
+- Post-publish verify: `npx -y @blamechris/repo-memory` completes an MCP `initialize` handshake returning `serverInfo {name:"repo-memory", version:<new>}`.
+- Note: tagging began at `v0.7.0`; earlier published versions (0.1.0–0.6.0) have no git tags, and npm `0.6.0` predates the tool-group feature.
+
+## deps Customizations
+- npm, single manifest. Outdated: `npm outdated`. Audit: `npm audit` (high+ must-fix before release).
+- Native dependency **better-sqlite3** is ABI-pinned. On **Node 26 it is prebuilt-only** — it cannot compile from source (its C++ uses the V8 API `PropertyCallbackInfo::This`, removed in Node 26). Fix an ABI mismatch (`NODE_MODULE_VERSION` error) with `npm install better-sqlite3` (fetches a matching prebuilt) — **never `npm rebuild`** (forces the failing source compile and deletes the working binary). The `^` range floats to a Node-26-OK release.
+- Apply + gate: `npm install`, then `npm test` + `npm run build`; commit `package-lock.json`.
+
+## doctor Customizations
+- Runtime: Node 20+ (dev Node 26). Probe better-sqlite3 loads: `node -e "new (require('better-sqlite3'))(':memory:')"`; fix ABI mismatch with `npm install` (not `npm rebuild`).
+- Build state: `npm run build` (`tsc` → `dist/`); the entrypoint runs the **build output** `dist/server.js`, so `dist/` must be current with `src/`.
+- Entrypoint startup (decisive check): pipe an MCP `initialize` request to `node dist/server.js` over stdio and confirm a `serverInfo` response with name `repo-memory`.
+- Integration: an MCP client config (`.mcp.json`) should launch `node <abs path>/dist/server.js`.
+
+## changelog Customizations
+- Squash-merge enumeration: `gh pr list --state merged --base main`; previous release via `git describe --tags --abbrev=0` (root-commit fallback — tags only exist from v0.7.0 on).
+- Categorize by conventional-commit type: feat→Added, fix→Fixed, refactor/perf→Changed, security→Security; omit chore/version-bump noise.
+- Output: **GitHub release body** (`--output=release`) — repo keeps no `CHANGELOG.md` file.
+
+## agent-review Customizations
+- Persona: senior TypeScript/Node systems reviewer for a headless MCP server — thinks in cache correctness, deterministic hashing, SQLite integrity, and the per-tool token budget.
+- Criteria emphasis: TS strict/ESM/no-`console.log`; cache correctness (never stale); prefer optional params over new MCP tools; DB changes via `src/persistence/` migrations.
+- Issues: label `enhancement` + `from-review`; `type(scope)` titles with the scope list above.
+
+## project-audit / swarm-audit / agentic-audit Customizations
+- Add domain auditor/reviewer personas: **Cache Correctness** (stale-data, hash determinism, invalidation paths) and **MCP Protocol** (tool contracts, stdio transport, tool-count/token ROI). Sentinel security lens = filesystem + SQLite attack surface, not web vulns.
+- Grading: treat cache correctness and SHA-256 determinism as gating/Critical.
+
+## bug-hunt Customizations
+- Bias hunters toward stale-cache/invalidation correctness in `src/cache`, `src/indexer`, `src/persistence` (the project's hard invariant). Labels: `bug` + the `epic:*`/`complexity:*`/`testing:*` families.
+
+## create-issue / create-pr / decompose-issue / start-working / tackle-issues Customizations
+- Use the real label taxonomy above (`epic:*`, `complexity:*`, `testing:*`, `from-review`). PR bodies auto-detect issue closures (`Closes #N`); zero attribution in bodies. Work sources: GitHub issues + open PRs; design docs under `docs/planning/`.
+
+## merge / batch-merge / merge-gate / fix-ci Customizations
+- Required CI check name: **`ci`** (the single job in `ci.yml`). Merge via **squash**; branch protection requires conversations resolved before merge.
+- Never `npm publish` from a merge — publishing is a separate OTP-gated manual step (see release).
+- fix-ci: typecheck-passes-while-lint-fails is a known failure mode (check lint separately); better-sqlite3 native ABI on a new Node major → reinstall for a matching prebuilt, not source rebuild.
+
+## parallel-dev / autonomous-dev-flow Customizations
+- Per-agent verification = the full gate `npm run typecheck && npm run lint && npm test && npm run build`. Worktrees live under `.claude/worktrees/`. Worktree agents commonly leave unused vars that pass typecheck but fail lint — always run lint independently.
+
+## smoke-test Customizations
+- This is a **headless MCP stdio server — no browser/UI**. A smoke test = build → spawn `node dist/server.js` → MCP `initialize` (assert `serverInfo.name === "repo-memory"`) → `tools/list`. No screenshots/aria/URLs.

--- a/.claude/skills.lock
+++ b/.claude/skills.lock
@@ -24,6 +24,7 @@
     "recon": { "hash": "7f5fa28", "installed": "2026-06-08" },
     "release": { "hash": "3254376", "installed": "2026-06-09" },
     "skill": { "hash": "18b9f3e", "installed": "2026-06-08" },
+    "skill-profile": { "hash": "ecb5d01", "installed": "2026-06-09" },
     "smoke-test": { "hash": "21fa678", "installed": "2026-06-08" },
     "start-working": { "hash": "15d7b73", "installed": "2026-06-08" },
     "swarm-audit": { "hash": "c8b8477", "installed": "2026-06-08" },


### PR DESCRIPTION
Installs the new `/skill-profile` generator and **runs it** to create `.claude/skill-profile.md` — which repo-memory never had, so every prior `skill add` inferred the repo from scratch.

## What's in the profile
- **Project Context** — TS/ESM/MCP/SQLite stack, Node 20+ (dev 26), CI job `ci`, hard invariants (cache correctness, deterministic hashing, ESM-only, zero attribution).
- **Build/Test Commands** — the full gate, plus the lint-vs-typecheck caveat.
- **Conventions** — branch/commit style, scopes, squash + conversation-resolution flow, the full label taxonomy, the ~100-tok/tool ethos.
- **Per-skill Customizations** capturing hard-won specifics: release (OTP don't-retry / full output / lint-first / `--no-git-tag-version` / changelog→GitHub-release / npx verify), deps + doctor (better-sqlite3 prebuilt-only on Node 26, install-not-rebuild), changelog (squash enumeration, no CHANGELOG file), review/audit personas (cache-correctness + MCP-protocol), CI check name for merge skills, worktree/lint for parallel skills, headless smoke-test.

## Notes
- `skill-profile` added to `.claude/skills.lock` (28 skills; reconciles with 28 command files).
- Existing skills keep their entries without `profileHash` (they predate the profile); a future `skill update` re-tailors them against it.
- Additive `.claude/` only. The skill itself is lint-clean.

Going forward, `skill add`/`skill update` read this profile for sharp, consistent, deterministic customization.