### PR TITLE
fix(indexer): resolve import targets to real file paths at write time

### DIFF
--- a/src/graph/dependency-graph.ts
+++ b/src/graph/dependency-graph.ts
@@ -59,6 +59,9 @@ export class DependencyGraph {
 
     const insertAll = db.transaction(() => {
       for (const ref of imports) {
+        // External targets (bare modules, builtins, unresolvable paths) are not
+        // repo files — persisting them would pollute traversal and mostConnected.
+        if (ref.external) continue;
         insert.run(ref.source, ref.target, JSON.stringify(ref.specifiers), ref.type);
         this.addEdge(ref.source, ref.target);
       }

--- a/src/indexer/imports.ts
+++ b/src/indexer/imports.ts
@@ -1,4 +1,5 @@
-import { dirname, join, normalize, relative } from 'path';
+import { statSync } from 'fs';
+import { dirname, extname, join, normalize, relative } from 'path';
 import type { ImportRef } from '../types.js';
 import { toPosix } from '../utils/posix-path.js';
 
@@ -7,17 +8,143 @@ function isRelativeImport(specifier: string): boolean {
     specifier.startsWith('./') || specifier.startsWith('../');
 }
 
+interface ResolvedTarget {
+  target: string;
+  external: boolean;
+}
+
+function isFile(absPath: string): boolean {
+  try {
+    return statSync(absPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Extensions probed when a specifier has no extension (TS first — most likely in source). */
+const JS_PROBE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** ESM specifiers reference output extensions; map them back to source extensions. */
+const JS_EXTENSION_SWAPS: Record<string, string[]> = {
+  '.js': ['.ts', '.tsx'],
+  '.jsx': ['.tsx'],
+  '.mjs': ['.mts'],
+  '.cjs': ['.cts'],
+};
+
+/**
+ * Probe the filesystem for the real file behind a JS/TS specifier base path:
+ * exact match, extension swaps (.js → .ts/.tsx, …), appended extensions, and
+ * directory index files. Returns the absolute path of the match, or null.
+ */
+function probeJsTs(absBase: string): string | null {
+  if (isFile(absBase)) return absBase;
+
+  const ext = extname(absBase);
+  const swaps = JS_EXTENSION_SWAPS[ext];
+  if (swaps) {
+    const stem = absBase.slice(0, -ext.length);
+    for (const swap of swaps) {
+      if (isFile(stem + swap)) return stem + swap;
+    }
+  }
+
+  if (!ext) {
+    for (const probeExt of JS_PROBE_EXTENSIONS) {
+      if (isFile(absBase + probeExt)) return absBase + probeExt;
+    }
+  }
+
+  // Directory import: <dir>/index.{ts,tsx,...}
+  for (const probeExt of JS_PROBE_EXTENSIONS) {
+    const candidate = join(absBase, 'index' + probeExt);
+    if (isFile(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/** Probe for a Python module file: foo.py or foo/__init__.py. */
+function probePython(absBase: string): string | null {
+  if (isFile(absBase)) return absBase;
+  if (isFile(absBase + '.py')) return absBase + '.py';
+  const initFile = join(absBase, '__init__.py');
+  if (isFile(initFile)) return initFile;
+  return null;
+}
+
+/** Probe for a Rust module file: foo.rs or foo/mod.rs. */
+function probeRust(absBase: string): string | null {
+  if (isFile(absBase)) return absBase;
+  if (isFile(absBase + '.rs')) return absBase + '.rs';
+  const modFile = join(absBase, 'mod.rs');
+  if (isFile(modFile)) return modFile;
+  return null;
+}
+
+/**
+ * Resolve a relative specifier against the importing file's directory and
+ * probe the filesystem for the real file. Unresolvable specifiers keep the
+ * normalized project-relative path but are tagged external.
+ */
+function resolveRelative(
+  importSpecifier: string,
+  filePath: string,
+  projectRoot: string,
+  probe: (absBase: string) => string | null,
+): ResolvedTarget {
+  const fileDir = dirname(join(projectRoot, filePath));
+  const resolvedAbs = normalize(join(fileDir, importSpecifier));
+  const found = probe(resolvedAbs);
+  if (found) {
+    return { target: toPosix(relative(projectRoot, found)), external: false };
+  }
+  return { target: toPosix(relative(projectRoot, resolvedAbs)), external: true };
+}
+
 function resolveTarget(
   importSpecifier: string,
   filePath: string,
   projectRoot: string,
-): string {
+): ResolvedTarget {
   if (!isRelativeImport(importSpecifier)) {
-    return importSpecifier;
+    // Bare specifier: package, builtin, or alias — external by definition.
+    return { target: importSpecifier, external: true };
   }
-  const fileDir = dirname(join(projectRoot, filePath));
-  const resolved = normalize(join(fileDir, importSpecifier));
-  return toPosix(relative(projectRoot, resolved));
+  return resolveRelative(importSpecifier, filePath, projectRoot, probeJsTs);
+}
+
+function makeRef(
+  source: string,
+  resolved: ResolvedTarget,
+  specifiers: string[],
+  type: ImportRef['type'],
+): ImportRef {
+  const ref: ImportRef = { source, target: resolved.target, specifiers, type };
+  if (resolved.external) ref.external = true;
+  return ref;
+}
+
+/** Resolve an absolute (non-relative) Python module path against the project root. */
+function resolvePythonModule(modulePath: string, projectRoot: string): ResolvedTarget {
+  const found = probePython(join(projectRoot, modulePath));
+  if (found) {
+    return { target: toPosix(relative(projectRoot, found)), external: false };
+  }
+  return { target: modulePath, external: true };
+}
+
+/** Resolve a Rust crate:: module path against the project root (and conventional src/). */
+function resolveRustModule(modulePath: string, projectRoot: string): ResolvedTarget {
+  const direct = probeRust(join(projectRoot, modulePath));
+  if (direct) {
+    return { target: toPosix(relative(projectRoot, direct)), external: false };
+  }
+  const inSrc = probeRust(join(projectRoot, 'src', modulePath));
+  if (inSrc) {
+    return { target: toPosix(relative(projectRoot, inSrc)), external: false };
+  }
+  return { target: modulePath, external: true };
 }
 
 function getExtension(filePath: string): string {
@@ -46,12 +173,9 @@ function extractJsTsImports(
       .split(',')
       .map((s) => s.trim().split(/\s+as\s+/)[0].trim())
       .filter(Boolean);
-    results.push({
-      source,
-      target: resolveTarget(match[2], filePath, projectRoot),
-      specifiers,
-      type: 'static',
-    });
+    results.push(
+      makeRef(source, resolveTarget(match[2], filePath, projectRoot), specifiers, 'static'),
+    );
   }
 
   // Default imports: import Foo from './module'
@@ -61,24 +185,23 @@ function extractJsTsImports(
     // Skip if this is a type import or already caught by named/namespace
     const fullMatch = match[0];
     if (fullMatch.includes('{') || fullMatch.includes('*')) continue;
-    results.push({
-      source,
-      target: resolveTarget(match[2], filePath, projectRoot),
-      specifiers: [match[1]],
-      type: 'static',
-    });
+    results.push(
+      makeRef(source, resolveTarget(match[2], filePath, projectRoot), [match[1]], 'static'),
+    );
   }
 
   // Namespace imports: import * as Foo from './module'
   const namespaceImportRe =
     /import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/g;
   while ((match = namespaceImportRe.exec(contents)) !== null) {
-    results.push({
-      source,
-      target: resolveTarget(match[2], filePath, projectRoot),
-      specifiers: [`* as ${match[1]}`],
-      type: 'static',
-    });
+    results.push(
+      makeRef(
+        source,
+        resolveTarget(match[2], filePath, projectRoot),
+        [`* as ${match[1]}`],
+        'static',
+      ),
+    );
   }
 
   // Side-effect imports: import './module'
@@ -94,23 +217,13 @@ function extractJsTsImports(
     // Ensure it's not from-style import (those have "from" before the string)
     const precedingText = contents.slice(Math.max(0, match.index - 5), match.index);
     if (/from\s*$/.test(precedingText)) continue;
-    results.push({
-      source,
-      target: resolveTarget(match[1], filePath, projectRoot),
-      specifiers: [],
-      type: 'static',
-    });
+    results.push(makeRef(source, resolveTarget(match[1], filePath, projectRoot), [], 'static'));
   }
 
   // Dynamic imports: import('./module')
   const dynamicImportRe = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
   while ((match = dynamicImportRe.exec(contents)) !== null) {
-    results.push({
-      source,
-      target: resolveTarget(match[1], filePath, projectRoot),
-      specifiers: [],
-      type: 'dynamic',
-    });
+    results.push(makeRef(source, resolveTarget(match[1], filePath, projectRoot), [], 'dynamic'));
   }
 
   // Re-exports: export { Foo } from './module'
@@ -121,34 +234,23 @@ function extractJsTsImports(
       .split(',')
       .map((s) => s.trim().split(/\s+as\s+/)[0].trim())
       .filter(Boolean);
-    results.push({
-      source,
-      target: resolveTarget(match[2], filePath, projectRoot),
-      specifiers,
-      type: 're-export',
-    });
+    results.push(
+      makeRef(source, resolveTarget(match[2], filePath, projectRoot), specifiers, 're-export'),
+    );
   }
 
   // Re-exports: export * from './module'
   const reExportAllRe = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g;
   while ((match = reExportAllRe.exec(contents)) !== null) {
-    results.push({
-      source,
-      target: resolveTarget(match[1], filePath, projectRoot),
-      specifiers: ['*'],
-      type: 're-export',
-    });
+    results.push(
+      makeRef(source, resolveTarget(match[1], filePath, projectRoot), ['*'], 're-export'),
+    );
   }
 
   // require() calls
   const requireRe = /require\(\s*['"]([^'"]+)['"]\s*\)/g;
   while ((match = requireRe.exec(contents)) !== null) {
-    results.push({
-      source,
-      target: resolveTarget(match[1], filePath, projectRoot),
-      specifiers: [],
-      type: 'static',
-    });
+    results.push(makeRef(source, resolveTarget(match[1], filePath, projectRoot), [], 'static'));
   }
 
   return results;
@@ -195,12 +297,8 @@ export function extractPythonImports(
   while ((match = simpleImportRe.exec(cleaned)) !== null) {
     const modules = match[1].split(',').map((s) => s.trim()).filter(Boolean);
     for (const mod of modules) {
-      results.push({
-        source,
-        target: mod.replace(/\./g, '/'),
-        specifiers: [],
-        type: 'static',
-      });
+      const resolved = resolvePythonModule(mod.replace(/\./g, '/'), projectRoot);
+      results.push(makeRef(source, resolved, [], 'static'));
     }
   }
 
@@ -226,7 +324,7 @@ export function extractPythonImports(
       .filter((s) => s.length > 0 && s !== '\\');
 
     // Determine target
-    let target: string;
+    let resolved: ResolvedTarget;
     if (fromModule === '.' || fromModule === '..' || fromModule.startsWith('.')) {
       // Relative import
       const dotCount = fromModule.match(/^\.+/)?.[0].length ?? 0;
@@ -238,23 +336,14 @@ export function extractPythonImports(
       }
       const modulePath = rest ? rest.replace(/\./g, '/') : '';
       const fullSpecifier = relPrefix + modulePath;
-      // Trim trailing slash but ensure we have at least './' for resolveTarget
+      // Trim trailing slash but ensure we have at least './' for resolveRelative
       const cleaned = fullSpecifier.endsWith('/') ? fullSpecifier.slice(0, -1) : fullSpecifier;
-      target = resolveTarget(
-        cleaned || './',
-        filePath,
-        projectRoot,
-      );
+      resolved = resolveRelative(cleaned || './', filePath, projectRoot, probePython);
     } else {
-      target = fromModule.replace(/\./g, '/');
+      resolved = resolvePythonModule(fromModule.replace(/\./g, '/'), projectRoot);
     }
 
-    results.push({
-      source,
-      target,
-      specifiers,
-      type: 'static',
-    });
+    results.push(makeRef(source, resolved, specifiers, 'static'));
   }
 
   return results;
@@ -311,11 +400,13 @@ export function extractGoImports(
       }
     }
 
+    // Go import paths are package paths, not file paths — treated as external.
     results.push({
       source,
       target: match[2],
       specifiers: match[1] ? [match[1]] : [],
       type: 'static',
+      external: true,
     });
   }
 
@@ -332,6 +423,7 @@ export function extractGoImports(
         target: lineMatch[2],
         specifiers: lineMatch[1] ? [lineMatch[1]] : [],
         type: 'static',
+        external: true,
       });
     }
   }
@@ -403,28 +495,26 @@ export function extractRustImports(
     const { target: rawTarget, specifiers } = parseRustUseTree(rawUse);
 
     // Determine if this is relative (crate::, super::, self::)
-    let target = rawTarget;
+    let resolved: ResolvedTarget;
     if (rawTarget.startsWith('crate/')) {
       // crate:: refers to the crate root — resolve relative to project root
-      target = rawTarget.replace(/^crate\//, '');
+      resolved = resolveRustModule(rawTarget.replace(/^crate\//, ''), projectRoot);
     } else if (rawTarget.startsWith('super/')) {
       // super:: means parent module
       const rest = rawTarget.replace(/^(super\/)+/, '');
       const superCount = (rawTarget.match(/super\//g) ?? []).length;
       const relPrefix = '../'.repeat(superCount);
-      target = resolveTarget(relPrefix + rest, filePath, projectRoot);
+      resolved = resolveRelative(relPrefix + rest, filePath, projectRoot, probeRust);
     } else if (rawTarget.startsWith('self/')) {
       // self:: means current module
       const rest = rawTarget.replace(/^self\//, '');
-      target = resolveTarget('./' + rest, filePath, projectRoot);
+      resolved = resolveRelative('./' + rest, filePath, projectRoot, probeRust);
+    } else {
+      // External crate path (std::, serde::, ...)
+      resolved = { target: rawTarget, external: true };
     }
 
-    results.push({
-      source,
-      target,
-      specifiers,
-      type: 'static',
-    });
+    results.push(makeRef(source, resolved, specifiers, 'static'));
   }
 
   // mod declarations: mod foo; (not mod foo { ... })
@@ -433,14 +523,13 @@ export function extractRustImports(
     const modName = match[1];
     // mod foo; declares a submodule — could be foo.rs or foo/mod.rs
     const fileDir = dirname(filePath);
-    const target = fileDir === '.' ? modName : fileDir + '/' + modName;
+    const base = fileDir === '.' ? modName : fileDir + '/' + modName;
+    const found = probeRust(join(projectRoot, base));
+    const resolved: ResolvedTarget = found
+      ? { target: toPosix(relative(projectRoot, found)), external: false }
+      : { target: base, external: true };
 
-    results.push({
-      source,
-      target,
-      specifiers: [],
-      type: 'static',
-    });
+    results.push(makeRef(source, resolved, [], 'static'));
   }
 
   return results;
@@ -483,11 +572,13 @@ export function extractKotlinImports(
   const importRe = /^[ \t]*import\s+([\w.]+?)(\.\*)?(?:\s+as\s+(\w+))?\s*;?\s*$/gm;
   let match: RegExpExecArray | null;
   while ((match = importRe.exec(cleaned)) !== null) {
+    // Kotlin import paths are package paths, not file paths — treated as external.
     results.push({
       source,
       target: match[1].replace(/\./g, '/'),
       specifiers: match[2] ? ['*'] : match[3] ? [match[3]] : [],
       type: 'static',
+      external: true,
     });
   }
 
@@ -519,11 +610,13 @@ export function extractJavaImports(
         path = path.slice(0, lastDot);
       }
     }
+    // Java import paths are package paths, not file paths — treated as external.
     results.push({
       source,
       target: path.replace(/\./g, '/'),
       specifiers,
       type: 'static',
+      external: true,
     });
   }
 

--- a/src/tools/get-related-files.ts
+++ b/src/tools/get-related-files.ts
@@ -52,25 +52,14 @@ export async function getRelatedFiles(
     }
   }
 
-  // The graph may store paths with .js extension (from import specifiers) while
-  // actual files have .ts extension. Query both variants to get complete results.
-  const variants = getPathVariants(validated);
-
-  // Get direct dependencies and dependents across all path variants
-  const dependencies = new Set<string>();
-  const dependents = new Set<string>();
-  for (const v of variants) {
-    for (const d of graph.getDependencies(v)) dependencies.add(d);
-    for (const d of graph.getDependents(v)) dependents.add(d);
-  }
+  // Import targets are resolved to real file paths at extraction time, so the
+  // graph can be queried with the validated path directly.
+  const dependencies = new Set<string>(graph.getDependencies(validated));
+  const dependents = new Set<string>(graph.getDependents(validated));
 
   // Get transitive dependencies (depth 2) for "transitive-dependency" classification
-  const transitiveDeps = new Set<string>();
-  const transitiveDependents = new Set<string>();
-  for (const v of variants) {
-    for (const d of graph.getTransitiveDependencies(v, 2)) transitiveDeps.add(d);
-    for (const d of graph.getTransitiveDependents(v, 2)) transitiveDependents.add(d);
-  }
+  const transitiveDeps = new Set<string>(graph.getTransitiveDependencies(validated, 2));
+  const transitiveDependents = new Set<string>(graph.getTransitiveDependents(validated, 2));
 
   // Determine same-directory files
   const fileDir = dirname(validated);
@@ -86,8 +75,8 @@ export async function getRelatedFiles(
   for (const d of transitiveDependents) candidates.add(d);
   for (const d of sameDirFiles) candidates.add(d);
 
-  // Remove the file itself (all variants)
-  for (const v of variants) candidates.delete(v);
+  // Remove the file itself
+  candidates.delete(validated);
 
   if (candidates.size === 0) {
     return { path: validated, relatedFiles: [] };
@@ -140,21 +129,4 @@ export async function getRelatedFiles(
   }));
 
   return { path: validated, relatedFiles };
-}
-
-/** Get path variants to handle .ts/.js extension mismatch in the dependency graph. */
-function getPathVariants(filePath: string): string[] {
-  const variants = [filePath];
-  if (filePath.endsWith('.ts')) {
-    variants.push(filePath.replace(/\.ts$/, '.js'));
-  } else if (filePath.endsWith('.tsx')) {
-    variants.push(filePath.replace(/\.tsx$/, '.js'));
-    variants.push(filePath.replace(/\.tsx$/, '.jsx'));
-  } else if (filePath.endsWith('.js')) {
-    variants.push(filePath.replace(/\.js$/, '.ts'));
-    variants.push(filePath.replace(/\.js$/, '.tsx'));
-  } else if (filePath.endsWith('.jsx')) {
-    variants.push(filePath.replace(/\.jsx$/, '.tsx'));
-  }
-  return variants;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,10 @@ export interface ImportRef {
   target: string;
   specifiers: string[];
   type: 'static' | 'dynamic' | 're-export';
+  /**
+   * True when the target does not resolve to a file inside the project
+   * (bare module specifiers, builtins, unresolvable relative paths).
+   * External refs are excluded from the dependency graph.
+   */
+  external?: boolean;
 }

--- a/tests/integration/v2-flow.test.ts
+++ b/tests/integration/v2-flow.test.ts
@@ -132,7 +132,7 @@ describe('V2 end-to-end flow', () => {
     // Step 11: Query dependents of the changed file to assess impact
     const impactGraph = await getDependencyGraphTool(
       projectDir,
-      'src/utils/validate.js',
+      'src/utils/validate.ts',
       'dependents',
     );
     // user.ts depends on validate

--- a/tests/integration/v3-flow.test.ts
+++ b/tests/integration/v3-flow.test.ts
@@ -227,7 +227,7 @@ describe('V3 end-to-end flow', () => {
     // Step 14: Query dependents of changed file to assess impact
     const impactGraph = await getDependencyGraphTool(
       projectDir,
-      'src/utils/validate.js',
+      'src/utils/validate.ts',
       'dependents',
     );
     expect(impactGraph.nodes).toContain('src/services/user.ts');

--- a/tests/unit/dependency-graph.test.ts
+++ b/tests/unit/dependency-graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { DependencyGraph } from '../../src/graph/dependency-graph.js';
 import { getDatabase, closeDatabase } from '../../src/persistence/db.js';
@@ -8,6 +8,14 @@ import { getDatabase, closeDatabase } from '../../src/persistence/db.js';
 describe('DependencyGraph', () => {
   let tempDir: string;
   let graph: DependencyGraph;
+
+  /** Write a real file to disk and index it in the graph. */
+  function addFile(relPath: string, contents: string): void {
+    const abs = join(tempDir, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, contents);
+    graph.updateFile(relPath, contents);
+  }
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'dep-graph-test-'));
@@ -21,16 +29,27 @@ describe('DependencyGraph', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('builds graph from import data', () => {
-    const contents = `import { Foo } from './bar';`;
-    graph.updateFile('src/index.ts', contents);
+  it('builds graph from import data with real file targets', () => {
+    addFile('src/bar.ts', `export const Foo = 1;`);
+    addFile('src/index.ts', `import { Foo } from './bar';`);
 
-    expect(graph.getDependencies('src/index.ts')).toEqual(['src/bar']);
-    expect(graph.getDependents('src/bar')).toEqual(['src/index.ts']);
+    expect(graph.getDependencies('src/index.ts')).toEqual(['src/bar.ts']);
+    expect(graph.getDependents('src/bar.ts')).toEqual(['src/index.ts']);
+  });
+
+  it('resolves .js specifiers to the real .ts file', () => {
+    addFile('src/cache/store.ts', `export const store = {};`);
+    addFile('src/index.ts', `import { store } from './cache/store.js';`);
+
+    expect(graph.getDependencies('src/index.ts')).toEqual(['src/cache/store.ts']);
+    expect(graph.getDependents('src/cache/store.ts')).toEqual(['src/index.ts']);
   });
 
   it('getDependencies returns correct files', () => {
-    graph.updateFile('src/app.ts', [
+    addFile('src/a.ts', `export const A = 1;`);
+    addFile('src/b.ts', `export const B = 1;`);
+    addFile('src/c.ts', `export const C = 1;`);
+    addFile('src/app.ts', [
       `import { A } from './a';`,
       `import { B } from './b';`,
       `import { C } from './c';`,
@@ -38,101 +57,139 @@ describe('DependencyGraph', () => {
 
     const deps = graph.getDependencies('src/app.ts');
     expect(deps).toHaveLength(3);
-    expect(deps).toContain('src/a');
-    expect(deps).toContain('src/b');
-    expect(deps).toContain('src/c');
+    expect(deps).toContain('src/a.ts');
+    expect(deps).toContain('src/b.ts');
+    expect(deps).toContain('src/c.ts');
   });
 
   it('getDependents returns correct files', () => {
-    graph.updateFile('src/a.ts', `import { Util } from './util';`);
-    graph.updateFile('src/b.ts', `import { Util } from './util';`);
-    graph.updateFile('src/c.ts', `import { Util } from './util';`);
+    addFile('src/util.ts', `export const Util = 1;`);
+    addFile('src/a.ts', `import { Util } from './util';`);
+    addFile('src/b.ts', `import { Util } from './util';`);
+    addFile('src/c.ts', `import { Util } from './util';`);
 
-    const dependents = graph.getDependents('src/util');
+    const dependents = graph.getDependents('src/util.ts');
     expect(dependents).toHaveLength(3);
     expect(dependents).toContain('src/a.ts');
     expect(dependents).toContain('src/b.ts');
     expect(dependents).toContain('src/c.ts');
   });
 
-  it('getTransitiveDependencies works with depth limiting', () => {
-    graph.updateFile('src/a.ts', `import { B } from './b';`);
-    graph.updateFile('src/b', `import { C } from './c';`);
-    graph.updateFile('src/c', `import { D } from './d';`);
+  it('transitive traversal follows real files: A → B → C reachable at depth 2', () => {
+    addFile('src/d.ts', `export const D = 1;`);
+    addFile('src/c.ts', `import { D } from './d.js';\nexport const C = 1;`);
+    addFile('src/b.ts', `import { C } from './c.js';\nexport const B = 1;`);
+    addFile('src/a.ts', `import { B } from './b.js';\nexport const A = 1;`);
 
     const all = graph.getTransitiveDependencies('src/a.ts');
-    expect(all).toContain('src/b');
-    expect(all).toContain('src/c');
-    expect(all).toContain('src/d');
+    expect(all).toContain('src/b.ts');
+    expect(all).toContain('src/c.ts');
+    expect(all).toContain('src/d.ts');
 
     const depth1 = graph.getTransitiveDependencies('src/a.ts', 1);
-    expect(depth1).toEqual(['src/b']);
+    expect(depth1).toEqual(['src/b.ts']);
 
     const depth2 = graph.getTransitiveDependencies('src/a.ts', 2);
-    expect(depth2).toContain('src/b');
-    expect(depth2).toContain('src/c');
-    expect(depth2).not.toContain('src/d');
+    expect(depth2).toContain('src/b.ts');
+    expect(depth2).toContain('src/c.ts');
+    expect(depth2).not.toContain('src/d.ts');
   });
 
   it('getTransitiveDependents works', () => {
-    graph.updateFile('src/a', `import { B } from './b';`);
-    graph.updateFile('src/c', `import { B } from './b';`);
-    graph.updateFile('src/d', `import { C } from './c';`);
+    addFile('src/b.ts', `export const B = 1;`);
+    addFile('src/a.ts', `import { B } from './b';`);
+    addFile('src/c.ts', `import { B } from './b';\nexport const C = 1;`);
+    addFile('src/d.ts', `import { C } from './c';`);
 
-    const dependents = graph.getTransitiveDependents('src/b');
-    expect(dependents).toContain('src/a');
-    expect(dependents).toContain('src/c');
-    expect(dependents).toContain('src/d');
+    const dependents = graph.getTransitiveDependents('src/b.ts');
+    expect(dependents).toContain('src/a.ts');
+    expect(dependents).toContain('src/c.ts');
+    expect(dependents).toContain('src/d.ts');
   });
 
   it('getMostConnected returns hub files', () => {
-    graph.updateFile('src/hub', [
+    addFile('src/a.ts', `export const A = 1;`);
+    addFile('src/b.ts', `export const B = 1;`);
+    addFile('src/c.ts', `export const C = 1;`);
+    addFile('src/hub.ts', [
       `import { A } from './a';`,
       `import { B } from './b';`,
       `import { C } from './c';`,
+      `export const Hub = 1;`,
     ].join('\n'));
-    graph.updateFile('src/x', `import { Hub } from './hub';`);
-    graph.updateFile('src/y', `import { Hub } from './hub';`);
+    addFile('src/x.ts', `import { Hub } from './hub';`);
+    addFile('src/y.ts', `import { Hub } from './hub';`);
 
     const top = graph.getMostConnected(3);
-    expect(top[0].path).toBe('src/hub');
+    expect(top[0].path).toBe('src/hub.ts');
     expect(top[0].connections).toBe(5);
   });
 
+  it('external imports do not become graph nodes', () => {
+    addFile('src/util.ts', `export const util = 1;`);
+    addFile('src/app.ts', [
+      `import { describe } from 'vitest';`,
+      `import { readFileSync } from 'node:fs';`,
+      `import { join } from 'path';`,
+      `import { util } from './util.js';`,
+      `import { ghost } from './does-not-exist.js';`,
+    ].join('\n'));
+
+    expect(graph.getDependencies('src/app.ts')).toEqual(['src/util.ts']);
+    expect(graph.getDependents('vitest')).toEqual([]);
+    expect(graph.getDependents('node:fs')).toEqual([]);
+    expect(graph.getDependents('path')).toEqual([]);
+    expect(graph.getDependents('src/does-not-exist.js')).toEqual([]);
+
+    const nodes = graph.getMostConnected(100).map((n) => n.path);
+    expect(nodes).toContain('src/app.ts');
+    expect(nodes).toContain('src/util.ts');
+    expect(nodes).not.toContain('vitest');
+    expect(nodes).not.toContain('node:fs');
+    expect(nodes).not.toContain('path');
+    expect(nodes).not.toContain('src/does-not-exist.js');
+  });
+
   it('incremental update works — change a file, edges update', () => {
-    graph.updateFile('src/app.ts', `import { A } from './a';`);
-    expect(graph.getDependencies('src/app.ts')).toEqual(['src/a']);
+    addFile('src/a.ts', `export const A = 1;`);
+    addFile('src/b.ts', `export const B = 1;`);
+    addFile('src/app.ts', `import { A } from './a';`);
+    expect(graph.getDependencies('src/app.ts')).toEqual(['src/a.ts']);
 
     graph.updateFile('src/app.ts', `import { B } from './b';`);
-    expect(graph.getDependencies('src/app.ts')).toEqual(['src/b']);
-    expect(graph.getDependents('src/a')).toEqual([]);
-    expect(graph.getDependents('src/b')).toEqual(['src/app.ts']);
+    expect(graph.getDependencies('src/app.ts')).toEqual(['src/b.ts']);
+    expect(graph.getDependents('src/a.ts')).toEqual([]);
+    expect(graph.getDependents('src/b.ts')).toEqual(['src/app.ts']);
   });
 
   it('handles circular dependencies without infinite loop', () => {
-    graph.updateFile('src/a', `import { B } from './b';`);
-    graph.updateFile('src/b', `import { C } from './c';`);
-    graph.updateFile('src/c', `import { A } from './a';`);
+    addFile('src/a.ts', '');
+    addFile('src/b.ts', '');
+    addFile('src/c.ts', '');
+    graph.updateFile('src/a.ts', `import { B } from './b';`);
+    graph.updateFile('src/b.ts', `import { C } from './c';`);
+    graph.updateFile('src/c.ts', `import { A } from './a';`);
 
-    const deps = graph.getTransitiveDependencies('src/a');
-    expect(deps).toContain('src/b');
-    expect(deps).toContain('src/c');
+    const deps = graph.getTransitiveDependencies('src/a.ts');
+    expect(deps).toContain('src/b.ts');
+    expect(deps).toContain('src/c.ts');
 
-    const dependents = graph.getTransitiveDependents('src/a');
-    expect(dependents).toContain('src/c');
-    expect(dependents).toContain('src/b');
+    const dependents = graph.getTransitiveDependents('src/a.ts');
+    expect(dependents).toContain('src/c.ts');
+    expect(dependents).toContain('src/b.ts');
   });
 
   it('load restores graph from database', () => {
-    graph.updateFile('src/a.ts', `import { B } from './b';`);
-    graph.updateFile('src/b.ts', `import { C } from './c';`);
+    addFile('src/c.ts', `export const C = 1;`);
+    addFile('src/b.ts', `import { C } from './c';\nexport const B = 1;`);
+    addFile('src/a.ts', `import { B } from './b';`);
 
     const graph2 = new DependencyGraph(tempDir);
     graph2.load();
 
-    expect(graph2.getDependencies('src/a.ts')).toEqual(['src/b']);
-    expect(graph2.getDependencies('src/b.ts')).toEqual(['src/c']);
-    expect(graph2.getDependents('src/b')).toEqual(['src/a.ts']);
+    expect(graph2.getDependencies('src/a.ts')).toEqual(['src/b.ts']);
+    expect(graph2.getDependencies('src/b.ts')).toEqual(['src/c.ts']);
+    expect(graph2.getDependents('src/b.ts')).toEqual(['src/a.ts']);
   });
 
   it('returns empty arrays for unknown paths', () => {
@@ -143,12 +200,13 @@ describe('DependencyGraph', () => {
   });
 
   it('getMostConnected with limit', () => {
-    graph.updateFile('src/a.ts', `import { X } from './x';`);
-    graph.updateFile('src/b.ts', `import { X } from './x';`);
-    graph.updateFile('src/c.ts', `import { X } from './x';`);
+    addFile('src/x.ts', `export const X = 1;`);
+    addFile('src/a.ts', `import { X } from './x';`);
+    addFile('src/b.ts', `import { X } from './x';`);
+    addFile('src/c.ts', `import { X } from './x';`);
 
     const top1 = graph.getMostConnected(1);
     expect(top1).toHaveLength(1);
-    expect(top1[0].path).toBe('src/x');
+    expect(top1[0].path).toBe('src/x.ts');
   });
 });

--- a/tests/unit/get-dependency-graph.test.ts
+++ b/tests/unit/get-dependency-graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getDependencyGraphTool } from '../../src/tools/get-dependency-graph.js';
@@ -32,12 +32,12 @@ describe('getDependencyGraphTool', () => {
   it('returns dependencies for a single file', async () => {
     const result = await getDependencyGraphTool(tempDir, 'src/index.ts', 'dependencies');
     expect(result.nodes).toContain('src/index.ts');
-    expect(result.nodes).toContain('src/helper.js');
-    expect(result.edges.some((e) => e.from === 'src/index.ts' && e.to === 'src/helper.js')).toBe(true);
+    expect(result.nodes).toContain('src/helper.ts');
+    expect(result.edges.some((e) => e.from === 'src/index.ts' && e.to === 'src/helper.ts')).toBe(true);
   });
 
   it('returns dependents for a single file', async () => {
-    const result = await getDependencyGraphTool(tempDir, 'src/helper.js', 'dependents');
+    const result = await getDependencyGraphTool(tempDir, 'src/helper.ts', 'dependents');
     expect(result.nodes).toContain('src/index.ts');
   });
 
@@ -49,23 +49,50 @@ describe('getDependencyGraphTool', () => {
 
   it('respects depth parameter', async () => {
     const result = await getDependencyGraphTool(tempDir, 'src/index.ts', 'dependencies', 1);
-    expect(result.nodes).toContain('src/helper.js');
+    expect(result.nodes).toContain('src/helper.ts');
     // At depth 1, should not include transitive deps of helper
+  });
+
+  it('mostConnected and nodes contain only real repo files (no bare modules or phantoms)', async () => {
+    // A file with external imports must not introduce phantom graph nodes
+    writeFileSync(
+      join(tempDir, 'src', 'externals.ts'),
+      [
+        `import { describe } from 'vitest';`,
+        `import { readFileSync } from 'node:fs';`,
+        `import { join } from 'path';`,
+        `import { ghost } from './does-not-exist.js';`,
+        `import { util } from './util.js';`,
+      ].join('\n'),
+    );
+
+    const result = await getDependencyGraphTool(tempDir);
+    expect(result.stats.mostConnected.length).toBeGreaterThan(0);
+
+    const allPaths = [...result.nodes, ...result.stats.mostConnected.map((m) => m.path)];
+    for (const p of allPaths) {
+      expect(existsSync(join(tempDir, p)), `${p} should be a real repo file`).toBe(true);
+    }
+    expect(allPaths).not.toContain('vitest');
+    expect(allPaths).not.toContain('node:fs');
+    expect(allPaths).not.toContain('path');
+    expect(allPaths).not.toContain('src/does-not-exist.js');
+    expect(allPaths).not.toContain('src/util.js');
   });
 
   describe('symbol filter', () => {
     it('filters by symbol when path is given', async () => {
       const result = await getDependencyGraphTool(tempDir, 'src/index.ts', undefined, undefined, 'helper');
-      expect(result.edges).toEqual([{ from: 'src/index.ts', to: 'src/helper.js' }]);
+      expect(result.edges).toEqual([{ from: 'src/index.ts', to: 'src/helper.ts' }]);
       expect(result.nodes).toContain('src/index.ts');
-      expect(result.nodes).toContain('src/helper.js');
+      expect(result.nodes).toContain('src/helper.ts');
     });
 
     it('filters by symbol when path is NOT given (search all edges)', async () => {
       const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'util');
-      expect(result.edges.some((e) => e.from === 'src/helper.ts' && e.to === 'src/util.js')).toBe(true);
+      expect(result.edges.some((e) => e.from === 'src/helper.ts' && e.to === 'src/util.ts')).toBe(true);
       expect(result.nodes).toContain('src/helper.ts');
-      expect(result.nodes).toContain('src/util.js');
+      expect(result.nodes).toContain('src/util.ts');
     });
 
     it('returns empty results for non-existent symbol', async () => {

--- a/tests/unit/get-related-files.test.ts
+++ b/tests/unit/get-related-files.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getRelatedFiles } from '../../src/tools/get-related-files.js';
@@ -50,7 +50,7 @@ describe('getRelatedFiles', () => {
   it('returns direct dependencies as related', async () => {
     const result = await getRelatedFiles(tempDir, 'src/index.ts');
     const paths = result.relatedFiles.map((f) => f.path);
-    expect(paths).toContain('src/helper.js');
+    expect(paths).toContain('src/helper.ts');
   });
 
   it('returns direct dependents as related', async () => {
@@ -61,7 +61,7 @@ describe('getRelatedFiles', () => {
 
   it('classifies relationships correctly', async () => {
     const result = await getRelatedFiles(tempDir, 'src/index.ts');
-    const helperEntry = result.relatedFiles.find((f) => f.path === 'src/helper.js');
+    const helperEntry = result.relatedFiles.find((f) => f.path === 'src/helper.ts');
     expect(helperEntry).toBeDefined();
     expect(helperEntry!.relationship).toBe('imports');
 
@@ -80,6 +80,15 @@ describe('getRelatedFiles', () => {
   it('respects limit parameter', async () => {
     const result = await getRelatedFiles(tempDir, 'src/helper.ts', { limit: 2 });
     expect(result.relatedFiles.length).toBeLessThanOrEqual(2);
+  });
+
+  it('returns only paths that exist on disk', async () => {
+    // index.ts imports './helper.js' — the graph must resolve it to helper.ts
+    const result = await getRelatedFiles(tempDir, 'src/index.ts');
+    expect(result.relatedFiles.length).toBeGreaterThan(0);
+    for (const f of result.relatedFiles) {
+      expect(existsSync(join(tempDir, f.path)), `${f.path} should exist`).toBe(true);
+    }
   });
 
   it('works without task context', async () => {

--- a/tests/unit/imports-go.test.ts
+++ b/tests/unit/imports-go.test.ts
@@ -15,6 +15,7 @@ import "fmt"`;
         target: 'fmt',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -30,6 +31,7 @@ import f "fmt"`;
         target: 'fmt',
         specifiers: ['f'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -61,6 +63,7 @@ import (
       target: 'path/to/pkg',
       specifiers: ['myalias'],
       type: 'static',
+      external: true,
     });
   });
 
@@ -100,6 +103,7 @@ import (
       target: 'net/http/pprof',
       specifiers: ['_'],
       type: 'static',
+      external: true,
     });
   });
 
@@ -129,6 +133,7 @@ import "github.com/user/repo/pkg/utils"`;
         target: 'github.com/user/repo/pkg/utils',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });

--- a/tests/unit/imports-java.test.ts
+++ b/tests/unit/imports-java.test.ts
@@ -15,6 +15,7 @@ import java.util.List;`;
         target: 'java/util/List',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -30,6 +31,7 @@ import java.util.*;`;
         target: 'java/util',
         specifiers: ['*'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -45,6 +47,7 @@ import static java.lang.Math.max;`;
         target: 'java/lang/Math',
         specifiers: ['max'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -60,6 +63,7 @@ import static java.lang.Math.*;`;
         target: 'java/lang/Math',
         specifiers: ['*'],
         type: 'static',
+        external: true,
       },
     ]);
   });

--- a/tests/unit/imports-kotlin.test.ts
+++ b/tests/unit/imports-kotlin.test.ts
@@ -15,6 +15,7 @@ import kotlin.math.max`;
         target: 'kotlin/math/max',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -30,6 +31,7 @@ import com.example.util.*`;
         target: 'com/example/util',
         specifiers: ['*'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -45,6 +47,7 @@ import com.example.io.Reader as R`;
         target: 'com/example/io/Reader',
         specifiers: ['R'],
         type: 'static',
+        external: true,
       },
     ]);
   });

--- a/tests/unit/imports-python.test.ts
+++ b/tests/unit/imports-python.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { extractImports } from '../../src/indexer/imports.js';
 
 describe('extractImports — Python', () => {
@@ -13,6 +16,7 @@ describe('extractImports — Python', () => {
         target: 'os',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -26,6 +30,7 @@ describe('extractImports — Python', () => {
         target: 'os/path',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -39,12 +44,14 @@ describe('extractImports — Python', () => {
         target: 'os',
         specifiers: [],
         type: 'static',
+        external: true,
       },
       {
         source: 'src/app.py',
         target: 'sys',
         specifiers: [],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -58,6 +65,7 @@ describe('extractImports — Python', () => {
         target: 'os/path',
         specifiers: ['join', 'dirname'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -71,6 +79,7 @@ describe('extractImports — Python', () => {
         target: 'src',
         specifiers: ['utils'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -84,6 +93,7 @@ describe('extractImports — Python', () => {
         target: 'src/bar',
         specifiers: ['baz'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -97,6 +107,7 @@ describe('extractImports — Python', () => {
         target: 'src/sibling',
         specifiers: ['func'],
         type: 'static',
+        external: true,
       },
     ]);
   });
@@ -152,5 +163,32 @@ from collections import defaultdict, OrderedDict`;
     const result = extractImports('src/pkg/sub/app.py', contents, projectRoot);
     expect(result[0].target).toBe('src/base');
     expect(result[0].specifiers).toEqual(['Config']);
+  });
+
+  it('resolves relative imports to real .py files and packages', () => {
+    const root = mkdtempSync(join(tmpdir(), 'imports-py-test-'));
+    try {
+      mkdirSync(join(root, 'src', 'pkg'), { recursive: true });
+      writeFileSync(join(root, 'src', 'helpers.py'), '');
+      writeFileSync(join(root, 'src', 'pkg', '__init__.py'), '');
+
+      const contents = `from .helpers import slug\nfrom .pkg import thing`;
+      const result = extractImports('src/app.py', contents, root);
+
+      expect(result).toContainEqual({
+        source: 'src/app.py',
+        target: 'src/helpers.py',
+        specifiers: ['slug'],
+        type: 'static',
+      });
+      expect(result).toContainEqual({
+        source: 'src/app.py',
+        target: 'src/pkg/__init__.py',
+        specifiers: ['thing'],
+        type: 'static',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/imports-rust.test.ts
+++ b/tests/unit/imports-rust.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { extractImports } from '../../src/indexer/imports.js';
 
 describe('extractImports — Rust', () => {
@@ -12,6 +15,7 @@ describe('extractImports — Rust', () => {
       target: 'foo/bar',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -23,6 +27,7 @@ describe('extractImports — Rust', () => {
       target: 'src/foo',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -34,6 +39,7 @@ describe('extractImports — Rust', () => {
       target: 'src/foo',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -45,6 +51,7 @@ describe('extractImports — Rust', () => {
       target: 'std/collections',
       specifiers: ['HashMap', 'HashSet'],
       type: 'static',
+      external: true,
     });
   });
 
@@ -56,6 +63,7 @@ describe('extractImports — Rust', () => {
       target: 'src/utils',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -67,6 +75,7 @@ describe('extractImports — Rust', () => {
       target: 'models/User',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -102,6 +111,7 @@ use std::fmt;`;
       target: 'serde',
       specifiers: ['Serialize', 'Deserialize'],
       type: 'static',
+      external: true,
     });
   });
 
@@ -113,6 +123,7 @@ use std::fmt;`;
       target: 'src/handlers',
       specifiers: [],
       type: 'static',
+      external: true,
     });
   });
 
@@ -137,6 +148,34 @@ mod db;`;
       target: 'src/foo',
       specifiers: [],
       type: 'static',
+      external: true,
     });
+  });
+
+  it('resolves crate:: and mod declarations to real .rs files', () => {
+    const root = mkdtempSync(join(tmpdir(), 'imports-rs-test-'));
+    try {
+      mkdirSync(join(root, 'src', 'db'), { recursive: true });
+      writeFileSync(join(root, 'src', 'utils.rs'), '');
+      writeFileSync(join(root, 'src', 'db', 'mod.rs'), '');
+
+      const contents = `use crate::utils;\nmod db;`;
+      const result = extractImports('src/main.rs', contents, root);
+
+      expect(result).toContainEqual({
+        source: 'src/main.rs',
+        target: 'src/utils.rs',
+        specifiers: [],
+        type: 'static',
+      });
+      expect(result).toContainEqual({
+        source: 'src/main.rs',
+        target: 'src/db/mod.rs',
+        specifiers: [],
+        type: 'static',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/imports.test.ts
+++ b/tests/unit/imports.test.ts
@@ -1,17 +1,84 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { extractImports } from '../../src/indexer/imports.js';
 
 describe('extractImports', () => {
-  const projectRoot = '/project';
+  let projectRoot: string;
 
-  it('extracts static named imports', () => {
+  function addFile(relPath: string, contents = ''): void {
+    const abs = join(projectRoot, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, contents);
+  }
+
+  beforeAll(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'imports-test-'));
+    addFile('src/module.ts');
+    addFile('src/utils.ts');
+    addFile('src/polyfill.ts');
+    addFile('src/types.ts');
+    addFile('src/lazy.ts');
+    addFile('src/lib.ts');
+    addFile('src/utils/helper.ts');
+    addFile('src/cache/store.ts');
+    addFile('src/components/App.tsx');
+    addFile('src/widgets/index.ts');
+    addFile('src/lib/index.ts');
+  });
+
+  afterAll(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('extracts static named imports and resolves to the real file', () => {
     const contents = `import { Foo, Bar } from './module';`;
     const result = extractImports('src/index.ts', contents, projectRoot);
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/module',
+        target: 'src/module.ts',
         specifiers: ['Foo', 'Bar'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('resolves .js specifiers to the real .ts file', () => {
+    const contents = `import { store } from './cache/store.js';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/index.ts',
+        target: 'src/cache/store.ts',
+        specifiers: ['store'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('resolves .jsx specifiers to the real .tsx file', () => {
+    const contents = `import { App } from './components/App.jsx';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/index.ts',
+        target: 'src/components/App.tsx',
+        specifiers: ['App'],
+        type: 'static',
+      },
+    ]);
+  });
+
+  it('resolves directory imports to the index file', () => {
+    const contents = `import { widget } from './widgets';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/index.ts',
+        target: 'src/widgets/index.ts',
+        specifiers: ['widget'],
         type: 'static',
       },
     ]);
@@ -23,7 +90,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/module',
+        target: 'src/module.ts',
         specifiers: ['Foo'],
         type: 'static',
       },
@@ -36,7 +103,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/utils',
+        target: 'src/utils.ts',
         specifiers: ['* as Utils'],
         type: 'static',
       },
@@ -49,7 +116,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/polyfill',
+        target: 'src/polyfill.ts',
         specifiers: [],
         type: 'static',
       },
@@ -62,7 +129,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/types',
+        target: 'src/types.ts',
         specifiers: ['Foo'],
         type: 'static',
       },
@@ -75,7 +142,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/lazy',
+        target: 'src/lazy.ts',
         specifiers: [],
         type: 'dynamic',
       },
@@ -88,7 +155,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/module',
+        target: 'src/module.ts',
         specifiers: ['Foo'],
         type: 're-export',
       },
@@ -101,14 +168,14 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/index.ts',
-        target: 'src/module',
+        target: 'src/module.ts',
         specifiers: ['*'],
         type: 're-export',
       },
     ]);
   });
 
-  it('keeps package imports as-is', () => {
+  it('tags package imports as external', () => {
     const contents = `import { z } from 'zod';\nimport sdk from '@modelcontextprotocol/sdk';`;
     const result = extractImports('src/index.ts', contents, projectRoot);
     expect(result).toContainEqual({
@@ -116,13 +183,45 @@ describe('extractImports', () => {
       target: 'zod',
       specifiers: ['z'],
       type: 'static',
+      external: true,
     });
     expect(result).toContainEqual({
       source: 'src/index.ts',
       target: '@modelcontextprotocol/sdk',
       specifiers: ['sdk'],
       type: 'static',
+      external: true,
     });
+  });
+
+  it('tags node builtins as external', () => {
+    const contents = `import { createHash } from 'node:crypto';\nimport { join } from 'path';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toHaveLength(2);
+    for (const ref of result) {
+      expect(ref.external).toBe(true);
+    }
+  });
+
+  it('tags unresolvable relative imports as external, keeping the resolved path', () => {
+    const contents = `import { ghost } from './does-not-exist.js';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toEqual([
+      {
+        source: 'src/index.ts',
+        target: 'src/does-not-exist.js',
+        specifiers: ['ghost'],
+        type: 'static',
+        external: true,
+      },
+    ]);
+  });
+
+  it('tags relative imports escaping the project root as external', () => {
+    const contents = `import { x } from '../../outside';`;
+    const result = extractImports('src/index.ts', contents, projectRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0].external).toBe(true);
   });
 
   it('resolves relative imports to project-relative paths', () => {
@@ -131,7 +230,7 @@ describe('extractImports', () => {
     expect(result).toEqual([
       {
         source: 'src/lib/index.ts',
-        target: 'src/utils/helper',
+        target: 'src/utils/helper.ts',
         specifiers: ['helper'],
         type: 'static',
       },
@@ -144,7 +243,7 @@ describe('extractImports', () => {
       `import { Bar } from './module';`,
     ].join('\n');
     const result = extractImports('src/index.ts', contents, projectRoot);
-    const moduleImports = result.filter((r) => r.target === 'src/module');
+    const moduleImports = result.filter((r) => r.target === 'src/module.ts');
     expect(moduleImports).toHaveLength(2);
     expect(moduleImports[0].specifiers).toEqual(['Foo']);
     expect(moduleImports[1].specifiers).toEqual(['Bar']);
@@ -158,10 +257,11 @@ describe('extractImports', () => {
       target: 'fs',
       specifiers: [],
       type: 'static',
+      external: true,
     });
     expect(result).toContainEqual({
       source: 'src/index.ts',
-      target: 'src/lib',
+      target: 'src/lib.ts',
       specifiers: [],
       type: 'static',
     });


### PR DESCRIPTION
Closes #162.

Import edge targets now resolve to actual on-disk files at extraction time: relative specifiers probe exact path → extension swaps (.js→.ts/.tsx etc.) → index.* resolution; bare/builtin and unresolvable specifiers are tagged `external` and excluded from graph nodes, traversal, and mostConnected. Python (`__init__.py`) and Rust (`mod.rs`, crate paths) resolve too; Go/Kotlin/Java package paths stay external for now.

Fixes (from the swarm audit): get_related_files returning nonexistent paths, getDependents returning [] for real keys, transitive traversal dead-ending at one hop, mostConnected listing `vitest`/`node:fs`/phantoms. Deletes the getPathVariants hack.

## Testing
467 unit + 7 integration pass; new tests: A→B→C reachable at depth 2, externals create no nodes, returned related paths exist on disk, phantom-free mostConnected.