### PR TITLE
fix(server): per-key config validation (closes #132)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,10 @@ export interface RepoMemoryConfig {
 
 const configCache = new Map<string, RepoMemoryConfig>();
 
+function warn(message: string): void {
+  process.stderr.write(`Warning: ${CONFIG_FILENAME}: ${message}\n`);
+}
+
 export function loadConfig(projectRoot: string): RepoMemoryConfig {
   const cached = configCache.get(projectRoot);
   if (cached) return cached;
@@ -32,12 +36,11 @@ export function loadConfig(projectRoot: string): RepoMemoryConfig {
   if (existsSync(configPath)) {
     try {
       const raw = readFileSync(configPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      config = validateConfig(parsed);
+      config = validateConfig(JSON.parse(raw));
     } catch (err) {
-      process.stderr.write(
-        `Warning: failed to load ${CONFIG_FILENAME}: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
+      // Only unparseable JSON reaches here — validateConfig itself never throws,
+      // it skips invalid keys. A broken file falls back to built-in defaults.
+      warn(`failed to parse: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -45,59 +48,71 @@ export function loadConfig(projectRoot: string): RepoMemoryConfig {
   return config;
 }
 
+// Validate per key: an invalid key is skipped with a warning and the valid keys
+// are still applied, rather than discarding the whole config on one bad value.
+// (A non-object root, or a non-object gc/tools, drops just that scope.)
 function validateConfig(raw: unknown): RepoMemoryConfig {
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    throw new Error('Config must be a JSON object');
-  }
-
-  const obj = raw as Record<string, unknown>;
   const config: RepoMemoryConfig = {};
 
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    warn('must be a JSON object; using defaults');
+    return config;
+  }
+  const obj = raw as Record<string, unknown>;
+
   if ('ignore' in obj) {
-    if (!Array.isArray(obj.ignore) || !obj.ignore.every((v) => typeof v === 'string')) {
-      throw new Error('"ignore" must be an array of strings');
+    if (Array.isArray(obj.ignore) && obj.ignore.every((v) => typeof v === 'string')) {
+      config.ignore = obj.ignore as string[];
+    } else {
+      warn('"ignore" must be an array of strings; ignoring it');
     }
-    config.ignore = obj.ignore;
   }
 
   if ('maxFiles' in obj) {
-    if (typeof obj.maxFiles !== 'number' || obj.maxFiles < 1) {
-      throw new Error('"maxFiles" must be a positive number');
+    if (typeof obj.maxFiles === 'number' && obj.maxFiles >= 1) {
+      config.maxFiles = obj.maxFiles;
+    } else {
+      warn('"maxFiles" must be a positive number; ignoring it');
     }
-    config.maxFiles = obj.maxFiles;
   }
 
   if ('gc' in obj) {
-    if (typeof obj.gc !== 'object' || obj.gc === null || Array.isArray(obj.gc)) {
-      throw new Error('"gc" must be an object');
-    }
-    const gc = obj.gc as Record<string, unknown>;
-    config.gc = {};
-
-    for (const key of ['cacheMaxAgeDays', 'taskMaxAgeDays', 'telemetryMaxAgeDays'] as const) {
-      if (key in gc) {
-        if (typeof gc[key] !== 'number' || gc[key] < 1) {
-          throw new Error(`"gc.${key}" must be a positive number`);
+    if (typeof obj.gc === 'object' && obj.gc !== null && !Array.isArray(obj.gc)) {
+      const gc = obj.gc as Record<string, unknown>;
+      const out: NonNullable<RepoMemoryConfig['gc']> = {};
+      for (const key of ['cacheMaxAgeDays', 'taskMaxAgeDays', 'telemetryMaxAgeDays'] as const) {
+        if (key in gc) {
+          const value = gc[key];
+          if (typeof value === 'number' && value >= 1) {
+            out[key] = value;
+          } else {
+            warn(`"gc.${key}" must be a positive number; ignoring it`);
+          }
         }
-        config.gc[key] = gc[key];
       }
+      if (Object.keys(out).length > 0) config.gc = out;
+    } else {
+      warn('"gc" must be an object; ignoring it');
     }
   }
 
   if ('tools' in obj) {
-    if (typeof obj.tools !== 'object' || obj.tools === null || Array.isArray(obj.tools)) {
-      throw new Error('"tools" must be an object');
-    }
-    const tools = obj.tools as Record<string, unknown>;
-    config.tools = {};
-
-    for (const key of ['summaries', 'tasks', 'telemetry'] as const) {
-      if (key in tools) {
-        if (typeof tools[key] !== 'boolean') {
-          throw new Error(`"tools.${key}" must be a boolean`);
+    if (typeof obj.tools === 'object' && obj.tools !== null && !Array.isArray(obj.tools)) {
+      const tools = obj.tools as Record<string, unknown>;
+      const out: ToolGroupConfig = {};
+      for (const key of ['summaries', 'tasks', 'telemetry'] as const) {
+        if (key in tools) {
+          const value = tools[key];
+          if (typeof value === 'boolean') {
+            out[key] = value;
+          } else {
+            warn(`"tools.${key}" must be a boolean; ignoring it`);
+          }
         }
-        config.tools[key] = tools[key];
       }
+      if (Object.keys(out).length > 0) config.tools = out;
+    } else {
+      warn('"tools" must be an object; ignoring it');
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,9 +38,10 @@ export function loadConfig(projectRoot: string): RepoMemoryConfig {
       const raw = readFileSync(configPath, 'utf-8');
       config = validateConfig(JSON.parse(raw));
     } catch (err) {
-      // Only unparseable JSON reaches here — validateConfig itself never throws,
-      // it skips invalid keys. A broken file falls back to built-in defaults.
-      warn(`failed to parse: ${err instanceof Error ? err.message : String(err)}`);
+      // Reached only if the file can't be read (IO/permissions) or parsed —
+      // validateConfig never throws, it skips invalid keys. Either way, fall
+      // back to built-in defaults.
+      warn(`failed to load: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -55,7 +55,7 @@ describe('loadConfig', () => {
       JSON.stringify({ ignore: 'not-an-array' }),
     );
     const config = loadConfig(tempDir);
-    // Falls back to empty config on validation error
+    // The only key is invalid, so it's dropped and nothing valid remains.
     expect(config).toEqual({});
   });
 
@@ -136,6 +136,34 @@ describe('loadConfig', () => {
     writeFileSync(
       join(tempDir, '.repo-memory.json'),
       JSON.stringify({ tools: { summaries: true, unknown: true } }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.tools).toEqual({ summaries: true });
+  });
+
+  it('keeps valid keys when another top-level key is invalid', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ maxFiles: -1, ignore: ['*.log'], tools: { tasks: true } }),
+    );
+    const config = loadConfig(tempDir);
+    // maxFiles is dropped (invalid); the valid ignore + tools are still applied.
+    expect(config).toEqual({ ignore: ['*.log'], tools: { tasks: true } });
+  });
+
+  it('keeps valid gc subkeys and drops only the invalid one', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ gc: { cacheMaxAgeDays: 7, taskMaxAgeDays: 0 } }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.gc).toEqual({ cacheMaxAgeDays: 7 });
+  });
+
+  it('keeps valid tool groups and drops only the invalid one', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ tools: { summaries: true, tasks: 'no' } }),
     );
     const config = loadConfig(tempDir);
     expect(config.tools).toEqual({ summaries: true });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -168,4 +168,24 @@ describe('loadConfig', () => {
     const config = loadConfig(tempDir);
     expect(config.tools).toEqual({ summaries: true });
   });
+
+  it('warns on stderr when a key is skipped', () => {
+    const writes: string[] = [];
+    const original = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      writeFileSync(
+        join(tempDir, '.repo-memory.json'),
+        JSON.stringify({ maxFiles: -1, ignore: ['*.log'] }),
+      );
+      const config = loadConfig(tempDir);
+      expect(config).toEqual({ ignore: ['*.log'] });
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(writes.join('')).toMatch(/maxFiles/);
+  });
 });


### PR DESCRIPTION
Closes #132.

Previously one bad key in `.repo-memory.json` (e.g. a typo'd `maxFiles`) made `loadConfig` throw and discard the **entire** config — silently disabling unrelated valid settings like `tools`.

Now validation is **per key**: an invalid key is skipped with a stderr warning and the valid keys still apply. A non-object root (or non-object `gc`/`tools`) drops just that scope. `validateConfig` no longer throws — only unparseable JSON falls back to built-in defaults.

## Behavior
- `{ maxFiles: -1, ignore: ['*.log'] }` → `{ ignore: ['*.log'] }` (was `{}`).
- `{ gc: { cacheMaxAgeDays: 7, taskMaxAgeDays: 0 } }` → `{ gc: { cacheMaxAgeDays: 7 } }`.
- Existing 'reject the whole thing' tests still pass (their only key was invalid → still empty).

Gates: typecheck / lint / build ✓; config suite 18 tests (3 new), full suite 332.