### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blamechris/repo-memory.git"
+    "url": "git+https://github.com/blamechris/repo-memory.git"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
Bump version to 0.9.0:
- Opt-in AST summarizer for TS/JS via tree-sitter wasm (#146), grammars vendored into dist (#148)
- fix: regex summarizer now sees `export async function` declarations (#147)
- Compact `get_project_map` output, ~45% smaller (#144)
- Docs: tool reference gaps filled, `summarizer` and `gc` config documented (#143, #148)

Also normalizes `repository.url` per npm pkg fix.