### PR TITLE
feat(indexer): AST summarization for Python, Go, and Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ Config validation is per-key: an invalid value is skipped with a warning on stde
 
 ## Language Support
 
-Summaries are extracted via regex analysis (or tree-sitter when `"summarizer": "ast"` is set — TS/JS only). Supported languages:
-- **TypeScript / JavaScript** — exports, imports, declarations, purpose classification; optional AST mode for semantic purpose lines
-- **Python** — functions, classes, `__all__`, `from`/`import` statements
-- **Go** — exported names (uppercase), imports, type/func/var/const declarations
-- **Rust** — `pub` items, `use`/`mod` statements, structs/enums/traits/impls
+Summaries are extracted via regex analysis, or from tree-sitter parse trees when `"summarizer": "ast"` is set. All four language families below have AST support in `ast` mode, which adds semantic purpose lines derived from doc comments; regex stays as the universal fallback for other languages and unparseable files. Supported languages:
+- **TypeScript / JavaScript** — exports, imports, declarations, purpose classification; AST mode adds JSDoc-derived purpose lines
+- **Python** — functions, classes (incl. `async def`), `__all__`, `from`/`import` statements; AST mode adds docstring-derived purpose lines
+- **Go** — exported names (uppercase), imports, type/func/var/const declarations; AST mode adds doc-comment purpose lines and grouped `var (…)` / `const (…)` support
+- **Rust** — `pub` items, `use`/`mod` statements, structs/enums/traits/impls; AST mode adds `///` doc-comment purpose lines and `pub use` re-exports
 
 Config files (JSON, YAML, TOML) and other file types get basic classification.
 

--- a/docs/planning/ast-summarizer-spike.md
+++ b/docs/planning/ast-summarizer-spike.md
@@ -144,9 +144,11 @@ Suggested rollout:
    ~573 kB compressed (~5.7 MB unpacked).
 3. Flip the default to `ast` for TS/JS after a release of soak time; the
    generation tag handles the cache migration automatically.
-4. Extend to Python/Go/Rust: grammars are already in `tree-sitter-wasms`; each
-   language needs an extraction visitor (~100 lines) and purpose templates.
-   Regex stays as the universal fallback.
+4. **Done.** Extend to Python/Go/Rust: per-language extraction visitors in
+   `ast-summarizer.ts` (exports, imports, declarations, doc-comment purpose
+   lines), with the three grammar wasms vendored alongside the TS/JS ones.
+   Regex stays as the universal fallback; summarizer generation bumped to 2 so
+   ast-mode caches for these languages regenerate lazily.
 5. Fix the `async` export bug in the regex summarizer independently — it
    benefits the fallback path and non-TS languages' sibling patterns.
 

--- a/scripts/copy-grammars.mjs
+++ b/scripts/copy-grammars.mjs
@@ -16,6 +16,9 @@ const GRAMMARS = [
   'tree-sitter-typescript.wasm',
   'tree-sitter-tsx.wasm',
   'tree-sitter-javascript.wasm',
+  'tree-sitter-python.wasm',
+  'tree-sitter-go.wasm',
+  'tree-sitter-rust.wasm',
 ];
 
 const require = createRequire(import.meta.url);

--- a/src/indexer/ast-summarizer.ts
+++ b/src/indexer/ast-summarizer.ts
@@ -7,18 +7,20 @@ import { summarizeFile } from './summarizer.js';
 import type { FileSummary } from '../types.js';
 
 /**
- * AST-based summarizer for TypeScript/JavaScript using web-tree-sitter (WASM).
+ * AST-based summarizer for TypeScript/JavaScript, Python, Go and Rust using
+ * web-tree-sitter (WASM).
  *
  * Same contract as `summarizeFile` in summarizer.ts, but exports/imports/
  * declarations come from a real parse tree instead of line-anchored regexes,
  * and `purpose` is a template-generated semantic one-liner derived from the
- * dominant symbols (class/function names, method counts, JSDoc first lines).
+ * dominant symbols (class/function names, method counts, doc-comment first
+ * lines).
  *
  * Unsupported extensions and files that fail to parse fall back to the regex
  * summarizer, so this is a strict superset in coverage.
  */
 
-type GrammarName = 'typescript' | 'tsx' | 'javascript';
+type GrammarName = 'typescript' | 'tsx' | 'javascript' | 'python' | 'go' | 'rust';
 
 const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
   '.ts': 'typescript',
@@ -30,6 +32,9 @@ const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
   '.jsx': 'javascript',
   '.mjs': 'javascript',
   '.cjs': 'javascript',
+  '.py': 'python',
+  '.go': 'go',
+  '.rs': 'rust',
 };
 
 const MAX_PURPOSE_LENGTH = 160;
@@ -95,6 +100,8 @@ async function getParser(grammar: GrammarName): Promise<Parser> {
 
 interface ClassInfo {
   name: string;
+  /** Display kind for the purpose line: class, struct, enum, type, … */
+  kind: string;
   methodCount: number;
   doc: string | null;
   exported: boolean;
@@ -121,6 +128,32 @@ function stripQuotes(text: string): string {
   return text.replace(/^['"`]|['"`]$/g, '');
 }
 
+function emptyResult(): ExtractionResult {
+  return {
+    exports: [],
+    imports: [],
+    topLevelDeclarations: [],
+    classes: [],
+    functions: [],
+    typeNames: [],
+    constNames: [],
+    fileDoc: null,
+  };
+}
+
+function dedupeResult(out: ExtractionResult): ExtractionResult {
+  out.exports = [...new Set(out.exports)];
+  out.imports = [...new Set(out.imports)];
+  out.topLevelDeclarations = [...new Set(out.topLevelDeclarations)];
+  return out;
+}
+
+/** Keep only the first sentence so multi-sentence doc lines stay short. */
+function firstSentence(line: string): string {
+  const sentenceEnd = line.indexOf('. ');
+  return sentenceEnd === -1 ? line : line.slice(0, sentenceEnd + 1);
+}
+
 /** First meaningful line of a comment, with `/**`, `*` and `//` markers removed. */
 function commentFirstLine(text: string): string | null {
   const cleaned = text
@@ -129,9 +162,7 @@ function commentFirstLine(text: string): string | null {
   for (const rawLine of cleaned.split('\n')) {
     const line = rawLine.replace(/^\s*(?:\*|\/\/)?\s*/, '').trim();
     if (line.length > 0 && !line.startsWith('@') && !line.startsWith('eslint')) {
-      // Keep only the first sentence so multi-sentence doc lines stay short.
-      const sentenceEnd = line.indexOf('. ');
-      return sentenceEnd === -1 ? line : line.slice(0, sentenceEnd + 1);
+      return firstSentence(line);
     }
   }
   return null;
@@ -199,7 +230,7 @@ function collectDeclaration(node: Node, exported: boolean, doc: string | null, o
       const name = node.childForFieldName('name')?.text;
       if (name) {
         out.topLevelDeclarations.push(`class ${name}`);
-        out.classes.push({ name, methodCount: countMethods(node), doc, exported });
+        out.classes.push({ name, kind: 'class', methodCount: countMethods(node), doc, exported });
         if (exported) out.exports.push(name);
       }
       break;
@@ -283,17 +314,8 @@ function collectExportStatement(node: Node, out: ExtractionResult): void {
   }
 }
 
-function extract(root: Node): ExtractionResult {
-  const out: ExtractionResult = {
-    exports: [],
-    imports: [],
-    topLevelDeclarations: [],
-    classes: [],
-    functions: [],
-    typeNames: [],
-    constNames: [],
-    fileDoc: null,
-  };
+function extractTsJs(root: Node): ExtractionResult {
+  const out = emptyResult();
 
   let seenCode = false;
   for (const child of root.namedChildren) {
@@ -321,18 +343,550 @@ function extract(root: Node): ExtractionResult {
     }
   }
 
-  out.exports = [...new Set(out.exports)];
-  out.imports = [...new Set(out.imports)];
-  out.topLevelDeclarations = [...new Set(out.topLevelDeclarations)];
-  return out;
+  return dedupeResult(out);
+}
+
+// ---------------------------------------------------------------------------
+// Python extraction
+// ---------------------------------------------------------------------------
+
+/** First line of a Python string literal's content, quotes and prefixes removed. */
+function pyStringFirstLine(stringNode: Node): string | null {
+  const content = stringNode.namedChildren.find((c) => c?.type === 'string_content');
+  if (!content) return null;
+  for (const rawLine of content.text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length > 0) return firstSentence(line);
+  }
+  return null;
+}
+
+/** Docstring first line of a `block` (or `module`) node, when present. */
+function pyDocstring(body: Node | null): string | null {
+  const first = body?.namedChildren.find((c) => c !== null && c.type !== 'comment');
+  if (first && first.type === 'expression_statement') {
+    const str = first.namedChildren.find((c) => c?.type === 'string');
+    if (str) return pyStringFirstLine(str);
+  }
+  return null;
+}
+
+function countPyMethods(classNode: Node): number {
+  const body = classNode.childForFieldName('body');
+  if (!body) return 0;
+  let count = 0;
+  for (let child of body.namedChildren) {
+    if (!child) continue;
+    if (child.type === 'decorated_definition') {
+      child = child.childForFieldName('definition') ?? child;
+    }
+    if (child.type === 'function_definition') {
+      if (child.childForFieldName('name')?.text !== '__init__') count++;
+    }
+  }
+  return count;
+}
+
+function extractPython(root: Node): ExtractionResult {
+  const out = emptyResult();
+  out.fileDoc = pyDocstring(root);
+
+  let allList: string[] | null = null;
+  const publicNames: string[] = [];
+
+  for (let child of root.namedChildren) {
+    if (!child) continue;
+    if (child.type === 'decorated_definition') {
+      child = child.childForFieldName('definition') ?? child;
+    }
+    switch (child.type) {
+      case 'import_statement': {
+        for (const item of child.namedChildren) {
+          if (!item) continue;
+          if (item.type === 'dotted_name') out.imports.push(item.text);
+          else if (item.type === 'aliased_import') {
+            const name = item.childForFieldName('name');
+            if (name) out.imports.push(name.text);
+          }
+        }
+        break;
+      }
+      case 'import_from_statement': {
+        const module = child.childForFieldName('module_name');
+        if (module) out.imports.push(module.text);
+        break;
+      }
+      case 'function_definition': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          const isPublic = !name.startsWith('_');
+          out.topLevelDeclarations.push(`def ${name}`);
+          out.functions.push({
+            name,
+            doc: pyDocstring(child.childForFieldName('body')),
+            exported: isPublic,
+          });
+          if (isPublic) publicNames.push(name);
+        }
+        break;
+      }
+      case 'class_definition': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          const isPublic = !name.startsWith('_');
+          out.topLevelDeclarations.push(`class ${name}`);
+          out.classes.push({
+            name,
+            kind: 'class',
+            methodCount: countPyMethods(child),
+            doc: pyDocstring(child.childForFieldName('body')),
+            exported: isPublic,
+          });
+          if (isPublic) publicNames.push(name);
+        }
+        break;
+      }
+      case 'expression_statement': {
+        const assignment = child.namedChildren.find((c) => c?.type === 'assignment');
+        const left = assignment?.childForFieldName('left');
+        if (!assignment || !left || left.type !== 'identifier') break;
+        const name = left.text;
+        if (name === '__all__') {
+          const right = assignment.childForFieldName('right');
+          if (right && (right.type === 'list' || right.type === 'tuple')) {
+            allList = [];
+            for (const item of right.namedChildren) {
+              if (item?.type !== 'string') continue;
+              const content = item.namedChildren.find((c) => c?.type === 'string_content');
+              if (content) allList.push(content.text);
+            }
+          }
+        } else if (!name.startsWith('_')) {
+          publicNames.push(name);
+          if (/^[A-Z0-9_]+$/.test(name)) out.constNames.push(name);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // `__all__` is the explicit export list; otherwise every public top-level
+  // binding (def/class/assignment without a leading underscore) is exported.
+  out.exports = allList ?? publicNames;
+  return dedupeResult(out);
+}
+
+// ---------------------------------------------------------------------------
+// Go extraction
+// ---------------------------------------------------------------------------
+
+function isGoExported(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+/**
+ * First line of the contiguous `//` comment block directly above `node`
+ * (Go doc-comment convention: no blank line between comment and declaration).
+ */
+function goDocComment(node: Node): string | null {
+  let expectedRow = node.startPosition.row;
+  let current = node.previousNamedSibling;
+  let top: Node | null = null;
+  while (current && current.type === 'comment' && current.endPosition.row === expectedRow - 1) {
+    top = current;
+    expectedRow = current.startPosition.row;
+    current = current.previousNamedSibling;
+  }
+  return top ? commentFirstLine(top.text) : null;
+}
+
+function goImportPath(spec: Node, out: ExtractionResult): void {
+  const path = spec.childForFieldName('path');
+  if (path) out.imports.push(stripQuotes(path.text));
+}
+
+/** Names declared in a `var_spec` / `const_spec` (may bind several identifiers). */
+function goSpecNames(spec: Node): string[] {
+  const names: string[] = [];
+  for (const child of spec.namedChildren) {
+    if (child?.type === 'identifier') names.push(child.text);
+    else break; // identifiers come first; stop at the type/value part
+  }
+  return names;
+}
+
+interface NamedTypeEntry {
+  name: string;
+  kind: string;
+  doc: string | null;
+  exported: boolean;
+}
+
+/** Promote named types with methods to class-like entries, the rest to typeNames. */
+function resolveNamedTypes(
+  types: NamedTypeEntry[],
+  methodCounts: Map<string, number>,
+  out: ExtractionResult,
+): void {
+  for (const entry of types) {
+    const methodCount = methodCounts.get(entry.name) ?? 0;
+    if (methodCount > 0) {
+      out.classes.push({ ...entry, methodCount });
+    } else {
+      out.typeNames.push(entry.name);
+    }
+  }
+}
+
+function extractGo(root: Node): ExtractionResult {
+  const out = emptyResult();
+  const types: NamedTypeEntry[] = [];
+  const methodCounts = new Map<string, number>();
+
+  for (const child of root.namedChildren) {
+    if (!child) continue;
+    switch (child.type) {
+      case 'package_clause':
+        out.fileDoc = goDocComment(child);
+        break;
+      case 'import_declaration': {
+        for (const inner of child.namedChildren) {
+          if (!inner) continue;
+          if (inner.type === 'import_spec') goImportPath(inner, out);
+          else if (inner.type === 'import_spec_list') {
+            for (const spec of inner.namedChildren) {
+              if (spec?.type === 'import_spec') goImportPath(spec, out);
+            }
+          }
+        }
+        break;
+      }
+      case 'function_declaration': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`func ${name}`);
+          out.functions.push({ name, doc: goDocComment(child), exported: isGoExported(name) });
+          if (isGoExported(name)) out.exports.push(name);
+        }
+        break;
+      }
+      case 'method_declaration': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`func ${name}`);
+          if (isGoExported(name)) out.exports.push(name);
+          // Attribute the method to its receiver's named type.
+          const receiver = child.childForFieldName('receiver');
+          const receiverType = receiver?.descendantsOfType('type_identifier')[0]?.text;
+          if (receiverType) {
+            methodCounts.set(receiverType, (methodCounts.get(receiverType) ?? 0) + 1);
+          }
+        }
+        break;
+      }
+      case 'type_declaration': {
+        for (const spec of child.namedChildren) {
+          if (!spec || (spec.type !== 'type_spec' && spec.type !== 'type_alias')) continue;
+          const name = spec.childForFieldName('name')?.text;
+          if (!name) continue;
+          const typeNode = spec.childForFieldName('type');
+          const kind =
+            typeNode?.type === 'struct_type'
+              ? 'struct'
+              : typeNode?.type === 'interface_type'
+                ? 'interface'
+                : 'type';
+          out.topLevelDeclarations.push(
+            kind === 'type' ? `type ${name}` : `type ${name} ${kind}`,
+          );
+          types.push({ name, kind, doc: goDocComment(child), exported: isGoExported(name) });
+          if (isGoExported(name)) out.exports.push(name);
+        }
+        break;
+      }
+      case 'var_declaration':
+      case 'const_declaration': {
+        const keyword = child.type === 'var_declaration' ? 'var' : 'const';
+        for (const spec of child.namedChildren) {
+          if (!spec || (spec.type !== 'var_spec' && spec.type !== 'const_spec')) continue;
+          for (const name of goSpecNames(spec)) {
+            out.topLevelDeclarations.push(`${keyword} ${name}`);
+            if (keyword === 'const') out.constNames.push(name);
+            if (isGoExported(name)) out.exports.push(name);
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  resolveNamedTypes(types, methodCounts, out);
+  return dedupeResult(out);
+}
+
+// ---------------------------------------------------------------------------
+// Rust extraction
+// ---------------------------------------------------------------------------
+
+/** Plain `pub` only — `pub(crate)` / `pub(super)` are not part of the public API. */
+function isRustPub(node: Node): boolean {
+  return node.namedChildren.some((c) => c?.type === 'visibility_modifier' && c.text === 'pub');
+}
+
+/**
+ * First line of the contiguous `///` doc-comment block directly above `node`,
+ * skipping any `#[...]` attributes between the docs and the item.
+ */
+function rustDocComment(node: Node): string | null {
+  let expectedRow = node.startPosition.row;
+  let current = node.previousNamedSibling;
+  while (current && current.type === 'attribute_item' && current.endPosition.row === expectedRow - 1) {
+    expectedRow = current.startPosition.row;
+    current = current.previousNamedSibling;
+  }
+  let top: Node | null = null;
+  while (
+    current &&
+    current.type === 'line_comment' &&
+    current.text.startsWith('///') &&
+    current.endPosition.row === expectedRow - 1
+  ) {
+    top = current;
+    expectedRow = current.startPosition.row;
+    current = current.previousNamedSibling;
+  }
+  if (top) {
+    const line = top.text.replace(/^\/\/\/\s*/, '').trim();
+    return line.length > 0 ? firstSentence(line) : null;
+  }
+  if (current && current.type === 'block_comment' && current.text.startsWith('/**')) {
+    return commentFirstLine(current.text);
+  }
+  return null;
+}
+
+/** Module path of a `use` argument, with grouped/aliased/glob tails removed. */
+function rustUseBasePath(argument: Node): string {
+  switch (argument.type) {
+    case 'scoped_use_list': {
+      const path = argument.childForFieldName('path');
+      return path ? path.text : argument.text;
+    }
+    case 'use_as_clause': {
+      const path = argument.childForFieldName('path');
+      return path ? path.text : argument.text;
+    }
+    case 'use_wildcard': {
+      const inner = argument.namedChildren.find((c) => c !== null);
+      return inner ? inner.text : argument.text;
+    }
+    default:
+      return argument.text;
+  }
+}
+
+/** Visible names introduced by a `pub use` argument (re-exports). */
+function rustUseNames(argument: Node, out: string[]): void {
+  switch (argument.type) {
+    case 'identifier':
+    case 'crate':
+    case 'self':
+    case 'super':
+      out.push(argument.text);
+      break;
+    case 'scoped_identifier': {
+      const name = argument.childForFieldName('name');
+      if (name) out.push(name.text);
+      break;
+    }
+    case 'use_as_clause': {
+      const alias = argument.childForFieldName('alias');
+      if (alias) out.push(alias.text);
+      break;
+    }
+    case 'scoped_use_list': {
+      const list = argument.childForFieldName('list');
+      for (const item of list?.namedChildren ?? []) {
+        if (item) rustUseNames(item, out);
+      }
+      break;
+    }
+    case 'use_list': {
+      for (const item of argument.namedChildren) {
+        if (item) rustUseNames(item, out);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+const RUST_TYPE_ITEMS: Record<string, string> = {
+  struct_item: 'struct',
+  enum_item: 'enum',
+  trait_item: 'trait',
+  union_item: 'union',
+};
+
+function extractRust(root: Node): ExtractionResult {
+  const out = emptyResult();
+  const types: NamedTypeEntry[] = [];
+  const methodCounts = new Map<string, number>();
+
+  let seenCode = false;
+  for (const child of root.namedChildren) {
+    if (!child) continue;
+    const pub = isRustPub(child);
+    switch (child.type) {
+      case 'line_comment':
+        if (!seenCode && out.fileDoc === null && child.text.startsWith('//!')) {
+          const line = child.text.replace(/^\/\/!\s*/, '').trim();
+          if (line.length > 0) out.fileDoc = firstSentence(line);
+        }
+        continue; // comments don't count as code
+      case 'block_comment':
+        continue;
+      case 'use_declaration': {
+        const argument = child.childForFieldName('argument');
+        if (argument) {
+          out.imports.push(rustUseBasePath(argument));
+          if (pub) rustUseNames(argument, out.exports); // `pub use` re-exports
+        }
+        break;
+      }
+      case 'mod_item': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`mod ${name}`);
+          if (!child.childForFieldName('body')) out.imports.push(name); // `mod x;`
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'function_item': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`fn ${name}`);
+          out.functions.push({ name, doc: rustDocComment(child), exported: pub });
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'struct_item':
+      case 'enum_item':
+      case 'trait_item':
+      case 'union_item': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          const kind = RUST_TYPE_ITEMS[child.type];
+          out.topLevelDeclarations.push(`${kind} ${name}`);
+          types.push({ name, kind, doc: rustDocComment(child), exported: pub });
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'impl_item': {
+        // Strip generic params so `impl Config<T>` matches `struct Config`.
+        const typeName = child.childForFieldName('type')?.text.replace(/<.*$/s, '');
+        if (typeName) {
+          out.topLevelDeclarations.push(`impl ${typeName}`);
+          const body = child.childForFieldName('body');
+          let methods = 0;
+          for (const item of body?.namedChildren ?? []) {
+            if (item?.type === 'function_item') methods++;
+          }
+          if (methods > 0) {
+            methodCounts.set(typeName, (methodCounts.get(typeName) ?? 0) + methods);
+          }
+        }
+        break;
+      }
+      case 'type_item': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`type ${name}`);
+          out.typeNames.push(name);
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'const_item':
+      case 'static_item': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(
+            `${child.type === 'const_item' ? 'const' : 'static'} ${name}`,
+          );
+          out.constNames.push(name);
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    seenCode = true;
+  }
+
+  resolveNamedTypes(types, methodCounts, out);
+  return dedupeResult(out);
+}
+
+function extract(root: Node, grammar: GrammarName): ExtractionResult {
+  switch (grammar) {
+    case 'python':
+      return extractPython(root);
+    case 'go':
+      return extractGo(root);
+    case 'rust':
+      return extractRust(root);
+    default:
+      return extractTsJs(root);
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Purpose line generation
 // ---------------------------------------------------------------------------
 
-function fileCategory(filePath: string): string | null {
+function fileCategory(filePath: string, contents: string): string | null {
   const basename = getBasename(filePath);
+  const ext = getExtension(filePath);
+  const dir = filePath.replace(/\\/g, '/');
+
+  const inTestsDir =
+    dir.includes('/tests/') || dir.includes('/test/') || /^tests?\//.test(dir);
+
+  if (ext === '.py') {
+    if (basename.startsWith('test_') || basename.endsWith('_test.py')) return 'test';
+    if (basename === 'conftest.py') return 'test';
+    if (inTestsDir) return 'test';
+    if (basename === 'setup.py' || basename === 'settings.py' || basename === 'config.py') {
+      return 'config';
+    }
+    if (basename === '__init__.py' || basename === '__main__.py') return 'entry point';
+    if (/\bif\s+__name__\s*==\s*['"]__main__['"]\s*:/.test(contents)) return 'entry point';
+    return null;
+  }
+  if (ext === '.go') {
+    if (basename.endsWith('_test.go')) return 'test';
+    if (basename === 'main.go') return 'entry point';
+    return null;
+  }
+  if (ext === '.rs') {
+    if (inTestsDir || basename.startsWith('test_')) return 'test';
+    if (basename === 'main.rs' || basename === 'lib.rs' || basename === 'mod.rs') {
+      return 'entry point';
+    }
+    if (basename === 'build.rs') return 'config';
+    return null;
+  }
+
   if (filePath.endsWith('.d.ts')) return 'types';
   if (/\.(?:test|spec)\.[tj]sx?$/.test(basename)) return 'test';
   if (/\.config\.[tj]sx?$/.test(basename) || /\.config\.mjs$/.test(basename)) return 'config';
@@ -347,7 +901,7 @@ function listNames(names: string[], max: number): string {
 }
 
 function buildPurpose(filePath: string, contents: string, info: ExtractionResult): string {
-  let category = fileCategory(filePath);
+  let category = fileCategory(filePath, contents);
   // Executable entry points: shebang line or a top-level main() function.
   if (
     category === null &&
@@ -365,7 +919,7 @@ function buildPurpose(filePath: string, contents: string, info: ExtractionResult
   if (classes.length > 0) {
     const primary = [...classes].sort((a, b) => b.methodCount - a.methodCount)[0];
     const desc = primary.doc ?? info.fileDoc;
-    const head = `class ${primary.name} (${primary.methodCount} method${primary.methodCount === 1 ? '' : 's'})`;
+    const head = `${primary.kind} ${primary.name} (${primary.methodCount} method${primary.methodCount === 1 ? '' : 's'})`;
     const rest = classes.filter((c) => c !== primary).map((c) => c.name);
     const suffix = rest.length > 0 ? ` +${listNames(rest, 2)}` : '';
     detail = desc ? `${head}${suffix}: ${desc}` : `${head}${suffix}`;
@@ -404,9 +958,9 @@ function buildPurpose(filePath: string, contents: string, info: ExtractionResult
 // ---------------------------------------------------------------------------
 
 /**
- * Summarize a TS/JS file from its syntax tree. Falls back to the regex
- * summarizer for unsupported extensions, empty files, parse errors, or when
- * the WASM runtime cannot be loaded.
+ * Summarize a TS/JS, Python, Go or Rust file from its syntax tree. Falls back
+ * to the regex summarizer for unsupported extensions, empty files, parse
+ * errors, or when the WASM runtime cannot be loaded.
  */
 export async function summarizeFileAst(filePath: string, contents: string): Promise<FileSummary> {
   const grammar = EXT_TO_GRAMMAR[getExtension(filePath)];
@@ -423,7 +977,9 @@ export async function summarizeFileAst(filePath: string, contents: string): Prom
     return summarizeFile(filePath, contents);
   }
 
-  const tree = parser.parse(contents);
+  // Some grammars (Go) need a statement terminator after the last declaration;
+  // parse with a trailing newline so files missing one don't report errors.
+  const tree = parser.parse(contents.endsWith('\n') ? contents : `${contents}\n`);
   if (!tree) return summarizeFile(filePath, contents);
 
   try {
@@ -431,7 +987,7 @@ export async function summarizeFileAst(filePath: string, contents: string): Prom
       return summarizeFile(filePath, contents);
     }
 
-    const info = extract(tree.rootNode);
+    const info = extract(tree.rootNode, grammar);
     return {
       purpose: buildPurpose(filePath, contents, info),
       exports: info.exports,

--- a/src/indexer/summarize.ts
+++ b/src/indexer/summarize.ts
@@ -14,8 +14,12 @@ export type SummarizerMode = 'regex' | 'ast';
 /**
  * Bump when summary output changes in a way that should invalidate previously
  * cached summaries (combined with the mode into the generation tag).
+ *
+ * Generation 2: the AST summarizer gained Python/Go/Rust support, so summaries
+ * for those languages cached under ast mode (which were regex-produced
+ * fallbacks at generation 1) must lazily regenerate.
  */
-const SUMMARIZER_GENERATION = 1;
+const SUMMARIZER_GENERATION = 2;
 
 const META_KEY = 'summarizer_generation';
 
@@ -52,9 +56,11 @@ export function ensureSummaryGeneration(projectRoot: string): void {
   const store = new CacheStore(projectRoot);
   const stored = store.getMeta(META_KEY);
   if (stored !== tag) {
-    // Pre-marker databases were summarized with regex generation 1; only wipe
-    // when the effective summarizer actually differs from what produced them.
-    if (stored !== null || tag !== 'regex:1') {
+    // Regex output is unchanged since generation 1, so summaries produced by
+    // regex generation 1 — including pre-marker databases, which carried no
+    // tag — are still valid under regex generation 2 and only need re-tagging.
+    const stillValid = tag === 'regex:2' && (stored === null || stored === 'regex:1');
+    if (!stillValid) {
       store.clearAllSummaries();
     }
     store.setMeta(META_KEY, tag);

--- a/tests/unit/ast-summarizer-go.test.ts
+++ b/tests/unit/ast-summarizer-go.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst — Go', () => {
+  it('reports .go files as AST-supported', () => {
+    expect(isAstSupported('pkg/widgets/widgets.go')).toBe(true);
+  });
+
+  describe('exports', () => {
+    it('exports capitalized top-level func/type/var/const names only', async () => {
+      const contents = [
+        'package widgets',
+        '',
+        'func ParseFoo(s string) error { return nil }',
+        '',
+        'func helper() {}',
+        '',
+        'type Widget struct{ Name string }',
+        '',
+        'type internal struct{}',
+        '',
+        'var Registry = map[string]int{}',
+        '',
+        'const MaxSize = 10',
+        '',
+        'const minSize = 1',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/widgets/widgets.go', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining(['ParseFoo', 'Widget', 'Registry', 'MaxSize']),
+      );
+      expect(summary.exports).not.toContain('helper');
+      expect(summary.exports).not.toContain('internal');
+      expect(summary.exports).not.toContain('minSize');
+    });
+
+    it('exports capitalized names inside grouped var/const blocks (regex weakness)', async () => {
+      const contents = [
+        'package config',
+        '',
+        'var (',
+        '\tGroupedVar = 1',
+        '\tprivateVar = 2',
+        ')',
+        '',
+        'const (',
+        '\tGroupedConst = 1',
+        ')',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/config/config.go', contents);
+      expect(summary.exports).toEqual(expect.arrayContaining(['GroupedVar', 'GroupedConst']));
+      expect(summary.exports).not.toContain('privateVar');
+    });
+
+    it('includes exported method names', async () => {
+      const contents = [
+        'package widgets',
+        '',
+        'type Widget struct{}',
+        '',
+        'func (w *Widget) Render() string { return "" }',
+        '',
+        'func (w *Widget) reset() {}',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/widgets/render.go', contents);
+      expect(summary.exports).toContain('Render');
+      expect(summary.exports).not.toContain('reset');
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts single, aliased and grouped imports', async () => {
+      const contents = [
+        'package app',
+        '',
+        'import "os"',
+        '',
+        'import (',
+        '\t"fmt"',
+        '\tstr "strings"',
+        '\t"github.com/example/pkg"',
+        ')',
+      ].join('\n');
+      const summary = await summarizeFileAst('cmd/app/imports.go', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining(['os', 'fmt', 'strings', 'github.com/example/pkg']),
+      );
+    });
+  });
+
+  describe('declarations', () => {
+    it('records funcs, types, vars and consts with their kinds', async () => {
+      const contents = [
+        'package decls',
+        '',
+        'func Run() {}',
+        '',
+        'type Widget struct{}',
+        '',
+        'type Reader interface{}',
+        '',
+        'type ID int',
+        '',
+        'var count = 0',
+        '',
+        'const limit = 5',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/decls/decls.go', contents);
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining([
+          'func Run',
+          'type Widget struct',
+          'type Reader interface',
+          'type ID',
+          'var count',
+          'const limit',
+        ]),
+      );
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes function files with names and doc-comment first sentence', async () => {
+      const contents = [
+        'package parse',
+        '',
+        '// ParseFoo parses foo values. It returns an error on bad input.',
+        'func ParseFoo(s string) error { return nil }',
+        '',
+        '// WriteBar writes bar values.',
+        'func WriteBar(s string) error { return nil }',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/parse/parse.go', contents);
+      expect(summary.purpose).toBe(
+        'functions: ParseFoo, WriteBar — ParseFoo parses foo values.',
+      );
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('describes a struct with methods using its doc comment', async () => {
+      const contents = [
+        'package widgets',
+        '',
+        '// Widget is a renderable thing.',
+        'type Widget struct{ Name string }',
+        '',
+        'func (w *Widget) Render() string { return "" }',
+        '',
+        'func (w *Widget) Reset() {}',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/widgets/widget.go', contents);
+      expect(summary.purpose).toBe('struct Widget (2 methods): Widget is a renderable thing.');
+    });
+
+    it('falls back to the package doc comment when symbols lack docs', async () => {
+      const contents = [
+        '// Package mathy provides arithmetic helpers.',
+        'package mathy',
+        '',
+        'func Add(a, b int) int { return a + b }',
+      ].join('\n');
+      const summary = await summarizeFileAst('pkg/mathy/mathy.go', contents);
+      expect(summary.purpose).toBe('function Add — Package mathy provides arithmetic helpers.');
+    });
+
+    it('marks main packages and test files', async () => {
+      const main = await summarizeFileAst(
+        'cmd/app/main.go',
+        'package main\n\nfunc main() {}\n',
+      );
+      expect(main.purpose.startsWith('entry point')).toBe(true);
+
+      const test = await summarizeFileAst(
+        'pkg/widgets/widget_test.go',
+        'package widgets\n\nfunc TestRender(t *testing.T) {}\n',
+      );
+      expect(test.purpose.startsWith('test')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'package x\nfunc broken( {{{\n';
+      const astResult = await summarizeFileAst('pkg/x/broken.go', broken);
+      const regexResult = summarizeFile('pkg/x/broken.go', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('pkg/x/empty.go', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+});

--- a/tests/unit/ast-summarizer-python.test.ts
+++ b/tests/unit/ast-summarizer-python.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst — Python', () => {
+  it('reports .py files as AST-supported', () => {
+    expect(isAstSupported('src/app.py')).toBe(true);
+  });
+
+  describe('exports', () => {
+    it('uses __all__ as the export list when present', async () => {
+      const contents = [
+        '__all__ = ["public_fn", "Widget"]',
+        '',
+        'def public_fn():',
+        '    pass',
+        '',
+        'def also_public():',
+        '    pass',
+        '',
+        'class Widget:',
+        '    pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/api.py', contents);
+      expect(summary.exports).toEqual(['public_fn', 'Widget']);
+    });
+
+    it('falls back to top-level non-underscore names without __all__', async () => {
+      const contents = [
+        'MAX_SIZE = 10',
+        '_internal = 1',
+        '',
+        'async def fetch():',
+        '    pass',
+        '',
+        'def _private():',
+        '    pass',
+        '',
+        'class Engine:',
+        '    pass',
+        '',
+        'class _Hidden:',
+        '    pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/engine.py', contents);
+      expect(summary.exports).toEqual(expect.arrayContaining(['MAX_SIZE', 'fetch', 'Engine']));
+      expect(summary.exports).not.toContain('_internal');
+      expect(summary.exports).not.toContain('_private');
+      expect(summary.exports).not.toContain('_Hidden');
+    });
+
+    it('includes decorated and async definitions', async () => {
+      const contents = [
+        'import functools',
+        '',
+        '@functools.cache',
+        'def cached():',
+        '    pass',
+        '',
+        '@decorator',
+        'class Service:',
+        '    pass',
+        '',
+        'async def run():',
+        '    pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/svc.py', contents);
+      expect(summary.exports).toEqual(expect.arrayContaining(['cached', 'Service', 'run']));
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining(['def cached', 'class Service', 'def run']),
+      );
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts import, dotted, aliased and from-imports', async () => {
+      const contents = [
+        'import os',
+        'import os.path as osp',
+        'from typing import List, Optional',
+        'from . import sibling',
+        'from ..pkg import helper',
+        '',
+        'x = os.getcwd()',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/app.py', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining(['os', 'os.path', 'typing', '.', '..pkg']),
+      );
+    });
+
+    it('does not match imports inside docstrings (regex weakness)', async () => {
+      const contents = [
+        'def helper():',
+        '    """Usage:',
+        'import fake_module',
+        '    """',
+        '    return 1',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/doc.py', contents);
+      expect(summary.imports).toEqual([]);
+    });
+  });
+
+  describe('declarations', () => {
+    it('records top-level defs and classes only', async () => {
+      const contents = [
+        'def outer():',
+        '    def nested():',
+        '        pass',
+        '    return nested',
+        '',
+        'class Box:',
+        '    def method(self):',
+        '        pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/decls.py', contents);
+      expect(summary.topLevelDeclarations).toEqual(['def outer', 'class Box']);
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes a class with method count and docstring first line', async () => {
+      const contents = [
+        'class Store:',
+        '    """SQLite-backed cache entry CRUD."""',
+        '',
+        '    def __init__(self):',
+        '        pass',
+        '',
+        '    def get(self):',
+        '        pass',
+        '',
+        '    def put(self):',
+        '        pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/store.py', contents);
+      expect(summary.purpose).toBe('class Store (2 methods): SQLite-backed cache entry CRUD.');
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('describes a function module using the module docstring', async () => {
+      const contents = [
+        '"""Compute deterministic hashes for cache keys."""',
+        '',
+        'def hash_file(path):',
+        '    pass',
+        '',
+        'def hash_contents(data):',
+        '    pass',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/hash.py', contents);
+      expect(summary.purpose).toContain('functions: hash_file, hash_contents');
+      expect(summary.purpose).toContain('Compute deterministic hashes for cache keys.');
+    });
+
+    it('prefixes test files with the test category', async () => {
+      const contents = 'def test_thing():\n    assert True\n';
+      const summary = await summarizeFileAst('test_thing.py', contents);
+      expect(summary.purpose.startsWith('test')).toBe(true);
+    });
+
+    it('recognizes __main__ guards as entry points', async () => {
+      const contents = [
+        'def main():',
+        '    pass',
+        '',
+        "if __name__ == '__main__':",
+        '    main()',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/cli.py', contents);
+      expect(summary.purpose.startsWith('entry point')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'def broken(:\n    ((( pass\n';
+      const astResult = await summarizeFileAst('src/broken.py', broken);
+      const regexResult = summarizeFile('src/broken.py', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('src/empty.py', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+});

--- a/tests/unit/ast-summarizer-rust.test.ts
+++ b/tests/unit/ast-summarizer-rust.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst — Rust', () => {
+  it('reports .rs files as AST-supported', () => {
+    expect(isAstSupported('src/lib.rs')).toBe(true);
+  });
+
+  describe('exports', () => {
+    it('exports pub items of all kinds, including pub async fn', async () => {
+      const contents = [
+        'pub fn parse(input: &str) -> u32 { 0 }',
+        'pub async fn fetch() {}',
+        'fn private_helper() {}',
+        'pub struct Config;',
+        'pub enum Mode { A, B }',
+        'pub trait Render { fn render(&self) -> String; }',
+        'pub type Alias = u32;',
+        'pub const MAX: u32 = 10;',
+        'pub static GLOBAL: u32 = 0;',
+        'pub mod api {}',
+        'struct Internal;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/items.rs', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining([
+          'parse',
+          'fetch',
+          'Config',
+          'Mode',
+          'Render',
+          'Alias',
+          'MAX',
+          'GLOBAL',
+          'api',
+        ]),
+      );
+      expect(summary.exports).not.toContain('private_helper');
+      expect(summary.exports).not.toContain('Internal');
+    });
+
+    it('handles modified functions like pub const fn (regex weakness)', async () => {
+      const contents = ['pub const fn double(x: u32) -> u32 { x * 2 }'].join('\n');
+      const summary = await summarizeFileAst('src/util.rs', contents);
+      expect(summary.exports).toEqual(['double']);
+      expect(summary.exports).not.toContain('fn');
+    });
+
+    it('does not export pub(crate) items', async () => {
+      const contents = [
+        'pub(crate) fn internal() {}',
+        'pub fn external() {}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/vis.rs', contents);
+      expect(summary.exports).toEqual(['external']);
+    });
+
+    it('treats pub use re-exports as exports', async () => {
+      const contents = [
+        'pub use crate::widget::Widget;',
+        'pub use crate::engine::{Engine, Result as EngineResult};',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/re.rs', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining(['Widget', 'Engine', 'EngineResult']),
+      );
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts use paths, grouped-use base paths and mod declarations', async () => {
+      const contents = [
+        'use std::collections::HashMap;',
+        'use crate::engine::{Engine, Result};',
+        'use foo::bar as baz;',
+        'use std::io::*;',
+        '',
+        'mod helpers;',
+        'mod inline { }',
+        '',
+        'pub fn run() -> HashMap<String, Engine> { todo!() }',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/app.rs', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining([
+          'std::collections::HashMap',
+          'crate::engine',
+          'foo::bar',
+          'std::io',
+          'helpers',
+        ]),
+      );
+      // `mod inline { }` defines a module in place; it is not an import.
+      expect(summary.imports).not.toContain('inline');
+    });
+  });
+
+  describe('declarations', () => {
+    it('records top-level items with their kinds', async () => {
+      const contents = [
+        'pub fn run() {}',
+        'pub struct Config;',
+        'enum Mode { A }',
+        'trait Render {}',
+        'impl Render for Config {}',
+        'type Alias = u32;',
+        'const MAX: u32 = 1;',
+        'static GLOBAL: u32 = 0;',
+        'mod helpers;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/decls.rs', contents);
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining([
+          'fn run',
+          'struct Config',
+          'enum Mode',
+          'trait Render',
+          'impl Config',
+          'type Alias',
+          'const MAX',
+          'static GLOBAL',
+          'mod helpers',
+        ]),
+      );
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes functions with /// doc-comment first sentences', async () => {
+      const contents = [
+        '/// Parses input into tokens. Returns an empty vec on failure.',
+        'pub fn parse(input: &str) -> Vec<String> { vec![] }',
+        '',
+        'pub fn write(tokens: &[String]) -> String { String::new() }',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/parse.rs', contents);
+      expect(summary.purpose).toBe('functions: parse, write — Parses input into tokens.');
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('describes a struct with impl methods using its doc comment', async () => {
+      const contents = [
+        '/// A widget configuration.',
+        '#[derive(Debug)]',
+        'pub struct Config {',
+        '    pub name: String,',
+        '}',
+        '',
+        'impl Config {',
+        '    pub fn new() -> Self { todo!() }',
+        '    pub fn name(&self) -> &str { &self.name }',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/config.rs', contents);
+      expect(summary.purpose).toBe('struct Config (2 methods): A widget configuration.');
+    });
+
+    it('uses //! inner doc comments as the file description', async () => {
+      const contents = [
+        '//! Token stream utilities.',
+        '',
+        'pub type TokenId = u32;',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/tokens.rs', contents);
+      expect(summary.purpose).toContain('TokenId');
+      expect(summary.purpose).toContain('Token stream utilities.');
+    });
+
+    it('marks entry points and tests', async () => {
+      const main = await summarizeFileAst('src/main.rs', 'fn main() {}\n');
+      expect(main.purpose.startsWith('entry point')).toBe(true);
+
+      const test = await summarizeFileAst(
+        'tests/integration.rs',
+        '#[test]\nfn it_works() { assert!(true); }\n',
+      );
+      expect(test.purpose.startsWith('test')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'pub fn broken( {{{ not rust ((((\n';
+      const astResult = await summarizeFileAst('src/broken.rs', broken);
+      const regexResult = summarizeFile('src/broken.rs', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('src/empty.rs', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+});

--- a/tests/unit/ast-summarizer.test.ts
+++ b/tests/unit/ast-summarizer.test.ts
@@ -203,11 +203,11 @@ describe('summarizeFileAst', () => {
     });
 
     it('delegates unsupported extensions to the regex summarizer', async () => {
-      const contents = 'def main():\n    pass\n';
-      const astResult = await summarizeFileAst('src/script.py', contents);
-      const regexResult = summarizeFile('src/script.py', contents);
+      const contents = 'def main\n  puts "hi"\nend\n';
+      const astResult = await summarizeFileAst('src/script.rb', contents);
+      const regexResult = summarizeFile('src/script.rb', contents);
       expect(astResult).toEqual(regexResult);
-      expect(isAstSupported('src/script.py')).toBe(false);
+      expect(isAstSupported('src/script.rb')).toBe(false);
     });
 
     it('delegates empty files to the regex summarizer', async () => {

--- a/tests/unit/summarize.test.ts
+++ b/tests/unit/summarize.test.ts
@@ -72,7 +72,7 @@ describe('summarizeForProject', () => {
 
     // Hashes were preserved, only summaries were dropped.
     const store = new CacheStore(tempDir);
-    expect(store.getMeta('summarizer_generation')).toBe('ast:1');
+    expect(store.getMeta('summarizer_generation')).toBe('ast:2');
   });
 
   it('does not wipe summaries when the mode is unchanged', async () => {


### PR DESCRIPTION
## Summary
Extends the AST summarizer (#146) from TS/JS to all four regex-supported language families, behind the same opt-in `summarizer: 'ast'` setting.

- Per-language parse-tree extraction: Python (`__all__`, docstrings, async def), Go (grouped declarations, doc comments, capitalization-based exports), Rust (`pub` items incl. `pub use` re-exports, /// docs, `pub(crate)` excluded)
- Vendors python/go/rust grammar wasms into dist/grammars/ (tarball: 573 kB → 801 kB compressed)
- SUMMARIZER_GENERATION bumped to 2: ast-mode caches lazily regenerate; regex-mode caches are re-tagged without a wipe

## Notable accuracy wins over regex (each test-covered)
- Go: exported names in `var (...)`/`const (...)` groups were invisible to the line-anchored regex
- Rust: `pub const fn double` produced a bogus export named `fn`; AST exports `double`
- Python: regex picks up imports written inside docstrings; AST doesn't

## Testing
410 tests / 41 files pass (35 new); typecheck, lint, build clean; all 6 wasms verified in dist/grammars/