### PR TITLE
fix(indexer): match async exported functions in regex summarizer

### DIFF
--- a/src/indexer/summarizer.ts
+++ b/src/indexer/summarizer.ts
@@ -11,7 +11,7 @@ const RUST_EXTENSIONS = new Set(['.rs']);
 const CONFIG_EXTENSIONS = new Set(['.json', '.yaml', '.yml', '.toml']);
 
 const EXPORT_PATTERN =
-  /^export\s+(?:default\s+)?(?:const|let|var|function\s*\*?|class|interface|type|enum|abstract\s+class)\s+(\w+)/gm;
+  /^export\s+(?:default\s+)?(?:async\s+)?(?:const|let|var|function\s*\*?|class|interface|type|enum|abstract\s+class)\s+(\w+)/gm;
 
 const DEFAULT_EXPORT_PATTERN = /^export\s+default\s+/gm;
 

--- a/tests/unit/summarizer.test.ts
+++ b/tests/unit/summarizer.test.ts
@@ -20,6 +20,16 @@ export enum Status { A, B }
     expect(result.exports).toContain('Status');
   });
 
+  it('extracts async function exports', () => {
+    const contents = `
+export async function fetchData() {}
+export default async function run() {}
+`;
+    const result = summarizeFile('src/fetch.ts', contents);
+    expect(result.exports).toContain('fetchData');
+    expect(result.exports).toContain('run');
+  });
+
   it('extracts default exports', () => {
     const contents = `
 export default function main() {}


### PR DESCRIPTION
## Summary
`EXPORT_PATTERN` had no `async` allowance, so every `export async function` was invisible to the regex summarizer — 15 of 35 src files in this repo had missing exports (e.g. `runGC`, `scanProject`, `getFileSummary`). Found by the AST spike benchmark (#146).

One-character-class fix plus a regression test covering `export async function` and `export default async function`.