### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
Bump version to 0.12.0:
- AST is now the default summarizer (#157); regex available via `"summarizer": "regex"` and still the automatic fallback

Existing caches migrate lazily on first access (generation tag); no action needed from users.