### PR TITLE
feat(indexer): compact get_project_map output

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,15 +119,15 @@ Returns a structural overview of the project including directory tree, entry poi
     "name": "repo-memory",
     "path": ".",
     "files": [
-      { "name": "server.ts", "purpose": "entry point" }
+      { "name": "server.ts", "purpose": "entry point", "size": 4096 }
     ],
     "children": [
       {
         "name": "cache",
         "path": "src/cache",
         "files": [
-          { "name": "hash.ts", "purpose": "utility" },
-          { "name": "store.ts", "purpose": "data access" }
+          { "name": "hash.ts", "purpose": "utility", "size": 512 },
+          { "name": "store.ts", "purpose": "data access", "size": 2048 }
         ],
         "children": [],
         "fileCount": 5
@@ -148,6 +148,9 @@ Returns a structural overview of the project including directory tree, entry poi
 **Notes:**
 - `depth` limits how deep the directory tree is traversed. Omit for full depth.
 - `entryPoints` lists files whose summarized purpose is `"entry point"`.
+- File entries are kept compact (`name`, `purpose`, `size`). Per-file confidence is available
+  via `get_file_summary`; recency is covered by `get_changed_files`.
+- Zero-byte `.gitkeep` placeholder files are omitted from the tree.
 
 ---
 

--- a/src/indexer/project-map.ts
+++ b/src/indexer/project-map.ts
@@ -12,9 +12,7 @@ export interface DirectoryNode {
   files: Array<{
     name: string;
     purpose: string;
-    confidence: string;
     size: number;
-    lastModified: number;
   }>;
   children: DirectoryNode[];
   fileCount: number;
@@ -31,7 +29,6 @@ interface FileSummaryEntry {
   relativePath: string;
   summary: FileSummary;
   size: number;
-  lastModified: number;
 }
 
 async function getSummaries(
@@ -47,9 +44,9 @@ async function getSummaries(
     if (cached?.summary) {
       try {
         const stats = await stat(absolutePath);
-        entries.push({ relativePath, summary: cached.summary, size: stats.size, lastModified: stats.mtimeMs });
+        entries.push({ relativePath, summary: cached.summary, size: stats.size });
       } catch {
-        entries.push({ relativePath, summary: cached.summary, size: 0, lastModified: 0 });
+        entries.push({ relativePath, summary: cached.summary, size: 0 });
       }
       continue;
     }
@@ -65,7 +62,7 @@ async function getSummaries(
     const hash = hashContents(contents);
     cache.setEntry(relativePath, hash, summary);
     const stats = await stat(absolutePath);
-    entries.push({ relativePath, summary, size: stats.size, lastModified: stats.mtimeMs });
+    entries.push({ relativePath, summary, size: stats.size });
   }
 
   return entries;
@@ -113,17 +110,19 @@ function buildTree(
   }
 
   for (const entry of entries) {
+    const name = basename(entry.relativePath);
+    // Zero-byte .gitkeep placeholders carry no information; omit them from the tree.
+    if (name === '.gitkeep' && entry.size === 0) continue;
+
     const dirPath = dirname(entry.relativePath);
     const depth = dirPath === '.' ? 0 : dirPath.split('/').length;
     const dir = getOrCreateDir(dirPath, depth);
     if (!dir) continue;
 
     dir.files.push({
-      name: basename(entry.relativePath),
+      name,
       purpose: entry.summary.purpose,
-      confidence: entry.summary.confidence,
       size: entry.size,
-      lastModified: entry.lastModified,
     });
   }
 

--- a/tests/unit/project-map.test.ts
+++ b/tests/unit/project-map.test.ts
@@ -96,7 +96,7 @@ describe('buildProjectMap', () => {
     expect(map.tree.fileCount).toBe(9);
   });
 
-  it('should include size, lastModified, and confidence on file entries', async () => {
+  it('should include only name, purpose, and size on file entries', async () => {
     const map = await buildProjectMap(tempDir);
 
     // Collect all file entries from the tree
@@ -112,13 +112,28 @@ describe('buildProjectMap', () => {
     expect(allFiles.length).toBeGreaterThan(0);
 
     for (const file of allFiles) {
-      // size should be a positive number
       expect(file.size).toBeGreaterThan(0);
-      // lastModified should be a valid epoch timestamp (after 2020-01-01)
-      expect(file.lastModified).toBeGreaterThan(1577836800000);
-      // confidence should be one of the known values
-      expect(['high', 'medium', 'low']).toContain(file.confidence);
+      expect(typeof file.name).toBe('string');
+      expect(typeof file.purpose).toBe('string');
+      expect(Object.keys(file).sort()).toEqual(['name', 'purpose', 'size']);
     }
+  });
+
+  it('should omit zero-byte .gitkeep files from the tree', async () => {
+    mkdirSync(join(tempDir, 'src', 'empty'), { recursive: true });
+    writeFileSync(join(tempDir, 'src', 'empty', '.gitkeep'), '');
+
+    const map = await buildProjectMap(tempDir);
+
+    function collectNames(node: typeof map.tree): string[] {
+      let names = node.files.map((f) => f.name);
+      for (const child of node.children) {
+        names = names.concat(collectNames(child));
+      }
+      return names;
+    }
+
+    expect(collectNames(map.tree)).not.toContain('.gitkeep');
   });
 
   it('should reuse cached summaries on repeated calls', async () => {


### PR DESCRIPTION
## Summary
- Drop `lastModified` (ms floats) and `confidence` from per-file entries in the project map — confidence lives in `get_file_summary`, recency in `get_changed_files`
- Omit zero-byte `.gitkeep` placeholder files from the tree
- Keep `name`, `purpose`, `size`

Measured on this repo (150 indexed files): map JSON shrinks ~45% (~10k → ~5.5k tokens per call).

## Testing
- typecheck, lint, full test suite (344 tests), and build all pass
- New tests: entries contain exactly name/purpose/size; .gitkeep omitted from tree