### PR TITLE
feat(infra): vendor tree-sitter grammars into dist at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Create a `.repo-memory.json` in your project root to customize behavior:
 {
   "ignore": ["dist", "node_modules", "*.generated.ts"],
   "maxFiles": 5000,
+  "summarizer": "ast",
   "gc": {
     "cacheMaxAgeDays": 30,
     "taskMaxAgeDays": 30,
@@ -192,6 +193,8 @@ Create a `.repo-memory.json` in your project root to customize behavior:
   }
 }
 ```
+
+`summarizer` selects the summary engine: `"regex"` (default) or `"ast"`. AST mode parses TypeScript/JavaScript files (`.ts/.tsx/.js/.jsx/.mjs/.cjs`) with tree-sitter, producing accurate exports/declarations and a semantic `purpose` line that names the dominant symbols (e.g. `class CacheStore (9 methods)` instead of `source`) — which is what `search_by_purpose` matches against. TS/JS only for now; other languages, unsupported extensions, and files with parse errors fall back to the regex summarizer automatically. Switching modes regenerates summaries lazily on next access.
 
 The `tools` block toggles tool groups. `navigation` and `summaries` are **on by default** (set `"summaries": false` to drop the summary tools); `tasks` and `telemetry` are **off by default** (set them to `true` to enable).
 
@@ -206,8 +209,8 @@ Config validation is per-key: an invalid value is skipped with a warning on stde
 
 ## Language Support
 
-Summaries are extracted via regex analysis. Supported languages:
-- **TypeScript / JavaScript** — exports, imports, declarations, purpose classification
+Summaries are extracted via regex analysis (or tree-sitter when `"summarizer": "ast"` is set — TS/JS only). Supported languages:
+- **TypeScript / JavaScript** — exports, imports, declarations, purpose classification; optional AST mode for semantic purpose lines
 - **Python** — functions, classes, `__all__`, `from`/`import` statements
 - **Go** — exported names (uppercase), imports, type/func/var/const declarations
 - **Rust** — `pub` items, `use`/`mod` statements, structs/enums/traits/impls

--- a/docs/planning/ast-summarizer-spike.md
+++ b/docs/planning/ast-summarizer-spike.md
@@ -133,10 +133,15 @@ can never do worse than today.
 
 Suggested rollout:
 
-1. Ship behind `summarizer: 'ast'` (this spike) — opt-in, default `regex`.
-2. Vendor the three grammar `.wasm` files into `dist/` at build time; demote
-   `tree-sitter-wasms` to a dev dependency (cuts the runtime footprint from
-   ~55 MB to ~11 MB unpacked).
+1. **Done.** Ship behind `summarizer: 'ast'` (this spike) — opt-in, default
+   `regex`.
+2. **Done.** Vendor the three grammar `.wasm` files into `dist/` at build time
+   (`scripts/copy-grammars.mjs`, wired into `npm run build`); demote
+   `tree-sitter-wasms` to a dev dependency. Grammar resolution prefers the
+   vendored `dist/grammars/` copies and falls back to the `tree-sitter-wasms`
+   devDependency when running from `src/` (dev/vitest). Cuts the runtime
+   footprint from ~55 MB to ~11 MB unpacked; the tarball grows from ~72 kB to
+   ~573 kB compressed (~5.7 MB unpacked).
 3. Flip the default to `ast` for TS/JS after a release of soak time; the
    generation tag handles the cache migration automatically.
 4. Extend to Python/Go/Rust: grammars are already in `tree-sitter-wasms`; each

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,6 +58,7 @@ Returns a cached summary of a file. If the file has not changed since last read,
 **Notes:**
 - `suggestFullRead` is `true` when the summary confidence is `"low"`, indicating the agent should read the full file for accuracy.
 - `cacheAge` is in seconds since last check, or `null` if no prior cache entry exists.
+- Summary quality depends on the `summarizer` setting in `.repo-memory.json`: `"regex"` (default) or `"ast"`. AST mode (TypeScript/JavaScript only for now) yields more accurate exports and a semantic `purpose` line naming the dominant symbols; files that fail to parse fall back to the regex engine automatically. See the README's Configuration section.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "better-sqlite3": "^12.10.0",
-        "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.25.10",
         "zod": "^4.3.6"
       },
@@ -26,6 +25,7 @@
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.1",
+        "tree-sitter-wasms": "^0.1.13",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },
@@ -3805,6 +3805,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
       "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "tree-sitter-wasms": "^0.1.11"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-grammars.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
@@ -51,13 +51,13 @@
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
+    "tree-sitter-wasms": "^0.1.13",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "^12.10.0",
-    "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "^0.25.10",
     "zod": "^4.3.6"
   }

--- a/scripts/copy-grammars.mjs
+++ b/scripts/copy-grammars.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Copies the tree-sitter grammar .wasm files used by the AST summarizer from
+ * the installed `tree-sitter-wasms` package (a devDependency) into
+ * `dist/grammars/`, so the published package carries its own grammars and the
+ * 49 MB grammar bundle never ships to consumers.
+ *
+ * Runs as part of `npm run build`. Fails loudly if a grammar is missing.
+ */
+import { copyFileSync, mkdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const GRAMMARS = [
+  'tree-sitter-typescript.wasm',
+  'tree-sitter-tsx.wasm',
+  'tree-sitter-javascript.wasm',
+];
+
+const require = createRequire(import.meta.url);
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = join(repoRoot, 'dist', 'grammars');
+
+mkdirSync(outDir, { recursive: true });
+
+for (const grammar of GRAMMARS) {
+  let source;
+  try {
+    source = require.resolve(`tree-sitter-wasms/out/${grammar}`);
+  } catch (err) {
+    console.error(
+      `copy-grammars: cannot resolve tree-sitter-wasms/out/${grammar}. ` +
+        'Is the tree-sitter-wasms devDependency installed?',
+    );
+    console.error(String(err));
+    process.exit(1);
+  }
+  const dest = join(outDir, grammar);
+  copyFileSync(source, dest);
+  const { size } = statSync(dest);
+  if (size === 0) {
+    console.error(`copy-grammars: copied ${grammar} is empty (${source})`);
+    process.exit(1);
+  }
+  const mb = (size / 1024 / 1024).toFixed(1);
+  console.log(`copy-grammars: ${grammar} -> dist/grammars/ (${mb} MB)`);
+}

--- a/src/indexer/ast-summarizer.ts
+++ b/src/indexer/ast-summarizer.ts
@@ -1,4 +1,7 @@
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Parser, Language, type Node } from 'web-tree-sitter';
 import { summarizeFile } from './summarizer.js';
 import type { FileSummary } from '../types.js';
@@ -32,6 +35,20 @@ const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
 const MAX_PURPOSE_LENGTH = 160;
 
 const require = createRequire(import.meta.url);
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Locate a grammar's .wasm file. Vendored grammars in `dist/grammars/`
+ * (copied by `scripts/copy-grammars.mjs` at build time) take precedence, so
+ * the published package works without `tree-sitter-wasms` installed. In dev
+ * and under vitest the code runs from `src/`, where no vendored copy exists,
+ * so we fall back to resolving the `tree-sitter-wasms` devDependency.
+ */
+function resolveGrammarWasm(grammar: GrammarName): string {
+  const vendored = join(moduleDir, '..', 'grammars', `tree-sitter-${grammar}.wasm`);
+  if (existsSync(vendored)) return vendored;
+  return require.resolve(`tree-sitter-wasms/out/tree-sitter-${grammar}.wasm`);
+}
 
 let initPromise: Promise<void> | null = null;
 let runtimeBroken = false;
@@ -61,8 +78,7 @@ async function getParser(grammar: GrammarName): Promise<Parser> {
 
   let languagePromise = languageCache.get(grammar);
   if (!languagePromise) {
-    const wasmPath = require.resolve(`tree-sitter-wasms/out/tree-sitter-${grammar}.wasm`);
-    languagePromise = Language.load(wasmPath);
+    languagePromise = Language.load(resolveGrammarWasm(grammar));
     languageCache.set(grammar, languagePromise);
   }
 


### PR DESCRIPTION
## Summary
- New build step (`scripts/copy-grammars.mjs`) copies the three TS/JS grammar wasms into `dist/grammars/`; `tree-sitter-wasms` moves to devDependencies
- `ast-summarizer` resolves grammars from `dist/grammars/` first, falling back to the dev dep for vitest/src runs
- Documents the `summarizer` config option in README and docs/usage.md (missed in #146)

## Impact
- Tarball: 72 kB → 573 kB compressed (wasms gzip ~10x)
- Consumer node_modules: drops the ~55 MB tree-sitter-wasms install entirely

## Testing
- typecheck/lint/372 tests/build all pass
- Smoke test: with `node_modules/tree-sitter-wasms` removed, dist-based AST summarization still produces AST-quality output (vendored path used, not regex fallback)