### PR TITLE
feat(indexer): AST summarizer spike (TS/JS via tree-sitter wasm)

### DIFF
--- a/docs/planning/ast-summarizer-spike.md
+++ b/docs/planning/ast-summarizer-spike.md
@@ -1,0 +1,160 @@
+# Spike: AST-based file summarization (TS/JS via tree-sitter WASM)
+
+**Status:** complete — recommendation at the bottom.
+**Scope:** TypeScript/JavaScript (`.ts/.tsx/.js/.jsx/.mjs/.cjs`). Python/Go/Rust stay on the regex summarizer.
+**Code:** `src/indexer/ast-summarizer.ts` (engine), `src/indexer/summarize.ts` (config dispatch + cache generation), `summarizer: 'regex' | 'ast'` in `.repo-memory.json` (default `'regex'`).
+
+## Hypothesis
+
+AST-derived summaries give (a) accurate exports/declarations and (b) a semantic
+one-line `purpose`, making `search_by_purpose` genuinely useful. The regex
+summarizer classifies almost every implementation file as `purpose: "source"`,
+which carries no search signal.
+
+## Dependency chosen
+
+| Option | Verdict |
+| --- | --- |
+| `web-tree-sitter` + `tree-sitter-wasms` | **Chosen.** Pure WASM, no native compilation, prebuilt grammars for 36 languages including typescript/tsx/javascript (and python/go/rust for later). |
+| `@vscode/tree-sitter-wasm` | Viable alternative (21 MB unpacked, bundles its own runtime + 16 grammars). Less standard API surface; grammars updated on VS Code's schedule. |
+| `tree-sitter-typescript` (native) | Rejected: `node-gyp-build` dependency — exactly the prebuild/Node-version pain we already have with better-sqlite3. |
+| TypeScript compiler API | Not needed — the WASM route works. Would add `typescript` (~23 MB unpacked) as a runtime dep and covers only TS/JS, no path to other languages. |
+
+Added to `dependencies`:
+
+- `web-tree-sitter@^0.25.10` — 1.7 MB tarball / 5.8 MB unpacked
+- `tree-sitter-wasms@^0.1.13` — 4.5 MB tarball / 51.8 MB unpacked (all 36 grammars)
+
+**Version pinning caveat:** `web-tree-sitter@0.26.x` rejects the grammar
+binaries in `tree-sitter-wasms@0.1.13` (Emscripten dylink-metadata mismatch at
+`Language.load`). The caret range `^0.25.10` resolves to `<0.26.0`, which is
+the compatible pairing — do not bump web-tree-sitter without re-testing grammar
+loading.
+
+### Package size impact
+
+- Download (npx cold install): **+6.2 MB** compressed.
+- `node_modules`: **+55 MB** unpacked. Of `tree-sitter-wasms`' 49 MB, we use
+  three files totaling **5.4 MB** (`tree-sitter-typescript.wasm` 2.3 MB,
+  `tree-sitter-tsx.wasm` 2.4 MB, `tree-sitter-javascript.wasm` 0.6 MB).
+- For full adoption, copy the needed `.wasm` files into `dist/` at build time
+  and move `tree-sitter-wasms` to `devDependencies`: runtime cost drops to
+  ~11 MB unpacked (~3.5 MB compressed) and grammar availability stops depending
+  on install-time resolution. The spike resolves them from `node_modules` via
+  `createRequire` for simplicity.
+
+## Measurements
+
+Benchmark: `npx tsx tests/benchmarks/ast-vs-regex.ts` — 35 files under `src/`
+(4,809 lines), median of 5 warm runs per file, Node 26 / Apple Silicon.
+
+### Startup and speed
+
+| Metric | regex | AST |
+| --- | --- | --- |
+| One-time WASM startup (init + grammar load + first parse) | — | **12–14 ms** |
+| Avg per file | 0.017 ms | **0.52 ms** (~30x regex) |
+| Total, all 35 files | 0.6 ms | 18.2 ms |
+| Slowest file (`src/indexer/imports.ts`, 477 lines) | — | 1.9 ms |
+
+Both are noise next to file I/O and SQLite writes; a full re-index of this repo
+costs ~18 ms extra in AST mode. Parse failures requiring regex fallback: **0/35**.
+
+### Summary size
+
+JSON chars per summary: 360 (regex) → 406 (AST), **+12.6%**. The growth is the
+richer `purpose` line — exports/imports/declarations are byte-identical shapes.
+
+### Accuracy spot-check
+
+- **Files where AST found exports the regex missed: 15/35** (43%).
+- Files where regex found exports the AST missed: 0.
+- Files where `topLevelDeclarations` differ: 0.
+
+All 15 misses are the same regex bug: `EXPORT_PATTERN` has no `async`
+alternative, so every `export async function` in the codebase is invisible to
+the regex summarizer (and therefore to `search_by_purpose`'s exports matching).
+Three concrete examples:
+
+1. `src/cache/gc.ts` — AST-only export: `runGC`
+2. `src/indexer/scanner.ts` — AST-only export: `scanProject`
+3. `src/tools/get-file-summary.ts` — AST-only export: `getFileSummary`
+
+The AST is also immune to false positives the regex is structurally prone to —
+`export` statements inside template literals or comments (covered by a unit
+test; this repo's src happens not to trigger it).
+
+> Side finding worth fixing regardless of this spike's outcome: adding
+> `(?:async\s+)?` to `EXPORT_PATTERN` in `summarizer.ts` repairs the regex
+> summarizer's biggest accuracy hole in one line.
+
+### Purpose quality — before/after
+
+| File | regex | AST |
+| --- | --- | --- |
+| `src/cache/store.ts` | `source` | `class CacheStore (9 methods)` |
+| `src/cache/hash.ts` | `source` | `functions: hashFile, hashContents — Compute a SHA-256 hex digest of a file at the given absolute path.` |
+| `src/utils/validate-path.ts` | `source` | `function validatePath — Validates that a file path is safe and resolves within the project root.` |
+
+Other categories keep their searchable prefix while gaining detail, e.g.
+`src/server.ts`: `entry point` → `entry point: functions: registerTools, main`;
+`src/types.ts`: `types` → `types: CacheEntry, FileSummary, ImportRef`.
+For this repo, 30 of 35 files go from the bare word `source` to a line naming
+the dominant symbols — that is the entire search corpus `search_by_purpose`
+operates on.
+
+## Cache invalidation on summarizer change (implemented)
+
+Switching summarizers must regenerate stale summaries. Implemented via a
+generation tag rather than a hash salt (salting content hashes would have
+broken `get_changed_files`, which compares stored hashes against fresh file
+hashes):
+
+- Migration 6 adds a `meta` key/value table.
+- `ensureSummaryGeneration(projectRoot)` (called before any cache read in
+  `get_file_summary`, `force_reread`, and project-map indexing) compares the
+  stored `summarizer_generation` tag (`<mode>:<generation>`, e.g. `ast:1`)
+  against the configured mode. On mismatch it nulls all `summary_json` columns
+  — hashes and timestamps survive, so change detection is unaffected and
+  summaries regenerate lazily — then records the new tag. Pre-existing
+  databases without a tag are treated as `regex:1` (what produced them) and are
+  not wiped.
+- `SUMMARIZER_GENERATION` in `summarize.ts` should be bumped whenever summary
+  output changes materially within a mode.
+
+## Recommendation: GO
+
+Adopt the AST summarizer for TS/JS. The accuracy delta is not marginal — 43% of
+this repo's files have wrong exports under the regex engine, and the purpose
+line goes from contentless (`source`) to a usable semantic index for the cost
+of ~0.5 ms/file and a one-time ~13 ms startup. Failure handling is total: any
+parse error or WASM load failure falls back to the regex engine, so AST mode
+can never do worse than today.
+
+Suggested rollout:
+
+1. Ship behind `summarizer: 'ast'` (this spike) — opt-in, default `regex`.
+2. Vendor the three grammar `.wasm` files into `dist/` at build time; demote
+   `tree-sitter-wasms` to a dev dependency (cuts the runtime footprint from
+   ~55 MB to ~11 MB unpacked).
+3. Flip the default to `ast` for TS/JS after a release of soak time; the
+   generation tag handles the cache migration automatically.
+4. Extend to Python/Go/Rust: grammars are already in `tree-sitter-wasms`; each
+   language needs an extraction visitor (~100 lines) and purpose templates.
+   Regex stays as the universal fallback.
+5. Fix the `async` export bug in the regex summarizer independently — it
+   benefits the fallback path and non-TS languages' sibling patterns.
+
+Caveats:
+
+- `web-tree-sitter` must stay on 0.25.x until `tree-sitter-wasms` publishes
+  grammars built for the 0.26 runtime (see pinning caveat above).
+- The AST engine summarizes only top-level statements; symbols produced by
+  metaprogramming (e.g. `Object.assign(exports, ...)`) are invisible to both
+  engines.
+- `purpose` is no longer a closed vocabulary in AST mode. The one consumer that
+  matched exact strings (`findEntryPoints` in `project-map.ts`) now matches the
+  `entry point` prefix; anything else that grows assumptions about purpose
+  values should do the same.
+- web-tree-sitter allocates WASM-heap memory per tree; the summarizer calls
+  `tree.delete()` after each file to keep long-lived MCP server processes flat.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "better-sqlite3": "^12.10.0",
+        "tree-sitter-wasms": "^0.1.13",
+        "web-tree-sitter": "^0.25.10",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -3799,6 +3801,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -4055,6 +4066,20 @@
           "optional": true
         },
         "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "^12.10.0",
+    "tree-sitter-wasms": "^0.1.13",
+    "web-tree-sitter": "^0.25.10",
     "zod": "^4.3.6"
   }
 }

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -84,6 +84,34 @@ export class CacheStore {
     runBatch();
   }
 
+  /** Read a value from the meta key/value table. */
+  getMeta(key: string): string | null {
+    const db = getDatabase(this.projectRoot);
+    const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as
+      | { value: string }
+      | undefined;
+    return row?.value ?? null;
+  }
+
+  /** Write a value to the meta key/value table. */
+  setMeta(key: string, value: string): void {
+    const db = getDatabase(this.projectRoot);
+    db.prepare(
+      `INSERT INTO meta (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    ).run(key, value);
+  }
+
+  /**
+   * Drop all cached summaries while keeping hashes and timestamps. Used when
+   * the summarizer implementation changes: change detection stays intact and
+   * summaries regenerate lazily on next access.
+   */
+  clearAllSummaries(): void {
+    const db = getDatabase(this.projectRoot);
+    db.prepare('UPDATE files SET summary_json = NULL').run();
+  }
+
   getStaleEntries(maxAge: number): CacheEntry[] {
     const db = getDatabase(this.projectRoot);
     const cutoff = Date.now() - maxAge;

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,8 @@ export interface ToolGroupConfig {
 export interface RepoMemoryConfig {
   ignore?: string[];
   maxFiles?: number;
+  /** Summary engine for TS/JS files: 'regex' (default) or 'ast' (tree-sitter). */
+  summarizer?: 'regex' | 'ast';
   gc?: {
     cacheMaxAgeDays?: number;
     taskMaxAgeDays?: number;
@@ -74,6 +76,14 @@ function validateConfig(raw: unknown): RepoMemoryConfig {
       config.maxFiles = obj.maxFiles;
     } else {
       warn('"maxFiles" must be a positive number; ignoring it');
+    }
+  }
+
+  if ('summarizer' in obj) {
+    if (obj.summarizer === 'regex' || obj.summarizer === 'ast') {
+      config.summarizer = obj.summarizer;
+    } else {
+      warn('"summarizer" must be "regex" or "ast"; ignoring it');
     }
   }
 

--- a/src/indexer/ast-summarizer.ts
+++ b/src/indexer/ast-summarizer.ts
@@ -1,0 +1,435 @@
+import { createRequire } from 'node:module';
+import { Parser, Language, type Node } from 'web-tree-sitter';
+import { summarizeFile } from './summarizer.js';
+import type { FileSummary } from '../types.js';
+
+/**
+ * AST-based summarizer for TypeScript/JavaScript using web-tree-sitter (WASM).
+ *
+ * Same contract as `summarizeFile` in summarizer.ts, but exports/imports/
+ * declarations come from a real parse tree instead of line-anchored regexes,
+ * and `purpose` is a template-generated semantic one-liner derived from the
+ * dominant symbols (class/function names, method counts, JSDoc first lines).
+ *
+ * Unsupported extensions and files that fail to parse fall back to the regex
+ * summarizer, so this is a strict superset in coverage.
+ */
+
+type GrammarName = 'typescript' | 'tsx' | 'javascript';
+
+const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
+  '.ts': 'typescript',
+  '.mts': 'typescript',
+  '.cts': 'typescript',
+  '.d.ts': 'typescript',
+  '.tsx': 'tsx',
+  '.js': 'javascript',
+  '.jsx': 'javascript',
+  '.mjs': 'javascript',
+  '.cjs': 'javascript',
+};
+
+const MAX_PURPOSE_LENGTH = 160;
+
+const require = createRequire(import.meta.url);
+
+let initPromise: Promise<void> | null = null;
+let runtimeBroken = false;
+const languageCache = new Map<GrammarName, Promise<Language>>();
+const parserCache = new Map<GrammarName, Parser>();
+
+function getExtension(filePath: string): string {
+  if (filePath.endsWith('.d.ts')) return '.d.ts';
+  const dot = filePath.lastIndexOf('.');
+  return dot === -1 ? '' : filePath.slice(dot);
+}
+
+function getBasename(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const slash = normalized.lastIndexOf('/');
+  return slash === -1 ? normalized : normalized.slice(slash + 1);
+}
+
+async function getParser(grammar: GrammarName): Promise<Parser> {
+  if (!initPromise) {
+    initPromise = Parser.init();
+  }
+  await initPromise;
+
+  const cached = parserCache.get(grammar);
+  if (cached) return cached;
+
+  let languagePromise = languageCache.get(grammar);
+  if (!languagePromise) {
+    const wasmPath = require.resolve(`tree-sitter-wasms/out/tree-sitter-${grammar}.wasm`);
+    languagePromise = Language.load(wasmPath);
+    languageCache.set(grammar, languagePromise);
+  }
+
+  const language = await languagePromise;
+  const parser = new Parser();
+  parser.setLanguage(language);
+  parserCache.set(grammar, parser);
+  return parser;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+interface ClassInfo {
+  name: string;
+  methodCount: number;
+  doc: string | null;
+  exported: boolean;
+}
+
+interface FunctionInfo {
+  name: string;
+  doc: string | null;
+  exported: boolean;
+}
+
+interface ExtractionResult {
+  exports: string[];
+  imports: string[];
+  topLevelDeclarations: string[];
+  classes: ClassInfo[];
+  functions: FunctionInfo[];
+  typeNames: string[];
+  constNames: string[];
+  fileDoc: string | null;
+}
+
+function stripQuotes(text: string): string {
+  return text.replace(/^['"`]|['"`]$/g, '');
+}
+
+/** First meaningful line of a comment, with `/**`, `*` and `//` markers removed. */
+function commentFirstLine(text: string): string | null {
+  const cleaned = text
+    .replace(/^\/\*+/, '')
+    .replace(/\*+\/$/, '');
+  for (const rawLine of cleaned.split('\n')) {
+    const line = rawLine.replace(/^\s*(?:\*|\/\/)?\s*/, '').trim();
+    if (line.length > 0 && !line.startsWith('@') && !line.startsWith('eslint')) {
+      // Keep only the first sentence so multi-sentence doc lines stay short.
+      const sentenceEnd = line.indexOf('. ');
+      return sentenceEnd === -1 ? line : line.slice(0, sentenceEnd + 1);
+    }
+  }
+  return null;
+}
+
+/** JSDoc-style block comment immediately preceding `node` at the same level. */
+function precedingDoc(node: Node): string | null {
+  const prev = node.previousNamedSibling;
+  if (prev && prev.type === 'comment' && prev.text.startsWith('/**')) {
+    return commentFirstLine(prev.text);
+  }
+  return null;
+}
+
+function countMethods(classNode: Node): number {
+  const body = classNode.childForFieldName('body');
+  if (!body) return 0;
+  let count = 0;
+  for (const child of body.namedChildren) {
+    if (!child) continue;
+    if (child.type === 'method_definition' || child.type === 'abstract_method_signature') {
+      const name = child.childForFieldName('name')?.text;
+      if (name !== 'constructor') count++;
+    }
+  }
+  return count;
+}
+
+function hasDefaultKeyword(exportStatement: Node): boolean {
+  return exportStatement.children.some((c) => c !== null && c.type === 'default');
+}
+
+/** Handles one top-level declaration node; doc comes from the outermost statement. */
+function collectDeclaration(node: Node, exported: boolean, doc: string | null, out: ExtractionResult): void {
+  switch (node.type) {
+    case 'lexical_declaration':
+    case 'variable_declaration': {
+      const kindNode = node.children.find(
+        (c) => c !== null && (c.type === 'const' || c.type === 'let' || c.type === 'var'),
+      );
+      const kind = kindNode?.text ?? 'const';
+      for (const declarator of node.namedChildren) {
+        if (!declarator || declarator.type !== 'variable_declarator') continue;
+        const nameNode = declarator.childForFieldName('name');
+        if (!nameNode || nameNode.type !== 'identifier') continue;
+        const name = nameNode.text;
+        out.topLevelDeclarations.push(`${kind} ${name}`);
+        if (kind === 'const') out.constNames.push(name);
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'function_declaration':
+    case 'generator_function_declaration': {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        out.topLevelDeclarations.push(`function ${name}`);
+        out.functions.push({ name, doc, exported });
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'class_declaration':
+    case 'abstract_class_declaration': {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        out.topLevelDeclarations.push(`class ${name}`);
+        out.classes.push({ name, methodCount: countMethods(node), doc, exported });
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'interface_declaration': {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        out.topLevelDeclarations.push(`interface ${name}`);
+        out.typeNames.push(name);
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'type_alias_declaration': {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        out.topLevelDeclarations.push(`type ${name}`);
+        out.typeNames.push(name);
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'enum_declaration': {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        out.topLevelDeclarations.push(`enum ${name}`);
+        out.typeNames.push(name);
+        if (exported) out.exports.push(name);
+      }
+      break;
+    }
+    case 'ambient_declaration': {
+      // `declare const x: number;` — recurse into the inner declaration.
+      for (const inner of node.namedChildren) {
+        if (inner) collectDeclaration(inner, exported, doc, out);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function collectExportStatement(node: Node, out: ExtractionResult): void {
+  const doc = precedingDoc(node);
+  const source = node.childForFieldName('source');
+  if (source) {
+    // Re-export: `export { a, b as c } from './x.js'` / `export * from './x.js'`.
+    out.imports.push(stripQuotes(source.text));
+  }
+
+  const declaration = node.childForFieldName('declaration');
+  if (declaration) {
+    collectDeclaration(declaration, true, doc, out);
+    if (hasDefaultKeyword(node)) out.exports.push('default');
+    return;
+  }
+
+  const value = node.childForFieldName('value');
+  if (value) {
+    // `export default <expression>;`
+    out.exports.push('default');
+    return;
+  }
+
+  for (const child of node.namedChildren) {
+    if (!child) continue;
+    if (child.type === 'export_clause') {
+      for (const spec of child.namedChildren) {
+        if (!spec || spec.type !== 'export_specifier') continue;
+        const alias = spec.childForFieldName('alias')?.text;
+        const name = spec.childForFieldName('name')?.text;
+        const visible = alias ?? name;
+        if (visible) out.exports.push(visible);
+      }
+    } else if (child.type === 'namespace_export') {
+      // `export * as ns from './x.js'`
+      const name = child.namedChildren.find((c) => c !== null)?.text;
+      if (name) out.exports.push(name);
+    }
+  }
+}
+
+function extract(root: Node): ExtractionResult {
+  const out: ExtractionResult = {
+    exports: [],
+    imports: [],
+    topLevelDeclarations: [],
+    classes: [],
+    functions: [],
+    typeNames: [],
+    constNames: [],
+    fileDoc: null,
+  };
+
+  let seenCode = false;
+  for (const child of root.namedChildren) {
+    if (!child) continue;
+    switch (child.type) {
+      case 'comment':
+        if (!seenCode && out.fileDoc === null) {
+          out.fileDoc = commentFirstLine(child.text);
+        }
+        break;
+      case 'import_statement': {
+        seenCode = true;
+        const source = child.childForFieldName('source');
+        if (source) out.imports.push(stripQuotes(source.text));
+        break;
+      }
+      case 'export_statement':
+        seenCode = true;
+        collectExportStatement(child, out);
+        break;
+      default:
+        seenCode = true;
+        collectDeclaration(child, false, precedingDoc(child), out);
+        break;
+    }
+  }
+
+  out.exports = [...new Set(out.exports)];
+  out.imports = [...new Set(out.imports)];
+  out.topLevelDeclarations = [...new Set(out.topLevelDeclarations)];
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Purpose line generation
+// ---------------------------------------------------------------------------
+
+function fileCategory(filePath: string): string | null {
+  const basename = getBasename(filePath);
+  if (filePath.endsWith('.d.ts')) return 'types';
+  if (/\.(?:test|spec)\.[tj]sx?$/.test(basename)) return 'test';
+  if (/\.config\.[tj]sx?$/.test(basename) || /\.config\.mjs$/.test(basename)) return 'config';
+  if (basename === 'types.ts' || basename === 'interfaces.ts') return 'types';
+  if (/^index\.[tj]sx?$/.test(basename)) return 'entry point';
+  return null;
+}
+
+function listNames(names: string[], max: number): string {
+  if (names.length <= max) return names.join(', ');
+  return `${names.slice(0, max).join(', ')} (+${names.length - max} more)`;
+}
+
+function buildPurpose(filePath: string, contents: string, info: ExtractionResult): string {
+  let category = fileCategory(filePath);
+  // Executable entry points: shebang line or a top-level main() function.
+  if (
+    category === null &&
+    (contents.startsWith('#!') || info.functions.some((f) => f.name === 'main'))
+  ) {
+    category = 'entry point';
+  }
+  let detail: string;
+
+  const exportedClasses = info.classes.filter((c) => c.exported);
+  const classes = exportedClasses.length > 0 ? exportedClasses : info.classes;
+  const exportedFns = info.functions.filter((f) => f.exported);
+  const fns = exportedFns.length > 0 ? exportedFns : info.functions;
+
+  if (classes.length > 0) {
+    const primary = [...classes].sort((a, b) => b.methodCount - a.methodCount)[0];
+    const desc = primary.doc ?? info.fileDoc;
+    const head = `class ${primary.name} (${primary.methodCount} method${primary.methodCount === 1 ? '' : 's'})`;
+    const rest = classes.filter((c) => c !== primary).map((c) => c.name);
+    const suffix = rest.length > 0 ? ` +${listNames(rest, 2)}` : '';
+    detail = desc ? `${head}${suffix}: ${desc}` : `${head}${suffix}`;
+  } else if (fns.length > 0) {
+    const desc = fns[0].doc ?? info.fileDoc;
+    const head =
+      fns.length === 1
+        ? `function ${fns[0].name}`
+        : `functions: ${listNames(
+            fns.map((f) => f.name),
+            3,
+          )}`;
+    detail = desc ? `${head} — ${desc}` : head;
+  } else if (info.typeNames.length > 0) {
+    const head = `types: ${listNames(info.typeNames, 4)}`;
+    detail = info.fileDoc ? `${head} — ${info.fileDoc}` : head;
+  } else if (info.constNames.length > 0) {
+    const head = `constants: ${listNames(info.constNames, 4)}`;
+    detail = info.fileDoc ? `${head} — ${info.fileDoc}` : head;
+  } else if (info.fileDoc) {
+    detail = info.fileDoc;
+  } else {
+    detail = 'source';
+  }
+
+  // Avoid "types: types: ..." when the detail already leads with the category.
+  let purpose = category && !detail.startsWith(category) ? `${category}: ${detail}` : detail;
+  if (purpose.length > MAX_PURPOSE_LENGTH) {
+    purpose = `${purpose.slice(0, MAX_PURPOSE_LENGTH - 1)}…`;
+  }
+  return purpose;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Summarize a TS/JS file from its syntax tree. Falls back to the regex
+ * summarizer for unsupported extensions, empty files, parse errors, or when
+ * the WASM runtime cannot be loaded.
+ */
+export async function summarizeFileAst(filePath: string, contents: string): Promise<FileSummary> {
+  const grammar = EXT_TO_GRAMMAR[getExtension(filePath)];
+  if (!grammar || runtimeBroken || contents.trim() === '') {
+    return summarizeFile(filePath, contents);
+  }
+
+  let parser: Parser;
+  try {
+    parser = await getParser(grammar);
+  } catch {
+    // WASM runtime or grammar failed to load; don't retry per file.
+    runtimeBroken = true;
+    return summarizeFile(filePath, contents);
+  }
+
+  const tree = parser.parse(contents);
+  if (!tree) return summarizeFile(filePath, contents);
+
+  try {
+    if (tree.rootNode.hasError) {
+      return summarizeFile(filePath, contents);
+    }
+
+    const info = extract(tree.rootNode);
+    return {
+      purpose: buildPurpose(filePath, contents, info),
+      exports: info.exports,
+      imports: info.imports,
+      lineCount: contents.split('\n').length,
+      topLevelDeclarations: info.topLevelDeclarations,
+      confidence: 'high',
+    };
+  } finally {
+    tree.delete();
+  }
+}
+
+/** True when the AST summarizer handles this file natively (vs regex fallback). */
+export function isAstSupported(filePath: string): boolean {
+  return getExtension(filePath) in EXT_TO_GRAMMAR;
+}

--- a/src/indexer/project-map.ts
+++ b/src/indexer/project-map.ts
@@ -1,7 +1,7 @@
 import { readFile, stat } from 'node:fs/promises';
 import { join, dirname, basename, extname } from 'node:path';
 import { scanProject } from './scanner.js';
-import { summarizeFile } from './summarizer.js';
+import { summarizeForProject, ensureSummaryGeneration } from './summarize.js';
 import { CacheStore } from '../cache/store.js';
 import { hashContents } from '../cache/hash.js';
 import type { FileSummary } from '../types.js';
@@ -35,6 +35,7 @@ async function getSummaries(
   projectRoot: string,
   files: string[],
 ): Promise<FileSummaryEntry[]> {
+  ensureSummaryGeneration(projectRoot);
   const cache = new CacheStore(projectRoot);
   const entries: FileSummaryEntry[] = [];
 
@@ -58,7 +59,7 @@ async function getSummaries(
       continue;
     }
 
-    const summary = summarizeFile(relativePath, contents);
+    const summary = await summarizeForProject(projectRoot, relativePath, contents);
     const hash = hashContents(contents);
     cache.setEntry(relativePath, hash, summary);
     const stats = await stat(absolutePath);
@@ -160,8 +161,9 @@ function computeLanguageBreakdown(files: string[]): Record<string, number> {
 }
 
 function findEntryPoints(entries: FileSummaryEntry[]): string[] {
+  // AST-generated purposes are richer ("entry point: ..."), so match by prefix.
   return entries
-    .filter((e) => e.summary.purpose === 'entry point')
+    .filter((e) => e.summary.purpose.startsWith('entry point'))
     .map((e) => e.relativePath)
     .sort();
 }

--- a/src/indexer/smart-summarizer.ts
+++ b/src/indexer/smart-summarizer.ts
@@ -1,16 +1,16 @@
 import type { FileSummary } from '../types.js';
 import { analyzeDiff } from './diff-analyzer.js';
-import { summarizeFile } from './summarizer.js';
+import { summarizeForProject } from './summarize.js';
 
-export function smartSummarize(
+export async function smartSummarize(
   filePath: string,
   contents: string,
   oldSummary: FileSummary | null,
   projectRoot: string,
-): { summary: FileSummary; source: 'full' | 'diff-partial' } {
+): Promise<{ summary: FileSummary; source: 'full' | 'diff-partial' }> {
   if (!oldSummary) {
     return {
-      summary: summarizeFile(filePath, contents),
+      summary: await summarizeForProject(projectRoot, filePath, contents),
       source: 'full',
     };
   }
@@ -19,7 +19,7 @@ export function smartSummarize(
 
   if (analysis.structural) {
     return {
-      summary: summarizeFile(filePath, contents),
+      summary: await summarizeForProject(projectRoot, filePath, contents),
       source: 'full',
     };
   }

--- a/src/indexer/summarize.ts
+++ b/src/indexer/summarize.ts
@@ -1,0 +1,68 @@
+import { loadConfig } from '../config.js';
+import { CacheStore } from '../cache/store.js';
+import { summarizeFile } from './summarizer.js';
+import { summarizeFileAst } from './ast-summarizer.js';
+import type { FileSummary } from '../types.js';
+
+/**
+ * Config-aware summarizer dispatch. Call sites that generate summaries go
+ * through here so the `summarizer` setting in .repo-memory.json takes effect.
+ */
+
+export type SummarizerMode = 'regex' | 'ast';
+
+/**
+ * Bump when summary output changes in a way that should invalidate previously
+ * cached summaries (combined with the mode into the generation tag).
+ */
+const SUMMARIZER_GENERATION = 1;
+
+const META_KEY = 'summarizer_generation';
+
+const generationChecked = new Map<string, string>();
+
+export function getSummarizerMode(projectRoot: string): SummarizerMode {
+  return loadConfig(projectRoot).summarizer ?? 'regex';
+}
+
+/** Generate a summary using the summarizer configured for this project. */
+export async function summarizeForProject(
+  projectRoot: string,
+  filePath: string,
+  contents: string,
+): Promise<FileSummary> {
+  if (getSummarizerMode(projectRoot) === 'ast') {
+    return summarizeFileAst(filePath, contents);
+  }
+  return summarizeFile(filePath, contents);
+}
+
+/**
+ * Ensure cached summaries were produced by the currently configured
+ * summarizer. When the mode (or generation) changes, all stored summaries are
+ * dropped — hashes stay, so change detection is unaffected and summaries
+ * regenerate lazily — and the new generation tag is recorded.
+ *
+ * Must run before any cache lookup that can return a stored summary.
+ */
+export function ensureSummaryGeneration(projectRoot: string): void {
+  const tag = `${getSummarizerMode(projectRoot)}:${SUMMARIZER_GENERATION}`;
+  if (generationChecked.get(projectRoot) === tag) return;
+
+  const store = new CacheStore(projectRoot);
+  const stored = store.getMeta(META_KEY);
+  if (stored !== tag) {
+    // Pre-marker databases were summarized with regex generation 1; only wipe
+    // when the effective summarizer actually differs from what produced them.
+    if (stored !== null || tag !== 'regex:1') {
+      store.clearAllSummaries();
+    }
+    store.setMeta(META_KEY, tag);
+  }
+  generationChecked.set(projectRoot, tag);
+}
+
+/** Test hook: forget which projects already had their generation verified. */
+export function clearSummaryGenerationCache(): void {
+  generationChecked.clear();
+}

--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -93,6 +93,17 @@ const MIGRATIONS: Array<{ version: number; up: (db: Database.Database) => void }
       `);
     },
   },
+  {
+    version: 6,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database.Database): void {

--- a/src/tools/force-reread.ts
+++ b/src/tools/force-reread.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
-import { summarizeFile } from '../indexer/summarizer.js';
+import { summarizeForProject, ensureSummaryGeneration } from '../indexer/summarize.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
 import { estimateTokens } from '../telemetry/tokens.js';
 import type { FileSummary } from '../types.js';
@@ -13,10 +13,11 @@ export async function forceReread(
   relativePath: string,
 ): Promise<{ path: string; hash: string; summary: FileSummary; reread: true; reason: string }> {
   relativePath = validatePath(projectRoot, relativePath);
+  ensureSummaryGeneration(projectRoot);
   const absolutePath = join(projectRoot, relativePath);
   const contents = await readFile(absolutePath, 'utf-8');
   const hash = hashContents(contents);
-  const summary = summarizeFile(relativePath, contents);
+  const summary = await summarizeForProject(projectRoot, relativePath, contents);
 
   const store = new CacheStore(projectRoot);
   store.setEntry(relativePath, hash, summary);

--- a/src/tools/get-file-summary.ts
+++ b/src/tools/get-file-summary.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
-import { summarizeFile } from '../indexer/summarizer.js';
+import { summarizeForProject, ensureSummaryGeneration } from '../indexer/summarize.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
 import { estimateTokensSaved } from '../telemetry/tokens.js';
 import type { FileSummary } from '../types.js';
@@ -23,6 +23,7 @@ export async function getFileSummary(
   relativePath: string,
 ): Promise<FileSummaryResult> {
   relativePath = validatePath(projectRoot, relativePath);
+  ensureSummaryGeneration(projectRoot);
   const store = new CacheStore(projectRoot);
   const absolutePath = join(projectRoot, relativePath);
 
@@ -54,7 +55,7 @@ export async function getFileSummary(
   }
 
   // Generate fresh summary
-  const summary = summarizeFile(relativePath, contents);
+  const summary = await summarizeForProject(projectRoot, relativePath, contents);
   store.setEntry(relativePath, currentHash, summary);
 
   let reason: string;

--- a/tests/benchmarks/ast-vs-regex.ts
+++ b/tests/benchmarks/ast-vs-regex.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+/**
+ * Standalone benchmark: AST summarizer vs regex summarizer on this repo's
+ * own src/**\/*.ts files.
+ * Run with: npx tsx tests/benchmarks/ast-vs-regex.ts
+ *
+ * Measures:
+ *  - one-time WASM startup cost (Parser.init + grammar load)
+ *  - per-file summarize time for both engines (warm)
+ *  - summary size (JSON chars) for both engines
+ *  - accuracy: files where exports/declarations differ between engines
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+import { summarizeFileAst } from '../../src/indexer/ast-summarizer.js';
+import type { FileSummary } from '../../src/types.js';
+
+const WARM_RUNS = 5;
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectTsFiles(full));
+    } else if (entry.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function setDiff(a: string[], b: string[]): string[] {
+  const bSet = new Set(b);
+  return a.filter((x) => !bSet.has(x));
+}
+
+interface FileResult {
+  path: string;
+  lineCount: number;
+  regexMs: number;
+  astMs: number;
+  regexChars: number;
+  astChars: number;
+  regex: FileSummary;
+  ast: FileSummary;
+  exportsAstOnly: string[];
+  exportsRegexOnly: string[];
+  declsAstOnly: string[];
+  declsRegexOnly: string[];
+}
+
+async function main(): Promise<void> {
+  const root = process.cwd();
+  const files = collectTsFiles(join(root, 'src'));
+  console.log(`AST vs regex summarizer benchmark — ${files.length} files under src/\n`);
+
+  // Cold start: first AST call pays Parser.init + Language.load.
+  const coldStartBegin = performance.now();
+  await summarizeFileAst('warmup.ts', 'export const warmup = 1;\n');
+  const coldStartMs = performance.now() - coldStartBegin;
+
+  const results: FileResult[] = [];
+
+  for (const absolutePath of files) {
+    const relPath = relative(root, absolutePath);
+    const contents = readFileSync(absolutePath, 'utf-8');
+
+    const regexTimes: number[] = [];
+    const astTimes: number[] = [];
+    let regex!: FileSummary;
+    let ast!: FileSummary;
+
+    for (let i = 0; i < WARM_RUNS; i++) {
+      const r0 = performance.now();
+      regex = summarizeFile(relPath, contents);
+      regexTimes.push(performance.now() - r0);
+
+      const a0 = performance.now();
+      ast = await summarizeFileAst(relPath, contents);
+      astTimes.push(performance.now() - a0);
+    }
+
+    results.push({
+      path: relPath,
+      lineCount: regex.lineCount,
+      regexMs: median(regexTimes),
+      astMs: median(astTimes),
+      regexChars: JSON.stringify(regex).length,
+      astChars: JSON.stringify(ast).length,
+      regex,
+      ast,
+      exportsAstOnly: setDiff(ast.exports, regex.exports),
+      exportsRegexOnly: setDiff(regex.exports, ast.exports),
+      declsAstOnly: setDiff(ast.topLevelDeclarations, regex.topLevelDeclarations),
+      declsRegexOnly: setDiff(regex.topLevelDeclarations, ast.topLevelDeclarations),
+    });
+  }
+
+  // --- Speed ---
+  const totalRegexMs = results.reduce((s, r) => s + r.regexMs, 0);
+  const totalAstMs = results.reduce((s, r) => s + r.astMs, 0);
+  const totalLines = results.reduce((s, r) => s + r.lineCount, 0);
+
+  console.log('--- Speed (median of %d warm runs per file) ---', WARM_RUNS);
+  console.log(`WASM cold start (init + grammar load + first parse): ${coldStartMs.toFixed(1)} ms (one-time)`);
+  console.log(`regex: total ${totalRegexMs.toFixed(2)} ms, avg ${(totalRegexMs / results.length).toFixed(3)} ms/file`);
+  console.log(`ast:   total ${totalAstMs.toFixed(2)} ms, avg ${(totalAstMs / results.length).toFixed(3)} ms/file`);
+  console.log(`ratio: ast is ${(totalAstMs / totalRegexMs).toFixed(1)}x regex (${totalLines} total lines)`);
+  const slowest = [...results].sort((a, b) => b.astMs - a.astMs)[0];
+  console.log(`slowest ast file: ${slowest.path} (${slowest.lineCount} lines) ${slowest.astMs.toFixed(2)} ms\n`);
+
+  // --- Size ---
+  const totalRegexChars = results.reduce((s, r) => s + r.regexChars, 0);
+  const totalAstChars = results.reduce((s, r) => s + r.astChars, 0);
+  console.log('--- Summary size (JSON chars) ---');
+  console.log(`regex: total ${totalRegexChars}, avg ${Math.round(totalRegexChars / results.length)}/file`);
+  console.log(`ast:   total ${totalAstChars}, avg ${Math.round(totalAstChars / results.length)}/file`);
+  console.log(`delta: ${(((totalAstChars - totalRegexChars) / totalRegexChars) * 100).toFixed(1)}%\n`);
+
+  // --- Accuracy ---
+  const exportDiffs = results.filter(
+    (r) => r.exportsAstOnly.length > 0 || r.exportsRegexOnly.length > 0,
+  );
+  const declDiffs = results.filter(
+    (r) => r.declsAstOnly.length > 0 || r.declsRegexOnly.length > 0,
+  );
+  console.log('--- Accuracy spot-check ---');
+  console.log(`files where exports differ:      ${exportDiffs.length}/${results.length}`);
+  console.log(`files where declarations differ: ${declDiffs.length}/${results.length}\n`);
+
+  const interesting = [...new Set([...exportDiffs, ...declDiffs])];
+  for (const r of interesting) {
+    console.log(`  ${r.path}`);
+    if (r.exportsAstOnly.length) console.log(`    exports AST-only:   ${r.exportsAstOnly.join(', ')}`);
+    if (r.exportsRegexOnly.length) console.log(`    exports regex-only: ${r.exportsRegexOnly.join(', ')}`);
+    if (r.declsAstOnly.length) console.log(`    decls AST-only:      ${r.declsAstOnly.join(', ')}`);
+    if (r.declsRegexOnly.length) console.log(`    decls regex-only:   ${r.declsRegexOnly.join(', ')}`);
+  }
+
+  // --- Purpose examples ---
+  console.log('\n--- Purpose lines (before → after) ---');
+  for (const r of results) {
+    console.log(`  ${r.path}`);
+    console.log(`    regex: ${r.regex.purpose}`);
+    console.log(`    ast:   ${r.ast.purpose}`);
+  }
+
+  // --- Confidence ---
+  const astLow = results.filter((r) => r.ast.confidence !== 'high');
+  console.log(`\nAST parses with non-high confidence (fell back to regex): ${astLow.length}`);
+  for (const r of astLow) console.log(`  ${r.path} (${r.ast.confidence})`);
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/tests/integration/v3-flow.test.ts
+++ b/tests/integration/v3-flow.test.ts
@@ -198,7 +198,7 @@ describe('V3 end-to-end flow', () => {
       '}',
       '',
     ].join('\n');
-    const smartResult = smartSummarize(
+    const smartResult = await smartSummarize(
       'src/utils/validate.ts',
       validateContents,
       { purpose: 'source', exports: ['validate'], imports: [], lineCount: 4, topLevelDeclarations: ['function validate'], confidence: 'high' as const },

--- a/tests/unit/ast-summarizer.test.ts
+++ b/tests/unit/ast-summarizer.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst', () => {
+  describe('exports', () => {
+    it('extracts named exports of all declaration kinds', async () => {
+      const contents = [
+        'export const X = 1, Y = 2;',
+        'export let mut = 3;',
+        'export function run() {}',
+        'export async function go() {}',
+        'export function* gen() {}',
+        'export class Widget {}',
+        'export abstract class Base {}',
+        'export interface Shape {}',
+        'export type Alias = string;',
+        'export enum Color { Red }',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/all-exports.ts', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining([
+          'X',
+          'Y',
+          'mut',
+          'run',
+          'go',
+          'gen',
+          'Widget',
+          'Base',
+          'Shape',
+          'Alias',
+          'Color',
+        ]),
+      );
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('extracts default exports (expression and named declaration)', async () => {
+      const expr = await summarizeFileAst('src/a.ts', 'const a = 1;\nexport default a;\n');
+      expect(expr.exports).toContain('default');
+
+      const named = await summarizeFileAst(
+        'src/b.ts',
+        'export default function main() { return 1; }\n',
+      );
+      expect(named.exports).toContain('default');
+      expect(named.exports).toContain('main');
+    });
+
+    it('extracts export clauses with aliases', async () => {
+      const contents = 'const a = 1;\nconst b = 2;\nexport { a, b as renamed };\n';
+      const summary = await summarizeFileAst('src/clause.ts', contents);
+      expect(summary.exports).toContain('a');
+      expect(summary.exports).toContain('renamed');
+      expect(summary.exports).not.toContain('b');
+    });
+
+    it('extracts re-exports and records their source as an import', async () => {
+      const contents = [
+        "export { one, two as three } from './nums.js';",
+        "export * from './star.js';",
+        "export * as ns from './ns.js';",
+      ].join('\n');
+      const summary = await summarizeFileAst('src/re.ts', contents);
+      expect(summary.exports).toEqual(expect.arrayContaining(['one', 'three', 'ns']));
+      expect(summary.imports).toEqual(
+        expect.arrayContaining(['./nums.js', './star.js', './ns.js']),
+      );
+    });
+
+    it('does not invent exports from strings or comments (regex weakness)', async () => {
+      const contents = [
+        'const sql = `',
+        'export const FAKE = 1;',
+        '`;',
+        '// export function alsoFake() {}',
+        'export const real = sql;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/tricky.ts', contents);
+      expect(summary.exports).toEqual(['real']);
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts static, namespace, type-only and side-effect imports', async () => {
+      const contents = [
+        "import { join } from 'node:path';",
+        "import Database from 'better-sqlite3';",
+        "import * as fs from 'fs';",
+        "import type { Foo } from './foo.js';",
+        "import './side-effect.js';",
+        'export const x = join;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/imports.ts', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining([
+          'node:path',
+          'better-sqlite3',
+          'fs',
+          './foo.js',
+          './side-effect.js',
+        ]),
+      );
+    });
+  });
+
+  describe('top-level declarations', () => {
+    it('records kind and name for classes, functions and consts', async () => {
+      const contents = [
+        'const limit = 10;',
+        'let counter = 0;',
+        'function helper() {}',
+        'class Engine { start() {} stop() {} }',
+        'interface Options {}',
+        'type Mode = string;',
+        'enum Level { Low }',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/decls.ts', contents);
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining([
+          'const limit',
+          'let counter',
+          'function helper',
+          'class Engine',
+          'interface Options',
+          'type Mode',
+          'enum Level',
+        ]),
+      );
+    });
+
+    it('does not report nested declarations as top-level', async () => {
+      const contents = [
+        'export function outer() {',
+        '  const inner = 1;',
+        '  function nested() {}',
+        '  return inner + nested();',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/nested.ts', contents);
+      expect(summary.topLevelDeclarations).toEqual(['function outer']);
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes a class file with method count and JSDoc first line', async () => {
+      const contents = [
+        '/** SQLite-backed cache entry CRUD. */',
+        'export class CacheStore {',
+        '  constructor() {}',
+        '  getEntry() {}',
+        '  setEntry() {}',
+        '  deleteEntry() {}',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/cache/store.ts', contents);
+      expect(summary.purpose).toBe('class CacheStore (3 methods): SQLite-backed cache entry CRUD.');
+    });
+
+    it('describes a function module using the file header comment', async () => {
+      const contents = [
+        '/**',
+        ' * Compute deterministic hashes for cache keys.',
+        ' */',
+        'export function hashFile() {}',
+        'export function hashContents() {}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/cache/hash.ts', contents);
+      expect(summary.purpose).toContain('functions: hashFile, hashContents');
+      expect(summary.purpose).toContain('Compute deterministic hashes for cache keys.');
+    });
+
+    it('describes a types-only file by its type names', async () => {
+      const contents = [
+        'export interface CacheEntry { path: string }',
+        'export interface FileSummary { purpose: string }',
+        'export type Confidence = "high" | "low";',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/types.ts', contents);
+      expect(summary.purpose).toContain('types');
+      expect(summary.purpose).toContain('CacheEntry');
+    });
+
+    it('keeps the entry point category recognizable', async () => {
+      const summary = await summarizeFileAst('src/index.ts', "export * from './lib.js';\n");
+      expect(summary.purpose.startsWith('entry point')).toBe(true);
+    });
+
+    it('prefixes test files with the test category', async () => {
+      const contents = "import { describe } from 'vitest';\nconst x = 1;\n";
+      const summary = await summarizeFileAst('tests/unit/foo.test.ts', contents);
+      expect(summary.purpose.startsWith('test')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'export class {{{ not valid typescript ((((\nconst = ;\n';
+      const astResult = await summarizeFileAst('src/broken.ts', broken);
+      const regexResult = summarizeFile('src/broken.ts', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates unsupported extensions to the regex summarizer', async () => {
+      const contents = 'def main():\n    pass\n';
+      const astResult = await summarizeFileAst('src/script.py', contents);
+      const regexResult = summarizeFile('src/script.py', contents);
+      expect(astResult).toEqual(regexResult);
+      expect(isAstSupported('src/script.py')).toBe(false);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('src/empty.ts', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+
+  describe('tsx support', () => {
+    it('parses .tsx files with JSX syntax', async () => {
+      const contents = [
+        "import React from 'react';",
+        '',
+        '/** Top navigation bar. */',
+        'export function NavBar({ title }: { title: string }) {',
+        '  return <nav className="bar"><h1>{title}</h1></nav>;',
+        '}',
+        '',
+        'export default NavBar;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/components/NavBar.tsx', contents);
+      expect(summary.confidence).toBe('high');
+      expect(summary.exports).toEqual(expect.arrayContaining(['NavBar', 'default']));
+      expect(summary.imports).toContain('react');
+      expect(summary.topLevelDeclarations).toContain('function NavBar');
+      expect(summary.purpose).toContain('NavBar');
+      expect(summary.purpose).toContain('Top navigation bar.');
+      expect(isAstSupported('src/components/NavBar.tsx')).toBe(true);
+    });
+  });
+
+  it('reports an accurate line count', async () => {
+    const contents = 'const a = 1;\nconst b = 2;\nexport { a, b };\n';
+    const summary = await summarizeFileAst('src/lines.ts', contents);
+    expect(summary.lineCount).toBe(contents.split('\n').length);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -169,6 +169,48 @@ describe('loadConfig', () => {
     expect(config.tools).toEqual({ summaries: true });
   });
 
+  it('loads summarizer mode from config file', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ summarizer: 'ast' }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.summarizer).toBe('ast');
+  });
+
+  it('accepts the explicit regex summarizer mode', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ summarizer: 'regex' }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config.summarizer).toBe('regex');
+  });
+
+  it('defaults to no summarizer mode when not specified', () => {
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ maxFiles: 100 }));
+    const config = loadConfig(tempDir);
+    expect(config.summarizer).toBeUndefined();
+  });
+
+  it('rejects invalid summarizer value and keeps other keys', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ summarizer: 'llm', maxFiles: 50 }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config).toEqual({ maxFiles: 50 });
+  });
+
+  it('rejects non-string summarizer value', () => {
+    writeFileSync(
+      join(tempDir, '.repo-memory.json'),
+      JSON.stringify({ summarizer: true }),
+    );
+    const config = loadConfig(tempDir);
+    expect(config).toEqual({});
+  });
+
   it('warns on stderr when a key is skipped', () => {
     const writes: string[] = [];
     const original = process.stderr.write;

--- a/tests/unit/summarize.test.ts
+++ b/tests/unit/summarize.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  summarizeForProject,
+  getSummarizerMode,
+  ensureSummaryGeneration,
+  clearSummaryGenerationCache,
+} from '../../src/indexer/summarize.js';
+import { clearConfigCache } from '../../src/config.js';
+import { CacheStore } from '../../src/cache/store.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { getFileSummary } from '../../src/tools/get-file-summary.js';
+
+const SAMPLE = [
+  '/** Greets people. */',
+  'export async function greet(name: string): Promise<string> {',
+  '  return `hi ${name}`;',
+  '}',
+  '',
+].join('\n');
+
+describe('summarizeForProject', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'summarize-test-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, 'src', 'greet.ts'), SAMPLE);
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('defaults to the regex summarizer', async () => {
+    expect(getSummarizerMode(tempDir)).toBe('regex');
+    const summary = await summarizeForProject(tempDir, 'src/greet.ts', SAMPLE);
+    expect(summary.purpose).toBe('source');
+  });
+
+  it('uses the AST summarizer when configured', async () => {
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'ast' }));
+    expect(getSummarizerMode(tempDir)).toBe('ast');
+    const summary = await summarizeForProject(tempDir, 'src/greet.ts', SAMPLE);
+    expect(summary.purpose).toBe('function greet — Greets people.');
+    expect(summary.exports).toEqual(['greet']);
+  });
+
+  it('drops cached summaries when the summarizer mode changes', async () => {
+    // Populate the cache under the default regex mode.
+    const first = await getFileSummary(tempDir, 'src/greet.ts');
+    expect(first.fromCache).toBe(false);
+    const second = await getFileSummary(tempDir, 'src/greet.ts');
+    expect(second.fromCache).toBe(true);
+    expect(second.summary.purpose).toBe('source');
+
+    // Switch to the AST summarizer.
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'ast' }));
+    clearConfigCache();
+    clearSummaryGenerationCache();
+
+    const third = await getFileSummary(tempDir, 'src/greet.ts');
+    expect(third.fromCache).toBe(false); // stale regex summary was invalidated
+    expect(third.summary.purpose).toBe('function greet — Greets people.');
+
+    // Hashes were preserved, only summaries were dropped.
+    const store = new CacheStore(tempDir);
+    expect(store.getMeta('summarizer_generation')).toBe('ast:1');
+  });
+
+  it('does not wipe summaries when the mode is unchanged', async () => {
+    await getFileSummary(tempDir, 'src/greet.ts');
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    const result = await getFileSummary(tempDir, 'src/greet.ts');
+    expect(result.fromCache).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Opt-in AST-based summarization for TS/JS behind `summarizer: 'ast'` in .repo-memory.json (default stays 'regex'). Full findings in docs/planning/ast-summarizer-spike.md.

- `web-tree-sitter` (WASM, no native compilation) + `tree-sitter-wasms` grammars; pinned `^0.25.10` — 0.26.x rejects the grammar binaries (documented in the spike doc)
- Semantic purpose lines from the parse tree, e.g. `src/cache/store.ts`: `source` → `class CacheStore (9 methods)`
- Summarizer dispatch + generation-tag cache invalidation (migration 6, `meta` table): switching engines lazily regenerates summaries without touching hashes
- Graceful fallback to the regex engine on parse errors

## Findings
- AST found exports the regex missed in **15/35 src files (43%)** — root cause: `EXPORT_PATTERN` doesn't match `export async function` (fix to follow separately)
- Speed: 0.52 ms/file vs 0.017 ms regex; 12–14 ms one-time WASM startup — noise next to I/O
- Cost: +6.2 MB compressed install (+55 MB node_modules); full adoption should vendor the 3 needed .wasm files into dist/ to cut this to ~3.5 MB

## Testing
- 372 unit tests + integration pass; typecheck/lint/build clean
- New: 18 AST engine tests, dispatcher tests, config validation tests, ast-vs-regex benchmark