### PR TITLE
fix(telemetry): suppress cache events during index prewarm

### DIFF
--- a/src/cli/index-command.ts
+++ b/src/cli/index-command.ts
@@ -54,8 +54,10 @@ export async function runIndex(
   for (const file of files) {
     try {
       // Reuses the exact cache-read/write semantics of the get_file_summary
-      // tool: hash, compare, regenerate only when missing/stale.
-      const result = await getFileSummary(root, file);
+      // tool: hash, compare, regenerate only when missing/stale. Telemetry is
+      // suppressed — prewarm traffic isn't agent traffic and would distort
+      // hit-ratio stats.
+      const result = await getFileSummary(root, file, { trackTelemetry: false });
       if (result.fromCache) {
         fresh += 1;
       } else {

--- a/src/tools/get-file-summary.ts
+++ b/src/tools/get-file-summary.ts
@@ -18,10 +18,21 @@ export interface FileSummaryResult {
   suggestFullRead: boolean;
 }
 
+export interface GetFileSummaryOptions {
+  /**
+   * Record cache_hit/cache_miss telemetry (default true). Bulk operations like
+   * the `index` prewarm CLI disable this so they don't distort agent-traffic
+   * hit-ratio stats.
+   */
+  trackTelemetry?: boolean;
+}
+
 export async function getFileSummary(
   projectRoot: string,
   relativePath: string,
+  options: GetFileSummaryOptions = {},
 ): Promise<FileSummaryResult> {
+  const trackTelemetry = options.trackTelemetry ?? true;
   relativePath = validatePath(projectRoot, relativePath);
   ensureSummaryGeneration(projectRoot);
   const store = new CacheStore(projectRoot);
@@ -40,8 +51,10 @@ export async function getFileSummary(
   const tracker = new TelemetryTracker(projectRoot);
 
   if (cached && cached.hash === currentHash && cached.summary) {
-    const tokensSaved = estimateTokensSaved(contents, cached.summary);
-    tracker.trackEvent('cache_hit', relativePath, tokensSaved);
+    if (trackTelemetry) {
+      const tokensSaved = estimateTokensSaved(contents, cached.summary);
+      tracker.trackEvent('cache_hit', relativePath, tokensSaved);
+    }
 
     return {
       path: relativePath,
@@ -67,7 +80,9 @@ export async function getFileSummary(
     reason = 'cache_miss: no summary in cache';
   }
 
-  tracker.trackEvent('cache_miss', relativePath, 0);
+  if (trackTelemetry) {
+    tracker.trackEvent('cache_miss', relativePath, 0);
+  }
 
   return {
     path: relativePath,

--- a/tests/unit/index-command.test.ts
+++ b/tests/unit/index-command.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CacheStore } from '../../src/cache/store.js';
 import { runIndex } from '../../src/cli/index-command.js';
+import { TelemetryTracker } from '../../src/telemetry/tracker.js';
 import { clearConfigCache } from '../../src/config.js';
 import { clearSummaryGenerationCache } from '../../src/indexer/summarize.js';
 import { closeDatabase, getDatabasePath } from '../../src/persistence/db.js';
@@ -103,6 +104,14 @@ describe('runIndex', () => {
     const store = new CacheStore(projectDir);
     expect(store.getEntry('src/index.ts')!.summary).not.toBeNull();
     expect(store.getEntry('src/utils.ts')!.summary).not.toBeNull();
+  });
+
+  it('records no telemetry events', async () => {
+    await runIndex(tempDir, { quiet: true });
+    await runIndex(tempDir, { quiet: true }); // second run hits the cache
+
+    const tracker = new TelemetryTracker(tempDir);
+    expect(tracker.getEvents()).toHaveLength(0);
   });
 
   it('rejects a project root that does not exist', async () => {


### PR DESCRIPTION
## Summary
`repo-memory index` recorded a `cache_miss` telemetry event for every file it prewarmed (1,334 events on one chroxy run), which would distort the agent-traffic hit ratios `get_token_report` exists to measure. `getFileSummary` now accepts `{ trackTelemetry: false }` (default unchanged) and the prewarm path uses it.

## Testing
- New test: two back-to-back `runIndex` runs leave zero telemetry events
- Full suite (418) plus typecheck/lint pass