### PR TITLE
fix(cache): never store a summary under a hash it wasn't computed from

### DIFF
--- a/src/tools/get-changed-files.ts
+++ b/src/tools/get-changed-files.ts
@@ -42,8 +42,12 @@ export async function getChangedFiles(
         }
       }
 
-      // Update the cache entry with current hash and timestamp
-      store.setEntry(relativePath, currentHash, cached?.summary ?? null);
+      // Update the cache entry with current hash and timestamp. A summary may
+      // only be stored under the hash it was computed from — when the file
+      // changed, store null so the summary regenerates on next access instead
+      // of masquerading as a fresh cache hit.
+      const summaryStillValid = cached !== undefined && cached.hash === currentHash;
+      store.setEntry(relativePath, currentHash, summaryStillValid ? cached.summary : null);
     }),
   );
 

--- a/tests/unit/get-changed-files.test.ts
+++ b/tests/unit/get-changed-files.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getChangedFiles } from '../../src/tools/get-changed-files.js';
+import { getFileSummary } from '../../src/tools/get-file-summary.js';
 import { closeDatabase } from '../../src/persistence/db.js';
 
 describe('getChangedFiles', () => {
@@ -67,6 +68,26 @@ describe('getChangedFiles', () => {
 
     expect(result.deleted).toEqual(['b.ts']);
     expect(result.added).toEqual([]);
+  });
+
+  it('never serves a stale summary after a changed file is detected', async () => {
+    writeFileSync(join(tempDir, 'a.ts'), 'export const a = 1;');
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    // Cache a summary for the original content.
+    const original = await getFileSummary(tempDir, 'a.ts');
+    expect(original.summary.exports).toEqual(['a']);
+
+    // Change the file, then run change detection (the post-merge pattern).
+    writeFileSync(join(tempDir, 'a.ts'), 'export const renamed = 2;');
+    const changes = await getChangedFiles(tempDir);
+    expect(changes.changed).toEqual(['a.ts']);
+
+    // The summary must regenerate — a cache hit here would be poisoned data.
+    const after = await getFileSummary(tempDir, 'a.ts');
+    expect(after.fromCache).toBe(false);
+    expect(after.summary.exports).toEqual(['renamed']);
   });
 
   it('should not report unchanged files in any list', async () => {


### PR DESCRIPTION
Closes #161.

`get_changed_files` updated changed files' cache entries with the new hash but the OLD summary, so every subsequent `get_file_summary` reported `cache_hit: hash unchanged` and served stale data — the system's only freshness defense defeated by its own sibling tool (found by the swarm audit, Guardian §1.4).

Fix: store `null` as the summary when the hash changed; it regenerates lazily on next access (hashes preserved, change detection unaffected).

Regression test implements audit invariant I7: change file → get_changed_files → get_file_summary must be a cache_miss with fresh exports.