### PR TITLE
feat(indexer): make AST the default summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Create a `.repo-memory.json` in your project root to customize behavior:
 }
 ```
 
-`summarizer` selects the summary engine: `"regex"` (default) or `"ast"`. AST mode parses supported languages (see [Language Support](#language-support)) with tree-sitter, producing accurate exports/declarations and a semantic `purpose` line that names the dominant symbols (e.g. `class CacheStore (9 methods)` instead of `source`) — which is what `search_by_purpose` matches against. Other languages, unsupported extensions, and files with parse errors fall back to the regex summarizer automatically. Switching modes regenerates summaries lazily on next access.
+`summarizer` selects the summary engine: `"ast"` (default) or `"regex"`. AST mode parses supported languages (see [Language Support](#language-support)) with tree-sitter, producing accurate exports/declarations and a semantic `purpose` line that names the dominant symbols (e.g. `class CacheStore (9 methods)` instead of `source`) — which is what `search_by_purpose` matches against. Other languages, unsupported extensions, and files with parse errors fall back to the regex summarizer automatically. Switching modes regenerates summaries lazily on next access.
 
 The `tools` block toggles tool groups. `navigation` and `summaries` are **on by default** (set `"summaries": false` to drop the summary tools); `tasks` and `telemetry` are **off by default** (set them to `true` to enable).
 

--- a/docs/planning/ast-summarizer-spike.md
+++ b/docs/planning/ast-summarizer-spike.md
@@ -2,7 +2,7 @@
 
 **Status:** complete — recommendation at the bottom.
 **Scope:** TypeScript/JavaScript (`.ts/.tsx/.js/.jsx/.mjs/.cjs`). Python/Go/Rust stay on the regex summarizer.
-**Code:** `src/indexer/ast-summarizer.ts` (engine), `src/indexer/summarize.ts` (config dispatch + cache generation), `summarizer: 'regex' | 'ast'` in `.repo-memory.json` (default `'regex'`).
+**Code:** `src/indexer/ast-summarizer.ts` (engine), `src/indexer/summarize.ts` (config dispatch + cache generation), `summarizer: 'regex' | 'ast'` in `.repo-memory.json` (default `'ast'` since 0.12.0; was `'regex'` during the opt-in phase).
 
 ## Hypothesis
 
@@ -142,8 +142,11 @@ Suggested rollout:
    devDependency when running from `src/` (dev/vitest). Cuts the runtime
    footprint from ~55 MB to ~11 MB unpacked; the tarball grows from ~72 kB to
    ~573 kB compressed (~5.7 MB unpacked).
-3. Flip the default to `ast` for TS/JS after a release of soak time; the
-   generation tag handles the cache migration automatically.
+3. **Done.** Flip the default to `ast`; the generation tag handles the cache
+   migration automatically (config-less projects lazily regenerate on first
+   access). Validated on real codebases first: ~86% of 860 cached Kotlin files
+   in a production Android app received semantic AST purposes, zero parse-crash
+   incidents across ~3,000 files in four projects.
 4. **Done.** Extend to Python/Go/Rust: per-language extraction visitors in
    `ast-summarizer.ts` (exports, imports, declarations, doc-comment purpose
    lines), with the three grammar wasms vendored alongside the TS/JS ones.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ Returns a cached summary of a file. If the file has not changed since last read,
 **Notes:**
 - `suggestFullRead` is `true` when the summary confidence is `"low"`, indicating the agent should read the full file for accuracy.
 - `cacheAge` is in seconds since last check, or `null` if no prior cache entry exists.
-- Summary quality depends on the `summarizer` setting in `.repo-memory.json`: `"regex"` (default) or `"ast"`. AST mode (TypeScript/JavaScript only for now) yields more accurate exports and a semantic `purpose` line naming the dominant symbols; files that fail to parse fall back to the regex engine automatically. See the README's Configuration section.
+- Summary quality depends on the `summarizer` setting in `.repo-memory.json`: `"ast"` (default) or `"regex"`. AST mode (TS/JS, Python, Go, Rust, Kotlin, Java) yields more accurate exports and a semantic `purpose` line naming the dominant symbols; other languages and files that fail to parse fall back to the regex engine automatically. See the README's Configuration section.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export interface ToolGroupConfig {
 export interface RepoMemoryConfig {
   ignore?: string[];
   maxFiles?: number;
-  /** Summary engine for TS/JS files: 'regex' (default) or 'ast' (tree-sitter). */
+  /** Summary engine: 'ast' (default, tree-sitter) or 'regex'. */
   summarizer?: 'regex' | 'ast';
   gc?: {
     cacheMaxAgeDays?: number;

--- a/src/indexer/summarize.ts
+++ b/src/indexer/summarize.ts
@@ -30,7 +30,7 @@ const META_KEY = 'summarizer_generation';
 const generationChecked = new Map<string, string>();
 
 export function getSummarizerMode(projectRoot: string): SummarizerMode {
-  return loadConfig(projectRoot).summarizer ?? 'regex';
+  return loadConfig(projectRoot).summarizer ?? 'ast';
 }
 
 /** Generate a summary using the summarizer configured for this project. */

--- a/tests/integration/v1-flow.test.ts
+++ b/tests/integration/v1-flow.test.ts
@@ -77,7 +77,7 @@ describe('V1 end-to-end flow', () => {
     // Step 2: Get file summary — cache hit (project map already cached it)
     const summary1 = await getFileSummary(projectDir, 'src/index.ts');
     expect(summary1.fromCache).toBe(true);
-    expect(summary1.summary.purpose).toBe('entry point');
+    expect(summary1.summary.purpose).toBe('entry point: function main'); // AST default
     expect(summary1.summary.exports).toContain('main');
     expect(summary1.summary.imports).toContain('./utils/greet.js');
     expect(summary1.hash).toHaveLength(64);
@@ -137,7 +137,7 @@ describe('V1 end-to-end flow', () => {
     // Step 10: After invalidation, next get_file_summary regenerates
     const summary4 = await getFileSummary(projectDir, 'src/index.ts');
     expect(summary4.fromCache).toBe(false);
-    expect(summary4.summary.purpose).toBe('entry point');
+    expect(summary4.summary.purpose).toBe('entry point: function main'); // AST default
   });
 
   it('detects new and deleted files via get_changed_files', async () => {

--- a/tests/unit/get-file-summary.test.ts
+++ b/tests/unit/get-file-summary.test.ts
@@ -27,7 +27,7 @@ describe('getFileSummary', () => {
     expect(result.path).toBe(filePath);
     expect(result.hash).toBeTypeOf('string');
     expect(result.hash.length).toBe(64); // SHA-256 hex
-    expect(result.summary.purpose).toBe('source');
+    expect(result.summary.purpose).toBe('function hello'); // AST default
     expect(result.summary.exports).toContain('hello');
     expect(result.summary.lineCount).toBe(4);
     expect(result.reason).toBe('cache_miss: no prior entry');

--- a/tests/unit/summarize.test.ts
+++ b/tests/unit/summarize.test.ts
@@ -39,7 +39,14 @@ describe('summarizeForProject', () => {
     clearSummaryGenerationCache();
   });
 
-  it('defaults to the regex summarizer', async () => {
+  it('defaults to the AST summarizer', async () => {
+    expect(getSummarizerMode(tempDir)).toBe('ast');
+    const summary = await summarizeForProject(tempDir, 'src/greet.ts', SAMPLE);
+    expect(summary.purpose).toBe('function greet — Greets people.');
+  });
+
+  it('uses the regex summarizer when configured', async () => {
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'regex' }));
     expect(getSummarizerMode(tempDir)).toBe('regex');
     const summary = await summarizeForProject(tempDir, 'src/greet.ts', SAMPLE);
     expect(summary.purpose).toBe('source');
@@ -54,25 +61,25 @@ describe('summarizeForProject', () => {
   });
 
   it('drops cached summaries when the summarizer mode changes', async () => {
-    // Populate the cache under the default regex mode.
+    // Populate the cache under the default AST mode.
     const first = await getFileSummary(tempDir, 'src/greet.ts');
     expect(first.fromCache).toBe(false);
     const second = await getFileSummary(tempDir, 'src/greet.ts');
     expect(second.fromCache).toBe(true);
-    expect(second.summary.purpose).toBe('source');
+    expect(second.summary.purpose).toBe('function greet — Greets people.');
 
-    // Switch to the AST summarizer.
-    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'ast' }));
+    // Switch to the regex summarizer.
+    writeFileSync(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'regex' }));
     clearConfigCache();
     clearSummaryGenerationCache();
 
     const third = await getFileSummary(tempDir, 'src/greet.ts');
-    expect(third.fromCache).toBe(false); // stale regex summary was invalidated
-    expect(third.summary.purpose).toBe('function greet — Greets people.');
+    expect(third.fromCache).toBe(false); // stale AST summary was invalidated
+    expect(third.summary.purpose).toBe('source');
 
     // Hashes were preserved, only summaries were dropped.
     const store = new CacheStore(tempDir);
-    expect(store.getMeta('summarizer_generation')).toBe('ast:3');
+    expect(store.getMeta('summarizer_generation')).toBe('regex:3');
   });
 
   it('does not wipe summaries when the mode is unchanged', async () => {


### PR DESCRIPTION
## Summary
Flips the `summarizer` default from 'regex' to 'ast'. Regex remains available via `"summarizer": "regex"` and is still the automatic fallback for unsupported languages and parse failures.

Decision data from the opt-in phase: ~86% of 860 cached Kotlin files in a production Android app got semantic AST purposes, zero parse-crash incidents across ~3,000 files in four projects, 0.5 ms/file cost.

Config-less projects migrate lazily via the existing generation tag (summaries regenerate on next access; hashes untouched).

## Testing
- Default/mode-switch tests inverted and extended (explicit-regex case added); v1-flow and get-file-summary assertions updated for AST purposes
- 454 unit + 7 integration pass; typecheck/lint clean