### PR TITLE
docs: post-merge hook snippet for automated cache prewarming

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ repo-memory index --quiet    # no output on success (for scripts/CI)
 
 Only missing or stale entries are re-summarized; unchanged files are left untouched.
 
+To automate it, drop a git `post-merge` hook in the project (see [docs/usage.md](docs/usage.md#cli) for the snippet) so every pull keeps the cache warm.
+
 ## How It Works
 
 ### The problem

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,16 @@ Indexed /path/to/project
 
 Exits `0` on success, `1` on error (message on stderr).
 
+To keep the cache warm automatically, run it from a git `post-merge` hook so every pull/merge re-indexes only what changed:
+
+```sh
+#!/bin/sh
+# .git/hooks/post-merge (chmod +x)
+(npx -y @blamechris/repo-memory index . --quiet >/dev/null 2>&1 &)
+```
+
+The subshell-and-background form keeps pulls fast; with `--quiet` the run is silent. Note `post-merge` does not fire on rebase pulls (`git pull --rebase`).
+
 ## Tools Reference
 
 ### `get_file_summary`


### PR DESCRIPTION
Documents the recommended git post-merge hook (backgrounded npx index --quiet) in the usage CLI section, linked from the README prewarm subsection. Notes the rebase-pull caveat.