### PR TITLE
feat(server): add 'repo-memory index' cache prewarm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ npm install -g @blamechris/repo-memory
 repo-memory  # starts MCP server on stdio
 ```
 
+### Prewarm the cache
+The first time an agent touches a file it pays full price — the summary has to be generated. You can pay that cost ahead of time (post-pull hook, CI step) so the first session starts with cache hits:
+
+```bash
+repo-memory index            # index the current directory
+repo-memory index /path/to/project
+repo-memory index --quiet    # no output on success (for scripts/CI)
+```
+
+Only missing or stale entries are re-summarized; unchanged files are left untouched.
+
 ## How It Works
 
 ### The problem

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,30 @@
 
 Detailed documentation for each repo-memory MCP tool, with example inputs and outputs.
 
+## CLI
+
+By default `repo-memory` starts the MCP server on stdio. One subcommand is available:
+
+### `repo-memory index [projectRoot] [--quiet]`
+
+Prewarms the summary cache: scans the project, hashes every indexable file, and generates summaries for entries that are missing or stale. Unchanged files are left untouched, so it is cheap to run repeatedly (post-pull hook, CI step). Respects `.repo-memory.json` (ignore patterns, `maxFiles`, summarizer mode).
+
+- `projectRoot` (optional): directory to index. Default: current directory.
+- `--quiet` / `-q`: print nothing on success.
+
+```
+$ repo-memory index
+Indexed /path/to/project
+  scanned:       128
+  summarized:    126
+  already fresh: 2
+  skipped:       0
+  elapsed:       0.42s
+  cache db:      /path/to/project/.repo-memory/cache.db
+```
+
+Exits `0` on success, `1` on error (message on stderr).
+
 ## Tools Reference
 
 ### `get_file_summary`

--- a/src/cli/index-command.ts
+++ b/src/cli/index-command.ts
@@ -1,0 +1,135 @@
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { scanProject } from '../indexer/scanner.js';
+import { ensureSummaryGeneration } from '../indexer/summarize.js';
+import { getDatabasePath } from '../persistence/db.js';
+import { getFileSummary } from '../tools/get-file-summary.js';
+
+export interface IndexOptions {
+  /** Suppress the human-readable report printed to stdout. */
+  quiet?: boolean;
+}
+
+export interface IndexReport {
+  projectRoot: string;
+  cacheDbPath: string;
+  scanned: number;
+  summarized: number;
+  fresh: number;
+  skipped: number;
+  skippedPaths: string[];
+  elapsedMs: number;
+}
+
+/**
+ * Prewarm the summary cache for a project: scan all indexable files and run
+ * each one through the same hash/compare/summarize/store path the
+ * `get_file_summary` tool uses, so a later MCP session starts with cache hits.
+ *
+ * Files whose hash already matches the cache are left untouched ("fresh");
+ * files that cannot be read or summarized are counted as skipped rather than
+ * aborting the run.
+ */
+export async function runIndex(
+  projectRoot: string,
+  options: IndexOptions = {},
+): Promise<IndexReport> {
+  const root = resolve(projectRoot);
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new Error(`project root does not exist or is not a directory: ${root}`);
+  }
+
+  const started = Date.now();
+
+  // Verify cached summaries match the configured summarizer mode/generation
+  // before any cache comparisons happen.
+  ensureSummaryGeneration(root);
+
+  const files = await scanProject(root);
+
+  let summarized = 0;
+  let fresh = 0;
+  const skippedPaths: string[] = [];
+
+  for (const file of files) {
+    try {
+      // Reuses the exact cache-read/write semantics of the get_file_summary
+      // tool: hash, compare, regenerate only when missing/stale.
+      const result = await getFileSummary(root, file);
+      if (result.fromCache) {
+        fresh += 1;
+      } else {
+        summarized += 1;
+      }
+    } catch {
+      // Unreadable entries (deleted since scan, gitlinks, permission errors).
+      skippedPaths.push(file);
+    }
+  }
+
+  const report: IndexReport = {
+    projectRoot: root,
+    cacheDbPath: getDatabasePath(root),
+    scanned: files.length,
+    summarized,
+    fresh,
+    skipped: skippedPaths.length,
+    skippedPaths,
+    elapsedMs: Date.now() - started,
+  };
+
+  if (!options.quiet) {
+    // stdout is safe here — the index command never runs while the MCP stdio
+    // transport is active, so this cannot corrupt the protocol channel.
+    process.stdout.write(formatReport(report));
+  }
+
+  return report;
+}
+
+function formatReport(report: IndexReport): string {
+  const lines = [
+    `Indexed ${report.projectRoot}`,
+    `  scanned:       ${report.scanned}`,
+    `  summarized:    ${report.summarized}`,
+    `  already fresh: ${report.fresh}`,
+    `  skipped:       ${report.skipped}`,
+    `  elapsed:       ${(report.elapsedMs / 1000).toFixed(2)}s`,
+    `  cache db:      ${report.cacheDbPath}`,
+  ];
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Thin argv wrapper for `repo-memory index [projectRoot] [--quiet]`.
+ * Exits 0 on success, 1 on error (message to stderr).
+ */
+export async function runIndexCli(argv: string[]): Promise<never> {
+  let quiet = false;
+  let projectRoot: string | undefined;
+
+  for (const arg of argv) {
+    if (arg === '--quiet' || arg === '-q') {
+      quiet = true;
+    } else if (arg.startsWith('-')) {
+      process.stderr.write(`repo-memory index: unknown option '${arg}'\n`);
+      process.stderr.write('Usage: repo-memory index [projectRoot] [--quiet]\n');
+      process.exit(1);
+    } else if (projectRoot === undefined) {
+      projectRoot = arg;
+    } else {
+      process.stderr.write(`repo-memory index: unexpected argument '${arg}'\n`);
+      process.stderr.write('Usage: repo-memory index [projectRoot] [--quiet]\n');
+      process.exit(1);
+    }
+  }
+
+  try {
+    await runIndex(projectRoot ?? process.cwd(), { quiet });
+    process.exit(0);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`repo-memory index: ${message}\n`);
+    process.exit(1);
+  }
+}

--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -137,9 +137,14 @@ function runMigrations(db: Database.Database): void {
   applyMigrations();
 }
 
+/** Absolute path of the cache database for a project (whether or not it exists yet). */
+export function getDatabasePath(projectRoot: string): string {
+  return join(projectRoot, REPO_MEMORY_DIR, DB_FILENAME);
+}
+
 export function getDatabase(projectRoot: string): Database.Database {
   const dbDir = join(projectRoot, REPO_MEMORY_DIR);
-  const dbPath = join(dbDir, DB_FILENAME);
+  const dbPath = getDatabasePath(projectRoot);
 
   if (instance && instancePath === dbPath) {
     return instance;

--- a/src/server.ts
+++ b/src/server.ts
@@ -329,8 +329,16 @@ async function main() {
   });
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  process.stderr.write(`Fatal error: ${message}\n`);
-  process.exit(1);
-});
+// Subcommand dispatch: `repo-memory index [projectRoot]` prewarms the summary
+// cache and exits. Anything else starts the MCP server on stdio, where stdout
+// is reserved for the protocol channel.
+if (process.argv[2] === 'index') {
+  const { runIndexCli } = await import('./cli/index-command.js');
+  await runIndexCli(process.argv.slice(3));
+} else {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`Fatal error: ${message}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/unit/index-command.test.ts
+++ b/tests/unit/index-command.test.ts
@@ -1,0 +1,117 @@
+import { cpSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CacheStore } from '../../src/cache/store.js';
+import { runIndex } from '../../src/cli/index-command.js';
+import { clearConfigCache } from '../../src/config.js';
+import { clearSummaryGenerationCache } from '../../src/indexer/summarize.js';
+import { closeDatabase, getDatabasePath } from '../../src/persistence/db.js';
+
+describe('runIndex', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'index-command-test-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(
+      join(tempDir, 'src', 'greet.ts'),
+      'export function greet(name: string): string {\n  return `hi ${name}`;\n}\n',
+    );
+    writeFileSync(join(tempDir, 'src', 'answer.ts'), 'export const answer = 42;\n');
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('populates the cache on a fresh index', async () => {
+    const report = await runIndex(tempDir, { quiet: true });
+
+    expect(report.projectRoot).toBe(tempDir);
+    expect(report.cacheDbPath).toBe(getDatabasePath(tempDir));
+    expect(report.scanned).toBe(2);
+    expect(report.summarized).toBe(2);
+    expect(report.fresh).toBe(0);
+    expect(report.skipped).toBe(0);
+    expect(report.elapsedMs).toBeGreaterThanOrEqual(0);
+
+    const store = new CacheStore(tempDir);
+    const entry = store.getEntry('src/greet.ts');
+    expect(entry).not.toBeNull();
+    expect(entry!.hash.length).toBe(64); // SHA-256 hex
+    expect(entry!.summary).not.toBeNull();
+    expect(entry!.summary!.exports).toContain('greet');
+  });
+
+  it('reports all files as fresh on a second run', async () => {
+    const first = await runIndex(tempDir, { quiet: true });
+    expect(first.summarized).toBe(2);
+
+    const second = await runIndex(tempDir, { quiet: true });
+    expect(second.scanned).toBe(2);
+    expect(second.summarized).toBe(0);
+    expect(second.fresh).toBe(2);
+  });
+
+  it('re-summarizes only changed files', async () => {
+    await runIndex(tempDir, { quiet: true });
+    writeFileSync(join(tempDir, 'src', 'answer.ts'), 'export const answer = 43;\n');
+
+    const report = await runIndex(tempDir, { quiet: true });
+    expect(report.summarized).toBe(1);
+    expect(report.fresh).toBe(1);
+  });
+
+  it('respects ignore patterns from .repo-memory.json', async () => {
+    mkdirSync(join(tempDir, 'generated'));
+    writeFileSync(join(tempDir, 'generated', 'out.ts'), 'export const out = true;\n');
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ ignore: ['generated/'] }));
+
+    const report = await runIndex(tempDir, { quiet: true });
+
+    // src/greet.ts, src/answer.ts, and .repo-memory.json — but not generated/out.ts
+    expect(report.scanned).toBe(3);
+
+    const store = new CacheStore(tempDir);
+    expect(store.getEntry('generated/out.ts')).toBeNull();
+    expect(store.getEntry('src/greet.ts')).not.toBeNull();
+  });
+
+  it('indexes the sample-project fixture', async () => {
+    // Copy the fixture so the cache db lands in a temp dir, not the repo.
+    const fixture = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'fixtures',
+      'sample-project',
+    );
+    const projectDir = join(tempDir, 'sample-project');
+    cpSync(fixture, projectDir, { recursive: true });
+
+    const report = await runIndex(projectDir, { quiet: true });
+    // .gitignore, package.json, README.md, src/index.ts, src/utils.ts
+    expect(report.scanned).toBe(5);
+    expect(report.summarized).toBe(5);
+
+    const store = new CacheStore(projectDir);
+    expect(store.getEntry('src/index.ts')!.summary).not.toBeNull();
+    expect(store.getEntry('src/utils.ts')!.summary).not.toBeNull();
+  });
+
+  it('rejects a project root that does not exist', async () => {
+    const missing = join(tempDir, 'no-such-dir');
+    await expect(runIndex(missing, { quiet: true })).rejects.toThrow(/does not exist/);
+  });
+
+  it('rejects a project root that is a file', async () => {
+    const file = join(tempDir, 'src', 'greet.ts');
+    await expect(runIndex(file, { quiet: true })).rejects.toThrow(/not a directory/);
+  });
+});


### PR DESCRIPTION
## Summary
New CLI subcommand: `repo-memory index [projectRoot]` populates the summary cache ahead of time (post-pull, CI), so first agent sessions start with cache hits instead of misses.

- Reuses the existing `getFileSummary` path verbatim — same hash/compare/regenerate-only-when-stale and cache-write semantics, respects the configured summarizer mode and generation
- Human-readable report (scanned/summarized/fresh/skipped, elapsed, db path); `--quiet` for scripts; exit 0/1
- MCP server path unchanged — dispatch happens before stdio startup; verified the initialize handshake still returns clean JSON-RPC with nothing extra on stdout

## Testing
- 7 new unit tests (fresh index, all-fresh second run, stale-only regeneration, ignore config, fixture project, error cases); 417 total pass
- typecheck/lint/build clean; sanity-ran the built CLI (162 files, ~50ms warm)