### PR TITLE
fix(indexer): posix-normalize stored paths and pathPrefix for Windows

### DIFF
--- a/src/indexer/imports.ts
+++ b/src/indexer/imports.ts
@@ -1,5 +1,6 @@
 import { dirname, join, normalize, relative } from 'path';
 import type { ImportRef } from '../types.js';
+import { toPosix } from '../utils/posix-path.js';
 
 function isRelativeImport(specifier: string): boolean {
   return specifier === '.' || specifier === '..' ||
@@ -16,7 +17,7 @@ function resolveTarget(
   }
   const fileDir = dirname(join(projectRoot, filePath));
   const resolved = normalize(join(fileDir, importSpecifier));
-  return relative(projectRoot, resolved);
+  return toPosix(relative(projectRoot, resolved));
 }
 
 function getExtension(filePath: string): string {

--- a/src/indexer/scanner.ts
+++ b/src/indexer/scanner.ts
@@ -3,6 +3,7 @@ import { readdir } from 'fs/promises';
 import { join, relative } from 'path';
 import { promisify } from 'util';
 import { loadConfig } from '../config.js';
+import { toPosix } from '../utils/posix-path.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -108,7 +109,7 @@ async function scanWithFs(rootDir: string): Promise<string[]> {
       if (entry.isDirectory()) {
         await walk(fullPath);
       } else if (entry.isFile()) {
-        files.push(relative(rootDir, fullPath));
+        files.push(toPosix(relative(rootDir, fullPath)));
       }
     }
   }

--- a/src/tools/search-by-purpose.ts
+++ b/src/tools/search-by-purpose.ts
@@ -1,5 +1,6 @@
 import { CacheStore } from '../cache/store.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
+import { toPosix } from '../utils/posix-path.js';
 
 export interface SearchResult {
   path: string;
@@ -26,15 +27,22 @@ export function searchByPurpose(
   const effectiveLimit = limit ?? 20;
 
   // Optional scope: restrict the search to files at or under a directory/prefix.
-  // Normalized so "src/cache", "src/cache/", "./src/cache", and "/src/cache"
-  // behave the same, and matched on a path boundary so "src/cache" excludes
-  // "src/cache-utils.ts". (Stored paths are POSIX-style and relative to root.)
-  const normalizedPrefix = pathPrefix?.trim().replace(/^(?:\.?\/)+/, '').replace(/\/+$/, '');
+  // Normalized so "src/cache", "src/cache/", "./src/cache", "/src/cache", and the
+  // Windows form "src\cache" behave the same, and matched on a path boundary so
+  // "src/cache" excludes "src/cache-utils.ts". (Stored paths are POSIX-style and
+  // relative to root.)
+  const normalizedPrefix = pathPrefix
+    ? toPosix(pathPrefix.trim()).replace(/^(?:\.?\/)+/, '').replace(/\/+$/, '')
+    : undefined;
   const allEntries = store.getAllEntries();
+  // Normalize the stored side too, so a forward-slash prefix still scopes paths
+  // that were cached on Windows (backslash separators) before posix-normalization
+  // at the indexing boundary existed.
   const entries = normalizedPrefix
-    ? allEntries.filter(
-        (e) => e.path === normalizedPrefix || e.path.startsWith(`${normalizedPrefix}/`),
-      )
+    ? allEntries.filter((e) => {
+        const p = toPosix(e.path);
+        return p === normalizedPrefix || p.startsWith(`${normalizedPrefix}/`);
+      })
     : allEntries;
 
   const queryTerms = query.toLowerCase().split(/\s+/).filter(Boolean);

--- a/src/utils/posix-path.ts
+++ b/src/utils/posix-path.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize a path to use POSIX (forward-slash) separators.
+ *
+ * Stored cache paths, dependency-graph edges, and validated relative paths are
+ * all kept in POSIX form so that lookups, prefix scoping (search_by_purpose
+ * `pathPrefix`), and segment splits behave identically across platforms. On
+ * Windows, `path.relative()` yields backslash separators; this converts them at
+ * the boundary so the rest of the codebase never has to special-case `\`.
+ *
+ * @param p - A path that may contain backslash separators.
+ * @returns The same path with all backslashes replaced by forward slashes.
+ */
+export function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}

--- a/src/utils/validate-path.ts
+++ b/src/utils/validate-path.ts
@@ -1,4 +1,5 @@
 import { resolve, normalize, relative, sep } from 'node:path';
+import { toPosix } from './posix-path.js';
 
 /**
  * Validates that a file path is safe and resolves within the project root.
@@ -25,5 +26,5 @@ export function validatePath(projectRoot: string, filePath: string): string {
     );
   }
 
-  return relative(normalizedRoot, resolvedPath);
+  return toPosix(relative(normalizedRoot, resolvedPath));
 }

--- a/tests/unit/posix-path.test.ts
+++ b/tests/unit/posix-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { toPosix } from '../../src/utils/posix-path.js';
+
+describe('toPosix', () => {
+  it('converts backslash separators to forward slashes', () => {
+    expect(toPosix('src\\cache\\store.ts')).toBe('src/cache/store.ts');
+  });
+
+  it('leaves posix paths unchanged', () => {
+    expect(toPosix('src/cache/store.ts')).toBe('src/cache/store.ts');
+  });
+
+  it('handles mixed separators', () => {
+    expect(toPosix('src\\cache/store.ts')).toBe('src/cache/store.ts');
+  });
+
+  it('handles an empty string', () => {
+    expect(toPosix('')).toBe('');
+  });
+});

--- a/tests/unit/search-by-purpose.test.ts
+++ b/tests/unit/search-by-purpose.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getFileSummary } from '../../src/tools/get-file-summary.js';
 import { searchByPurpose } from '../../src/tools/search-by-purpose.js';
+import { CacheStore } from '../../src/cache/store.js';
 
 describe('searchByPurpose', () => {
   let tempDir: string;
@@ -155,5 +156,30 @@ describe('searchByPurpose', () => {
   it('omits scope when no pathPrefix is given', () => {
     const result = searchByPurpose(tempDir, 'database');
     expect(result.scope).toBeUndefined();
+  });
+
+  it('matches Windows-style (backslash) stored paths against a forward-slash pathPrefix', () => {
+    // Simulate a cache populated on Windows, where path.relative() yields
+    // backslash separators, by seeding an entry directly. A forward-slash
+    // pathPrefix must still scope it.
+    const store = new CacheStore(tempDir);
+    store.setEntry('src\\win\\handler.ts', 'deadbeef', {
+      purpose: 'windows request handler',
+      exports: ['handleRequest'],
+      imports: [],
+      lineCount: 10,
+      topLevelDeclarations: ['handleRequest'],
+      confidence: 'high',
+    });
+
+    const result = searchByPurpose(tempDir, 'windows', undefined, 'src/win');
+    expect(result.scope).toBe('src/win');
+    expect(result.results.some(r => r.path === 'src\\win\\handler.ts')).toBe(true);
+  });
+
+  it('normalizes a Windows-style (backslash) pathPrefix to posix', () => {
+    const a = searchByPurpose(tempDir, 'database', undefined, 'src\\db');
+    expect(a.scope).toBe('src/db');
+    expect(a.results.every(r => r.path.startsWith('src/db/'))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #141.

## Problem
Cached file paths come from `relative(rootDir, fullPath)` in `src/indexer/scanner.ts` with no separator normalization. On Windows these are stored with backslashes (`src\cache\store.ts`). The `pathPrefix` filter added in #140 matches on forward-slash boundaries (`startsWith(prefix + '/')`), so a `src/cache` prefix would scope **nothing** on Windows. The scanner's own `f.split('/')` segment filter (scanner.ts:132) also assumed posix — so this was a latent cross-platform gap, not new to #140.

## Fix
Add a shared `toPosix()` helper (`src/utils/posix-path.ts`) and apply it at every path-producing boundary so the rest of the codebase never special-cases `\`:

- **`scanner.ts`** — stored cache paths (root cause; fixes segment filtering too)
- **`imports.ts`** — dependency-graph edge targets
- **`validate-path.ts`** — validated relative-path lookups (keeps lookups consistent with stored paths)
- **`search-by-purpose.ts`** — normalizes the user-supplied `pathPrefix` (so `src\cache` works) **and** the stored side at comparison time (so a forward-slash prefix still scopes any pre-existing backslash entries)

`scanWithGit` already returns posix paths, so normalization is a no-op there; `scanWithFs` is the source of backslashes.

## Tests (+6, suite 337 → 343)
- `tests/unit/posix-path.test.ts` — helper unit tests (backslash, posix, mixed, empty)
- `tests/unit/search-by-purpose.test.ts` —
  - backslash-stored path (seeded via `setEntry`, simulating a Windows cache) matches a forward-slash `pathPrefix`
  - a Windows-style `src\db` prefix normalizes to `src/db`

## Gate
typecheck + lint + 343 tests + build all pass.