### PR TITLE
feat(indexer): AST summarization for Kotlin and Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Create a `.repo-memory.json` in your project root to customize behavior:
 }
 ```
 
-`summarizer` selects the summary engine: `"regex"` (default) or `"ast"`. AST mode parses TypeScript/JavaScript files (`.ts/.tsx/.js/.jsx/.mjs/.cjs`) with tree-sitter, producing accurate exports/declarations and a semantic `purpose` line that names the dominant symbols (e.g. `class CacheStore (9 methods)` instead of `source`) — which is what `search_by_purpose` matches against. TS/JS only for now; other languages, unsupported extensions, and files with parse errors fall back to the regex summarizer automatically. Switching modes regenerates summaries lazily on next access.
+`summarizer` selects the summary engine: `"regex"` (default) or `"ast"`. AST mode parses supported languages (see [Language Support](#language-support)) with tree-sitter, producing accurate exports/declarations and a semantic `purpose` line that names the dominant symbols (e.g. `class CacheStore (9 methods)` instead of `source`) — which is what `search_by_purpose` matches against. Other languages, unsupported extensions, and files with parse errors fall back to the regex summarizer automatically. Switching modes regenerates summaries lazily on next access.
 
 The `tools` block toggles tool groups. `navigation` and `summaries` are **on by default** (set `"summaries": false` to drop the summary tools); `tasks` and `telemetry` are **off by default** (set them to `true` to enable).
 
@@ -220,11 +220,15 @@ Config validation is per-key: an invalid value is skipped with a warning on stde
 
 ## Language Support
 
-Summaries are extracted via regex analysis, or from tree-sitter parse trees when `"summarizer": "ast"` is set. All four language families below have AST support in `ast` mode, which adds semantic purpose lines derived from doc comments; regex stays as the universal fallback for other languages and unparseable files. Supported languages:
+Summaries are extracted via regex analysis, or from tree-sitter parse trees when `"summarizer": "ast"` is set. All language families below have AST support in `ast` mode, which adds semantic purpose lines derived from doc comments; regex stays as the universal fallback for other languages and unparseable files. Supported languages:
 - **TypeScript / JavaScript** — exports, imports, declarations, purpose classification; AST mode adds JSDoc-derived purpose lines
 - **Python** — functions, classes (incl. `async def`), `__all__`, `from`/`import` statements; AST mode adds docstring-derived purpose lines
 - **Go** — exported names (uppercase), imports, type/func/var/const declarations; AST mode adds doc-comment purpose lines and grouped `var (…)` / `const (…)` support
 - **Rust** — `pub` items, `use`/`mod` statements, structs/enums/traits/impls; AST mode adds `///` doc-comment purpose lines and `pub use` re-exports
+- **Kotlin** (`.kt/.kts`) — AST mode only: public top-level `fun`/`class`/`object`/`interface`/`enum class`/`data class`/`val`/`var`/`typealias` (excluding `private`/`internal`), `import` paths, KDoc-derived purpose lines; regex mode gives only basic filename classification
+- **Java** — AST mode only: public types and the public methods/fields of the public type, `import` statements (incl. `static` and wildcard), Javadoc-derived purpose lines; regex mode gives only basic filename classification
+
+The dependency graph (`get_related_files`, `get_dependency_graph`) extracts imports for all six language families regardless of summarizer mode.
 
 Config files (JSON, YAML, TOML) and other file types get basic classification.
 

--- a/docs/planning/ast-summarizer-spike.md
+++ b/docs/planning/ast-summarizer-spike.md
@@ -151,6 +151,18 @@ Suggested rollout:
    ast-mode caches for these languages regenerate lazily.
 5. Fix the `async` export bug in the regex summarizer independently — it
    benefits the fallback path and non-TS languages' sibling patterns.
+6. **Done.** Extend to Kotlin (`.kt/.kts`) and Java: per-language extraction
+   visitors (public-API exports with `private`/`internal` filtering for
+   Kotlin and `public`-member filtering for Java, dotted import paths,
+   KDoc/Javadoc purpose lines), grammar wasms vendored (8 total in
+   `dist/grammars/`), summarizer generation bumped to 3. Unlike the earlier
+   languages, the regex summarizer has no Kotlin/Java extraction, so AST mode
+   is the only real engine for them — the fallback path yields generic
+   filename-based classification only. Simple regex import extraction for
+   Kotlin/Java was added to `imports.ts` so the dependency graph covers them
+   in both modes. Known grammar quirk: `tree-sitter-kotlin` rejects
+   single-line class bodies (`class C { fun f() {} }`), which triggers the
+   regex fallback for such files.
 
 Caveats:
 

--- a/scripts/copy-grammars.mjs
+++ b/scripts/copy-grammars.mjs
@@ -19,6 +19,8 @@ const GRAMMARS = [
   'tree-sitter-python.wasm',
   'tree-sitter-go.wasm',
   'tree-sitter-rust.wasm',
+  'tree-sitter-kotlin.wasm',
+  'tree-sitter-java.wasm',
 ];
 
 const require = createRequire(import.meta.url);

--- a/src/indexer/ast-summarizer.ts
+++ b/src/indexer/ast-summarizer.ts
@@ -7,8 +7,8 @@ import { summarizeFile } from './summarizer.js';
 import type { FileSummary } from '../types.js';
 
 /**
- * AST-based summarizer for TypeScript/JavaScript, Python, Go and Rust using
- * web-tree-sitter (WASM).
+ * AST-based summarizer for TypeScript/JavaScript, Python, Go, Rust, Kotlin
+ * and Java using web-tree-sitter (WASM).
  *
  * Same contract as `summarizeFile` in summarizer.ts, but exports/imports/
  * declarations come from a real parse tree instead of line-anchored regexes,
@@ -20,7 +20,15 @@ import type { FileSummary } from '../types.js';
  * summarizer, so this is a strict superset in coverage.
  */
 
-type GrammarName = 'typescript' | 'tsx' | 'javascript' | 'python' | 'go' | 'rust';
+type GrammarName =
+  | 'typescript'
+  | 'tsx'
+  | 'javascript'
+  | 'python'
+  | 'go'
+  | 'rust'
+  | 'kotlin'
+  | 'java';
 
 const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
   '.ts': 'typescript',
@@ -35,6 +43,9 @@ const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
   '.py': 'python',
   '.go': 'go',
   '.rs': 'rust',
+  '.kt': 'kotlin',
+  '.kts': 'kotlin',
+  '.java': 'java',
 };
 
 const MAX_PURPOSE_LENGTH = 160;
@@ -837,6 +848,296 @@ function extractRust(root: Node): ExtractionResult {
   return dedupeResult(out);
 }
 
+// ---------------------------------------------------------------------------
+// Kotlin extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * True unless the declaration carries a `private`/`internal`/`protected`
+ * visibility modifier (`public` is the Kotlin default).
+ */
+function ktIsPublic(node: Node): boolean {
+  const mods = node.namedChildren.find((c) => c?.type === 'modifiers');
+  for (const m of mods?.namedChildren ?? []) {
+    if (m?.type === 'visibility_modifier' && m.text !== 'public') return false;
+  }
+  return true;
+}
+
+/** The Kotlin grammar exposes keywords (`interface`, `enum`, …) as anonymous tokens. */
+function ktHasToken(node: Node, token: string): boolean {
+  return node.children.some((c) => c !== null && c.type === token);
+}
+
+function ktHasClassModifier(node: Node, modifier: string): boolean {
+  const mods = node.namedChildren.find((c) => c?.type === 'modifiers');
+  return (mods?.namedChildren ?? []).some(
+    (m) => m !== null && m.type === 'class_modifier' && m.text === modifier,
+  );
+}
+
+/**
+ * KDoc block immediately above `node`. The Kotlin grammar attaches the
+ * comment preceding the first declaration after the imports as the trailing
+ * descendant of the import list, so that path is checked too.
+ */
+function ktPrecedingDoc(node: Node): string | null {
+  let prev = node.previousNamedSibling;
+  if (prev && (prev.type === 'import_list' || prev.type === 'package_header')) {
+    let tail: Node = prev;
+    while (tail.lastNamedChild) tail = tail.lastNamedChild;
+    prev = tail;
+  }
+  if (prev && prev.type === 'multiline_comment' && prev.text.startsWith('/**')) {
+    return commentFirstLine(prev.text);
+  }
+  return null;
+}
+
+/** Method count of a class/object body, including companion-object functions. */
+function ktCountMethods(body: Node | null | undefined): number {
+  let count = 0;
+  for (const child of body?.namedChildren ?? []) {
+    if (!child) continue;
+    if (child.type === 'function_declaration') count++;
+    else if (child.type === 'companion_object') {
+      count += ktCountMethods(child.namedChildren.find((c) => c?.type === 'class_body'));
+    }
+  }
+  return count;
+}
+
+function extractKotlin(root: Node): ExtractionResult {
+  const out = emptyResult();
+
+  let seenCode = false;
+  for (const child of root.namedChildren) {
+    if (!child) continue;
+    switch (child.type) {
+      case 'multiline_comment':
+        if (!seenCode && out.fileDoc === null && child.text.startsWith('/**')) {
+          out.fileDoc = commentFirstLine(child.text);
+        }
+        continue;
+      case 'line_comment':
+        continue;
+      case 'package_header':
+        break;
+      case 'import_list': {
+        for (const header of child.namedChildren) {
+          if (header?.type !== 'import_header') continue;
+          // `identifier` is the dotted path; a trailing `.*` (wildcard_import)
+          // and `as` aliases sit outside it, so they are stripped for free.
+          const path = header.namedChildren.find((c) => c?.type === 'identifier');
+          if (path) out.imports.push(path.text.replace(/\s/g, ''));
+        }
+        break;
+      }
+      case 'class_declaration': {
+        const name = child.namedChildren.find((c) => c?.type === 'type_identifier')?.text;
+        if (!name) break;
+        const pub = ktIsPublic(child);
+        const doc = ktPrecedingDoc(child);
+        const body = child.namedChildren.find((c) => c?.type === 'class_body');
+        if (ktHasToken(child, 'interface')) {
+          out.topLevelDeclarations.push(`interface ${name}`);
+          out.classes.push({
+            name,
+            kind: 'interface',
+            methodCount: ktCountMethods(body),
+            doc,
+            exported: pub,
+          });
+        } else if (ktHasToken(child, 'enum')) {
+          out.topLevelDeclarations.push(`enum class ${name}`);
+          out.typeNames.push(name);
+        } else {
+          const kind = ktHasClassModifier(child, 'data') ? 'data class' : 'class';
+          out.topLevelDeclarations.push(`${kind} ${name}`);
+          out.classes.push({ name, kind, methodCount: ktCountMethods(body), doc, exported: pub });
+        }
+        if (pub) out.exports.push(name);
+        break;
+      }
+      case 'object_declaration': {
+        const name = child.namedChildren.find((c) => c?.type === 'type_identifier')?.text;
+        if (name) {
+          const pub = ktIsPublic(child);
+          const body = child.namedChildren.find((c) => c?.type === 'class_body');
+          out.topLevelDeclarations.push(`object ${name}`);
+          out.classes.push({
+            name,
+            kind: 'object',
+            methodCount: ktCountMethods(body),
+            doc: ktPrecedingDoc(child),
+            exported: pub,
+          });
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'function_declaration': {
+        const name = child.namedChildren.find((c) => c?.type === 'simple_identifier')?.text;
+        if (name) {
+          const pub = ktIsPublic(child);
+          out.topLevelDeclarations.push(`fun ${name}`);
+          out.functions.push({ name, doc: ktPrecedingDoc(child), exported: pub });
+          if (pub) out.exports.push(name);
+        }
+        break;
+      }
+      case 'property_declaration': {
+        const kind =
+          child.namedChildren.find((c) => c?.type === 'binding_pattern_kind')?.text ?? 'val';
+        const decl = child.namedChildren.find((c) => c?.type === 'variable_declaration');
+        const name = decl?.namedChildren.find((c) => c?.type === 'simple_identifier')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`${kind} ${name}`);
+          if (kind === 'val') out.constNames.push(name);
+          if (ktIsPublic(child)) out.exports.push(name);
+        }
+        break;
+      }
+      case 'type_alias': {
+        const name = child.namedChildren.find((c) => c?.type === 'type_identifier')?.text;
+        if (name) {
+          out.topLevelDeclarations.push(`typealias ${name}`);
+          out.typeNames.push(name);
+          if (ktIsPublic(child)) out.exports.push(name);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    seenCode = true;
+  }
+
+  return dedupeResult(out);
+}
+
+// ---------------------------------------------------------------------------
+// Java extraction
+// ---------------------------------------------------------------------------
+
+/** Javadoc block immediately preceding `node`. */
+function javaPrecedingDoc(node: Node): string | null {
+  const prev = node.previousNamedSibling;
+  if (prev && prev.type === 'block_comment' && prev.text.startsWith('/**')) {
+    return commentFirstLine(prev.text);
+  }
+  return null;
+}
+
+/** Java modifiers (`public`, `static`, …) are anonymous tokens under `modifiers`. */
+function javaHasModifier(node: Node, modifier: string): boolean {
+  const mods = node.namedChildren.find((c) => c?.type === 'modifiers');
+  return (mods?.children ?? []).some((c) => c !== null && c.type === modifier);
+}
+
+/**
+ * Collect the public members of a top-level type into `out.exports` (when the
+ * type itself is public) and return its method count. Interface members are
+ * implicitly public. A `static main` method is recorded as a function so the
+ * purpose generator can mark the file as an entry point.
+ */
+function javaCollectMembers(
+  typeNode: Node,
+  kind: string,
+  typePublic: boolean,
+  out: ExtractionResult,
+): number {
+  const body = typeNode.childForFieldName('body');
+  let methods = 0;
+  for (const member of body?.namedChildren ?? []) {
+    if (!member) continue;
+    if (member.type === 'method_declaration') {
+      methods++;
+      const name = member.childForFieldName('name')?.text;
+      if (!name) continue;
+      const memberPublic = kind === 'interface' || javaHasModifier(member, 'public');
+      if (name === 'main' && javaHasModifier(member, 'static')) {
+        out.functions.push({ name, doc: null, exported: memberPublic });
+      }
+      if (typePublic && memberPublic) out.exports.push(name);
+    } else if (member.type === 'field_declaration') {
+      if (!typePublic) continue;
+      if (kind !== 'interface' && !javaHasModifier(member, 'public')) continue;
+      for (const decl of member.namedChildren) {
+        if (decl?.type !== 'variable_declarator') continue;
+        const name = decl.childForFieldName('name')?.text;
+        if (!name) continue;
+        out.exports.push(name);
+        if (/^[A-Z0-9_]+$/.test(name)) out.constNames.push(name);
+      }
+    }
+  }
+  return methods;
+}
+
+function extractJava(root: Node): ExtractionResult {
+  const out = emptyResult();
+
+  let seenCode = false;
+  for (const child of root.namedChildren) {
+    if (!child) continue;
+    switch (child.type) {
+      case 'block_comment':
+        if (!seenCode && out.fileDoc === null && child.text.startsWith('/**')) {
+          out.fileDoc = commentFirstLine(child.text);
+        }
+        continue;
+      case 'line_comment':
+        continue;
+      case 'package_declaration':
+        break;
+      case 'import_declaration': {
+        // The dotted path; a trailing `.*` is a separate `asterisk` node, so
+        // wildcard imports already arrive stripped.
+        const path = child.namedChildren.find(
+          (c) => c?.type === 'scoped_identifier' || c?.type === 'identifier',
+        );
+        if (path) out.imports.push(path.text.replace(/\s/g, ''));
+        break;
+      }
+      case 'class_declaration':
+      case 'interface_declaration':
+      case 'record_declaration': {
+        const name = child.childForFieldName('name')?.text;
+        if (!name) break;
+        const kind =
+          child.type === 'class_declaration'
+            ? 'class'
+            : child.type === 'interface_declaration'
+              ? 'interface'
+              : 'record';
+        const pub = javaHasModifier(child, 'public');
+        out.topLevelDeclarations.push(`${kind} ${name}`);
+        const methodCount = javaCollectMembers(child, kind, pub, out);
+        out.classes.push({ name, kind, methodCount, doc: javaPrecedingDoc(child), exported: pub });
+        if (pub) out.exports.push(name);
+        break;
+      }
+      case 'enum_declaration':
+      case 'annotation_type_declaration': {
+        const name = child.childForFieldName('name')?.text;
+        if (name) {
+          const kind = child.type === 'enum_declaration' ? 'enum' : 'annotation';
+          out.topLevelDeclarations.push(`${kind} ${name}`);
+          out.typeNames.push(name);
+          if (javaHasModifier(child, 'public')) out.exports.push(name);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    seenCode = true;
+  }
+
+  return dedupeResult(out);
+}
+
 function extract(root: Node, grammar: GrammarName): ExtractionResult {
   switch (grammar) {
     case 'python':
@@ -845,6 +1146,10 @@ function extract(root: Node, grammar: GrammarName): ExtractionResult {
       return extractGo(root);
     case 'rust':
       return extractRust(root);
+    case 'kotlin':
+      return extractKotlin(root);
+    case 'java':
+      return extractJava(root);
     default:
       return extractTsJs(root);
   }
@@ -884,6 +1189,18 @@ function fileCategory(filePath: string, contents: string): string | null {
       return 'entry point';
     }
     if (basename === 'build.rs') return 'config';
+    return null;
+  }
+
+  if (ext === '.kt' || ext === '.kts') {
+    if (/Test\.kts?$/.test(basename) || inTestsDir || dir.includes('/androidTest/')) return 'test';
+    if (basename.endsWith('.gradle.kts')) return 'config';
+    if (basename === 'Main.kt') return 'entry point';
+    return null;
+  }
+  if (ext === '.java') {
+    if (/Tests?\.java$/.test(basename) || inTestsDir) return 'test';
+    if (basename === 'Main.java') return 'entry point';
     return null;
   }
 
@@ -958,9 +1275,9 @@ function buildPurpose(filePath: string, contents: string, info: ExtractionResult
 // ---------------------------------------------------------------------------
 
 /**
- * Summarize a TS/JS, Python, Go or Rust file from its syntax tree. Falls back
- * to the regex summarizer for unsupported extensions, empty files, parse
- * errors, or when the WASM runtime cannot be loaded.
+ * Summarize a TS/JS, Python, Go, Rust, Kotlin or Java file from its syntax
+ * tree. Falls back to the regex summarizer for unsupported extensions, empty
+ * files, parse errors, or when the WASM runtime cannot be loaded.
  */
 export async function summarizeFileAst(filePath: string, contents: string): Promise<FileSummary> {
   const grammar = EXT_TO_GRAMMAR[getExtension(filePath)];

--- a/src/indexer/imports.ts
+++ b/src/indexer/imports.ts
@@ -447,6 +447,90 @@ export function extractRustImports(
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Kotlin / Java parsers
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Strip C-style comments and string literals (shared by Kotlin and Java) so
+ * import regexes don't match inside them. Preserves line structure.
+ */
+function stripCStyleNonCode(contents: string): string {
+  let result = contents;
+
+  // Remove block comments (incl. KDoc/Javadoc)
+  result = result.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+  // Remove triple-quoted (Kotlin raw) strings, then regular strings
+  result = result.replace(/"""[\s\S]*?"""/g, (m) => m.replace(/[^\n]/g, ' '));
+  result = result.replace(/"(?:[^"\\\n]|\\.)*"/g, (m) => ' '.repeat(m.length));
+
+  // Remove line comments
+  result = result.replace(/\/\/.*/g, (m) => ' '.repeat(m.length));
+
+  return result;
+}
+
+export function extractKotlinImports(
+  filePath: string,
+  contents: string,
+  _projectRoot: string,
+): ImportRef[] {
+  const results: ImportRef[] = [];
+  const source = filePath;
+  const cleaned = stripCStyleNonCode(contents);
+
+  // import a.b.C / import a.b.* / import a.b.C as D (optional semicolon)
+  const importRe = /^[ \t]*import\s+([\w.]+?)(\.\*)?(?:\s+as\s+(\w+))?\s*;?\s*$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = importRe.exec(cleaned)) !== null) {
+    results.push({
+      source,
+      target: match[1].replace(/\./g, '/'),
+      specifiers: match[2] ? ['*'] : match[3] ? [match[3]] : [],
+      type: 'static',
+    });
+  }
+
+  return results;
+}
+
+export function extractJavaImports(
+  filePath: string,
+  contents: string,
+  _projectRoot: string,
+): ImportRef[] {
+  const results: ImportRef[] = [];
+  const source = filePath;
+  const cleaned = stripCStyleNonCode(contents);
+
+  // import a.b.C; / import a.b.*; / import static a.b.Type.member;
+  const importRe = /^[ \t]*import\s+(static\s+)?([\w.]+?)(\.\*)?\s*;/gm;
+  let match: RegExpExecArray | null;
+  while ((match = importRe.exec(cleaned)) !== null) {
+    const isStatic = Boolean(match[1]);
+    const isWildcard = Boolean(match[3]);
+    let path = match[2];
+    let specifiers: string[] = isWildcard ? ['*'] : [];
+    if (isStatic && !isWildcard) {
+      // `import static a.b.Type.member` — the file-level target is the type.
+      const lastDot = path.lastIndexOf('.');
+      if (lastDot !== -1) {
+        specifiers = [path.slice(lastDot + 1)];
+        path = path.slice(0, lastDot);
+      }
+    }
+    results.push({
+      source,
+      target: path.replace(/\./g, '/'),
+      specifiers,
+      type: 'static',
+    });
+  }
+
+  return results;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Dispatcher
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -470,6 +554,11 @@ export function extractImports(
       return extractGoImports(filePath, contents, projectRoot);
     case '.rs':
       return extractRustImports(filePath, contents, projectRoot);
+    case '.kt':
+    case '.kts':
+      return extractKotlinImports(filePath, contents, projectRoot);
+    case '.java':
+      return extractJavaImports(filePath, contents, projectRoot);
     default:
       return extractJsTsImports(filePath, contents, projectRoot);
   }

--- a/src/indexer/summarize.ts
+++ b/src/indexer/summarize.ts
@@ -18,8 +18,12 @@ export type SummarizerMode = 'regex' | 'ast';
  * Generation 2: the AST summarizer gained Python/Go/Rust support, so summaries
  * for those languages cached under ast mode (which were regex-produced
  * fallbacks at generation 1) must lazily regenerate.
+ *
+ * Generation 3: the AST summarizer gained Kotlin/Java support, so summaries
+ * for those languages cached under ast mode (regex-produced generic
+ * classifications at earlier generations) must lazily regenerate.
  */
-const SUMMARIZER_GENERATION = 2;
+const SUMMARIZER_GENERATION = 3;
 
 const META_KEY = 'summarizer_generation';
 
@@ -57,9 +61,10 @@ export function ensureSummaryGeneration(projectRoot: string): void {
   const stored = store.getMeta(META_KEY);
   if (stored !== tag) {
     // Regex output is unchanged since generation 1, so summaries produced by
-    // regex generation 1 — including pre-marker databases, which carried no
-    // tag — are still valid under regex generation 2 and only need re-tagging.
-    const stillValid = tag === 'regex:2' && (stored === null || stored === 'regex:1');
+    // any earlier regex generation — including pre-marker databases, which
+    // carried no tag — are still valid under regex generation 3 and only need
+    // re-tagging.
+    const stillValid = tag === 'regex:3' && (stored === null || /^regex:[12]$/.test(stored));
     if (!stillValid) {
       store.clearAllSummaries();
     }

--- a/src/tools/get-related-files.ts
+++ b/src/tools/get-related-files.ts
@@ -37,7 +37,10 @@ export async function getRelatedFiles(
       !file.endsWith('.cjs') &&
       !file.endsWith('.py') &&
       !file.endsWith('.go') &&
-      !file.endsWith('.rs')
+      !file.endsWith('.rs') &&
+      !file.endsWith('.kt') &&
+      !file.endsWith('.kts') &&
+      !file.endsWith('.java')
     ) {
       continue;
     }

--- a/tests/unit/ast-summarizer-java.test.ts
+++ b/tests/unit/ast-summarizer-java.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst — Java', () => {
+  it('reports .java files as AST-supported', () => {
+    expect(isAstSupported('src/main/java/com/example/Arrow.java')).toBe(true);
+  });
+
+  describe('exports', () => {
+    it('exports public types and the public members of the public type', async () => {
+      const contents = [
+        'package com.example.game;',
+        '',
+        'public class Arrow {',
+        '    public static final int MAX_ARROWS = 6;',
+        '    private int x;',
+        '    public int y;',
+        '',
+        '    public Arrow(int x) {',
+        '        this.x = x;',
+        '    }',
+        '',
+        '    public double distance() {',
+        '        return 0.0;',
+        '    }',
+        '',
+        '    private void secret() {',
+        '    }',
+        '',
+        '    static int packageVisible() {',
+        '        return 1;',
+        '    }',
+        '}',
+        '',
+        'class Helper {',
+        '    public void help() {',
+        '    }',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/Arrow.java', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining(['Arrow', 'MAX_ARROWS', 'y', 'distance']),
+      );
+      expect(summary.exports).not.toContain('x');
+      expect(summary.exports).not.toContain('secret');
+      expect(summary.exports).not.toContain('packageVisible');
+      // Helper is package-private: neither the type nor its members are exported.
+      expect(summary.exports).not.toContain('Helper');
+      expect(summary.exports).not.toContain('help');
+    });
+
+    it('exports public interfaces, enums and records', async () => {
+      const contents = [
+        'package com.example;',
+        '',
+        'public interface Scorer {',
+        '    int score(int value);',
+        '}',
+        '',
+        'enum Color { RED, GOLD }',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/Scorer.java', contents);
+      // Interface members are implicitly public.
+      expect(summary.exports).toEqual(expect.arrayContaining(['Scorer', 'score']));
+      expect(summary.exports).not.toContain('Color'); // package-private
+
+      const record = await summarizeFileAst(
+        'src/main/java/Point.java',
+        [
+          'package com.example;',
+          '',
+          'public record Point(int x, int y) {',
+          '    public double norm() {',
+          '        return 0;',
+          '    }',
+          '}',
+        ].join('\n'),
+      );
+      expect(record.exports).toEqual(expect.arrayContaining(['Point', 'norm']));
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts plain, wildcard and static imports', async () => {
+      const contents = [
+        'package com.example.app;',
+        '',
+        'import java.util.List;',
+        'import java.util.*;',
+        'import static java.lang.Math.max;',
+        '',
+        'public class App {',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/App.java', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining(['java.util.List', 'java.util', 'java.lang.Math.max']),
+      );
+    });
+  });
+
+  describe('declarations', () => {
+    it('records classes, interfaces, enums and records with their kinds', async () => {
+      const contents = [
+        'package com.example.decls;',
+        '',
+        'public class Widget {',
+        '}',
+        '',
+        'interface Renderer {',
+        '}',
+        '',
+        'enum Mode { ON, OFF }',
+        '',
+        'record Pair(int a, int b) {',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/Widget.java', contents);
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining(['class Widget', 'interface Renderer', 'enum Mode', 'record Pair']),
+      );
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes a class with methods using its Javadoc first sentence', async () => {
+      const contents = [
+        'package com.example.game;',
+        '',
+        'import java.util.List;',
+        '',
+        '/**',
+        ' * An arrow fired at a target. Tracks position.',
+        ' */',
+        'public class Arrow {',
+        '    public double distance() {',
+        '        return 0.0;',
+        '    }',
+        '',
+        '    public int ring() {',
+        '        return 1;',
+        '    }',
+        '',
+        '    private void reset() {',
+        '    }',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/Arrow.java', contents);
+      expect(summary.purpose).toBe('class Arrow (3 methods): An arrow fired at a target.');
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('describes an interface with its Javadoc', async () => {
+      const contents = [
+        'package com.example;',
+        '',
+        '/** Scores a single end. */',
+        'public interface Scorer {',
+        '    int score(int value);',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/java/Scorer.java', contents);
+      expect(summary.purpose).toBe('interface Scorer (1 method): Scores a single end.');
+    });
+
+    it('marks test files and static-main entry points', async () => {
+      const test = await summarizeFileAst(
+        'src/test/java/com/example/ArrowTest.java',
+        'package com.example;\n\npublic class ArrowTest {\n}\n',
+      );
+      expect(test.purpose.startsWith('test')).toBe(true);
+
+      const main = await summarizeFileAst(
+        'src/main/java/com/example/Launcher.java',
+        [
+          'package com.example;',
+          '',
+          'public class Launcher {',
+          '    public static void main(String[] args) {',
+          '    }',
+          '}',
+        ].join('\n'),
+      );
+      expect(main.purpose.startsWith('entry point')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'public class Broken {{{ void (\n';
+      const astResult = await summarizeFileAst('src/main/java/Broken.java', broken);
+      const regexResult = summarizeFile('src/main/java/Broken.java', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('src/main/java/Empty.java', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+});

--- a/tests/unit/ast-summarizer-kotlin.test.ts
+++ b/tests/unit/ast-summarizer-kotlin.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeFileAst, isAstSupported } from '../../src/indexer/ast-summarizer.js';
+import { summarizeFile } from '../../src/indexer/summarizer.js';
+
+describe('summarizeFileAst — Kotlin', () => {
+  it('reports .kt and .kts files as AST-supported', () => {
+    expect(isAstSupported('app/src/main/kotlin/com/example/Scoring.kt')).toBe(true);
+    expect(isAstSupported('scripts/deploy.kts')).toBe(true);
+  });
+
+  describe('exports', () => {
+    it('exports public top-level declarations and excludes private/internal ones', async () => {
+      const contents = [
+        'package com.example.game',
+        '',
+        'class Visible {',
+        '    fun show() {',
+        '    }',
+        '}',
+        '',
+        'private class Hidden',
+        '',
+        'internal class AlsoHidden',
+        '',
+        'fun computeScore(): Int = 0',
+        '',
+        'private fun helper() {',
+        '}',
+        '',
+        'internal fun internalHelper() {',
+        '}',
+        '',
+        'val MAX_ARROWS = 6',
+        '',
+        'private val secretVal = 1',
+        '',
+        'var counter = 0',
+        '',
+        'typealias ArrowList = List<Int>',
+        '',
+        'private typealias Secret = Int',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Scoring.kt', contents);
+      expect(summary.exports).toEqual(
+        expect.arrayContaining(['Visible', 'computeScore', 'MAX_ARROWS', 'counter', 'ArrowList']),
+      );
+      expect(summary.exports).not.toContain('Hidden');
+      expect(summary.exports).not.toContain('AlsoHidden');
+      expect(summary.exports).not.toContain('helper');
+      expect(summary.exports).not.toContain('internalHelper');
+      expect(summary.exports).not.toContain('secretVal');
+      expect(summary.exports).not.toContain('Secret');
+    });
+
+    it('exports objects, interfaces and enum classes', async () => {
+      const contents = [
+        'package com.example',
+        '',
+        'object Registry {',
+        '    fun lookup(name: String): Int = 0',
+        '}',
+        '',
+        'interface Scorer {',
+        '    fun score(value: Int): Int',
+        '}',
+        '',
+        'enum class Color { RED, GOLD }',
+        '',
+        'private object SecretRegistry',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Registry.kt', contents);
+      expect(summary.exports).toEqual(expect.arrayContaining(['Registry', 'Scorer', 'Color']));
+      expect(summary.exports).not.toContain('SecretRegistry');
+    });
+  });
+
+  describe('imports', () => {
+    it('extracts dotted import paths, stripping wildcards and aliases', async () => {
+      const contents = [
+        'package com.example.app',
+        '',
+        'import kotlin.math.max',
+        'import com.example.util.*',
+        'import com.example.io.Reader as R',
+        '',
+        'fun run() {',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/App.kt', contents);
+      expect(summary.imports).toEqual(
+        expect.arrayContaining(['kotlin.math.max', 'com.example.util', 'com.example.io.Reader']),
+      );
+    });
+  });
+
+  describe('declarations', () => {
+    it('records classes, objects, functions, properties and typealiases with their kinds', async () => {
+      const contents = [
+        'package com.example.decls',
+        '',
+        'data class Arrow(val x: Int, val y: Int)',
+        '',
+        'class Plain',
+        '',
+        'interface Scorer',
+        '',
+        'enum class Color { RED }',
+        '',
+        'object Registry',
+        '',
+        'fun run() {',
+        '}',
+        '',
+        'val limit = 5',
+        '',
+        'var count = 0',
+        '',
+        'typealias Ids = List<Int>',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Decls.kt', contents);
+      expect(summary.topLevelDeclarations).toEqual(
+        expect.arrayContaining([
+          'data class Arrow',
+          'class Plain',
+          'interface Scorer',
+          'enum class Color',
+          'object Registry',
+          'fun run',
+          'val limit',
+          'var count',
+          'typealias Ids',
+        ]),
+      );
+    });
+  });
+
+  describe('purpose generation', () => {
+    it('describes a data class with methods using its KDoc first sentence', async () => {
+      const contents = [
+        'package com.example.game',
+        '',
+        'import kotlin.math.max',
+        '',
+        '/**',
+        ' * An arrow fired at a target. Tracks position.',
+        ' */',
+        'data class Arrow(val x: Int, val y: Int) {',
+        '    fun distance(): Double = 0.0',
+        '    fun ring(): Int = 1',
+        '    fun score(): Int = max(0, ring())',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Arrow.kt', contents);
+      expect(summary.purpose).toBe('data class Arrow (3 methods): An arrow fired at a target.');
+      expect(summary.confidence).toBe('high');
+    });
+
+    it('counts companion-object functions as methods', async () => {
+      const contents = [
+        'package com.example.game',
+        '',
+        'class Arrow {',
+        '    fun distance(): Double = 0.0',
+        '    companion object {',
+        '        fun fromString(s: String): Arrow = Arrow()',
+        '    }',
+        '}',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Arrow.kt', contents);
+      expect(summary.purpose).toBe('class Arrow (2 methods)');
+    });
+
+    it('describes function files with names and KDoc first sentence', async () => {
+      const contents = [
+        'package com.example.game',
+        '',
+        '/** Computes the score of an end. Higher is better. */',
+        'fun computeScore(arrows: List<Int>): Int = arrows.size',
+        '',
+        '/** Formats an end for display. */',
+        'fun formatEnd(arrows: List<Int>): String = ""',
+      ].join('\n');
+      const summary = await summarizeFileAst('src/main/kotlin/Score.kt', contents);
+      expect(summary.purpose).toBe(
+        'functions: computeScore, formatEnd — Computes the score of an end.',
+      );
+    });
+
+    it('marks test files and main entry points', async () => {
+      const test = await summarizeFileAst(
+        'app/src/test/kotlin/com/example/ScoringTest.kt',
+        'package com.example\n\nclass ScoringTest {\n    fun testScore() {\n    }\n}\n',
+      );
+      expect(test.purpose.startsWith('test')).toBe(true);
+
+      const main = await summarizeFileAst(
+        'app/src/main/kotlin/com/example/App.kt',
+        'package com.example\n\nfun main() {\n}\n',
+      );
+      expect(main.purpose.startsWith('entry point')).toBe(true);
+    });
+
+    it('classifies Gradle Kotlin scripts as config', async () => {
+      const summary = await summarizeFileAst(
+        'build.gradle.kts',
+        'plugins {\n    kotlin("jvm")\n}\n',
+      );
+      expect(summary.purpose.startsWith('config')).toBe(true);
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to the regex summarizer on parse errors', async () => {
+      const broken = 'package x\n\nfun broken( {{{\n';
+      const astResult = await summarizeFileAst('src/main/kotlin/Broken.kt', broken);
+      const regexResult = summarizeFile('src/main/kotlin/Broken.kt', broken);
+      expect(astResult).toEqual(regexResult);
+    });
+
+    it('delegates empty files to the regex summarizer', async () => {
+      const summary = await summarizeFileAst('src/main/kotlin/Empty.kt', '');
+      expect(summary.lineCount).toBe(0);
+      expect(summary.confidence).toBe('low');
+    });
+  });
+});

--- a/tests/unit/imports-java.test.ts
+++ b/tests/unit/imports-java.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { extractImports } from '../../src/indexer/imports.js';
+
+describe('extractImports — Java', () => {
+  const projectRoot = '/project';
+
+  it('extracts simple import', () => {
+    const contents = `package com.example;
+
+import java.util.List;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/java/App.java',
+        target: 'java/util/List',
+        specifiers: [],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts wildcard import with * specifier', () => {
+    const contents = `package com.example;
+
+import java.util.*;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/java/App.java',
+        target: 'java/util',
+        specifiers: ['*'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts static import with the member as specifier', () => {
+    const contents = `package com.example;
+
+import static java.lang.Math.max;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/java/App.java',
+        target: 'java/lang/Math',
+        specifiers: ['max'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts static wildcard import', () => {
+    const contents = `package com.example;
+
+import static java.lang.Math.*;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/java/App.java',
+        target: 'java/lang/Math',
+        specifiers: ['*'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts multiple imports in order', () => {
+    const contents = `package com.example;
+
+import java.util.List;
+import java.util.Map;
+import com.example.game.Arrow;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result.map((r) => r.target)).toEqual([
+      'java/util/List',
+      'java/util/Map',
+      'com/example/game/Arrow',
+    ]);
+  });
+
+  it('skips imports inside line comments', () => {
+    const contents = `package com.example;
+
+// import java.util.Unused;
+import java.util.List;`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0].target).toBe('java/util/List');
+  });
+
+  it('skips imports inside block comments and strings', () => {
+    const contents = `package com.example;
+
+/*
+import java.util.Unused;
+*/
+import java.util.List;
+
+class App {
+  String s = "import java.util.AlsoUnused;";
+}`;
+    const result = extractImports('src/main/java/App.java', contents, projectRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0].target).toBe('java/util/List');
+  });
+});

--- a/tests/unit/imports-kotlin.test.ts
+++ b/tests/unit/imports-kotlin.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { extractImports } from '../../src/indexer/imports.js';
+
+describe('extractImports — Kotlin', () => {
+  const projectRoot = '/project';
+
+  it('extracts simple dotted import', () => {
+    const contents = `package com.example
+
+import kotlin.math.max`;
+    const result = extractImports('src/main/kotlin/App.kt', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/kotlin/App.kt',
+        target: 'kotlin/math/max',
+        specifiers: [],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts wildcard import with * specifier', () => {
+    const contents = `package com.example
+
+import com.example.util.*`;
+    const result = extractImports('src/main/kotlin/App.kt', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/kotlin/App.kt',
+        target: 'com/example/util',
+        specifiers: ['*'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts aliased import with the alias as specifier', () => {
+    const contents = `package com.example
+
+import com.example.io.Reader as R`;
+    const result = extractImports('src/main/kotlin/App.kt', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/main/kotlin/App.kt',
+        target: 'com/example/io/Reader',
+        specifiers: ['R'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('extracts multiple imports and handles .kts files', () => {
+    const contents = `import java.io.File
+import kotlin.text.Regex
+
+val f = File("x")`;
+    const result = extractImports('scripts/deploy.kts', contents, projectRoot);
+    expect(result.map((r) => r.target)).toEqual(['java/io/File', 'kotlin/text/Regex']);
+  });
+
+  it('skips imports inside line comments', () => {
+    const contents = `package com.example
+
+// import com.example.Unused
+import kotlin.math.max`;
+    const result = extractImports('src/main/kotlin/App.kt', contents, projectRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0].target).toBe('kotlin/math/max');
+  });
+
+  it('skips imports inside block comments and strings', () => {
+    const contents = `package com.example
+
+/*
+import com.example.Unused
+*/
+import kotlin.math.max
+
+val s = """
+import com.example.AlsoUnused
+"""`;
+    const result = extractImports('src/main/kotlin/App.kt', contents, projectRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0].target).toBe('kotlin/math/max');
+  });
+});

--- a/tests/unit/summarize.test.ts
+++ b/tests/unit/summarize.test.ts
@@ -72,7 +72,7 @@ describe('summarizeForProject', () => {
 
     // Hashes were preserved, only summaries were dropped.
     const store = new CacheStore(tempDir);
-    expect(store.getMeta('summarizer_generation')).toBe('ast:2');
+    expect(store.getMeta('summarizer_generation')).toBe('ast:3');
   });
 
   it('does not wipe summaries when the mode is unchanged', async () => {


### PR DESCRIPTION
## Summary
Adds Kotlin (.kt/.kts) and Java (.java) to the AST summarizer. Unlike prior languages, the regex engine has no Kotlin/Java support — these were generic filename-classified before, so AST mode is the first real extraction for them.

- Kotlin: public-API surface (private/internal excluded), KDoc purposes, companion objects counted; Java: public types/members, Javadoc purposes, `static main` → entry point
- imports.ts gains Kotlin/Java import extraction (regex, matching existing per-language style) so the dependency graph and get_related_files cover both
- kotlin + java grammar wasms vendored (8 total); tarball 573 kB → 1.2 MB compressed
- SUMMARIZER_GENERATION → 3 (regex-mode caches re-tagged, not wiped)

## Testing
- 35 new tests (Kotlin AST 12, Java AST 10, Kotlin imports 6, Java imports 7); 453 unit + 7 integration pass; typecheck/lint/build clean
- Both grammars verified loading under web-tree-sitter 0.25.x; sanity-ran built dist against real .kt/.java files

## Known limitation
The Kotlin grammar rejects single-line class bodies (falls back to generic classification); documented in the spike doc.