### PR TITLE
fix(indexer): validate search results before serving and fix telemetry inflation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -178,7 +178,7 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
       },
     }, async ({ query, limit, pathPrefix }) => {
       const projectRoot = process.cwd();
-      const result = searchByPurpose(projectRoot, query, limit, pathPrefix);
+      const result = await searchByPurpose(projectRoot, query, limit, pathPrefix);
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result) }],
       };

--- a/src/tools/search-by-purpose.ts
+++ b/src/tools/search-by-purpose.ts
@@ -1,5 +1,10 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
+import { ensureSummaryGeneration, summarizeForProject } from '../indexer/summarize.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
+import type { CacheEntry, FileSummary } from '../types.js';
 import { toPosix } from '../utils/posix-path.js';
 
 export interface SearchResult {
@@ -17,12 +22,89 @@ export interface SearchByPurposeResult {
   scope?: string; // present when results were restricted to a pathPrefix
 }
 
-export function searchByPurpose(
+interface Match {
+  matchedOn: string[];
+  score: number;
+}
+
+/** Score a summary against the query terms; null when nothing matched. */
+function scoreSummary(summary: FileSummary, queryTerms: string[]): Match | null {
+  const matchedOn: string[] = [];
+  let score = 0;
+
+  const purpose = summary.purpose.toLowerCase();
+  const purposeMatches = queryTerms.filter((term) => purpose.includes(term));
+  if (purposeMatches.length > 0) {
+    matchedOn.push('purpose');
+    score += purposeMatches.length * 3; // purpose matches weighted highest
+  }
+
+  const exportsLower = summary.exports.map((e) => e.toLowerCase());
+  const exportMatches = queryTerms.filter((term) =>
+    exportsLower.some((exp) => exp.includes(term)),
+  );
+  if (exportMatches.length > 0) {
+    matchedOn.push('exports');
+    score += exportMatches.length * 2;
+  }
+
+  const declsLower = summary.topLevelDeclarations.map((d) => d.toLowerCase());
+  const declMatches = queryTerms.filter((term) => declsLower.some((decl) => decl.includes(term)));
+  if (declMatches.length > 0) {
+    matchedOn.push('declarations');
+    score += declMatches.length;
+  }
+
+  return matchedOn.length > 0 ? { matchedOn, score } : null;
+}
+
+interface Candidate {
+  entry: CacheEntry;
+  summary: FileSummary; // the summary actually served (fresh after validation)
+  matchedOn: string[];
+  score: number;
+}
+
+/**
+ * Re-hash a matched candidate before serving it (never return stale data).
+ * - Missing/unreadable file: evict the dead cache entry and drop the result.
+ * - Hash mismatch: regenerate the summary through the standard path (same
+ *   semantics as get_file_summary's cache-miss branch), re-score it against
+ *   the query, and keep it only if it still matches.
+ */
+async function validateCandidate(
+  projectRoot: string,
+  store: CacheStore,
+  candidate: Candidate,
+  queryTerms: string[],
+): Promise<Candidate | null> {
+  let contents: string;
+  try {
+    contents = await readFile(join(projectRoot, candidate.entry.path), 'utf-8');
+  } catch {
+    store.deleteEntry(candidate.entry.path);
+    return null;
+  }
+
+  const currentHash = hashContents(contents);
+  if (currentHash === candidate.entry.hash) return candidate;
+
+  const summary = await summarizeForProject(projectRoot, candidate.entry.path, contents);
+  store.setEntry(candidate.entry.path, currentHash, summary);
+  const match = scoreSummary(summary, queryTerms);
+  if (!match) return null;
+  return { entry: candidate.entry, summary, matchedOn: match.matchedOn, score: match.score };
+}
+
+export async function searchByPurpose(
   projectRoot: string,
   query: string,
   limit?: number,
   pathPrefix?: string,
-): SearchByPurposeResult {
+): Promise<SearchByPurposeResult> {
+  // Never serve summaries from an invalidated generation (audit invariant I5).
+  ensureSummaryGeneration(projectRoot);
+
   const store = new CacheStore(projectRoot);
   const effectiveLimit = limit ?? 20;
 
@@ -46,70 +128,62 @@ export function searchByPurpose(
     : allEntries;
 
   const queryTerms = query.toLowerCase().split(/\s+/).filter(Boolean);
-  const results: Array<SearchResult & { score: number }> = [];
+  const candidates: Candidate[] = [];
 
   for (const entry of entries) {
     if (!entry.summary) continue;
-
-    const matchedOn: string[] = [];
-    let score = 0;
-
-    const purpose = entry.summary.purpose.toLowerCase();
-    const purposeMatches = queryTerms.filter(term => purpose.includes(term));
-    if (purposeMatches.length > 0) {
-      matchedOn.push('purpose');
-      score += purposeMatches.length * 3; // purpose matches weighted highest
-    }
-
-    const exportsLower = entry.summary.exports.map(e => e.toLowerCase());
-    const exportMatches = queryTerms.filter(term =>
-      exportsLower.some(exp => exp.includes(term))
-    );
-    if (exportMatches.length > 0) {
-      matchedOn.push('exports');
-      score += exportMatches.length * 2;
-    }
-
-    const declsLower = entry.summary.topLevelDeclarations.map(d => d.toLowerCase());
-    const declMatches = queryTerms.filter(term =>
-      declsLower.some(decl => decl.includes(term))
-    );
-    if (declMatches.length > 0) {
-      matchedOn.push('declarations');
-      score += declMatches.length;
-    }
-
-    if (matchedOn.length > 0) {
-      results.push({
-        path: entry.path,
-        purpose: entry.summary.purpose,
-        matchedOn,
-        exports: entry.summary.exports,
-        confidence: entry.summary.confidence,
-        score,
-      });
+    const match = scoreSummary(entry.summary, queryTerms);
+    if (match) {
+      candidates.push({ entry, summary: entry.summary, ...match });
     }
   }
 
   // Sort by score descending
-  results.sort((a, b) => b.score - a.score);
+  candidates.sort((a, b) => b.score - a.score);
 
-  const matched = results.slice(0, effectiveLimit);
+  // Validate before serving: walk the sorted candidates in score order until
+  // `limit` survive, so slots freed by dropped (deleted or no-longer-matching)
+  // files are backfilled from the remaining candidates in one pass.
+  const served: Candidate[] = [];
+  for (const candidate of candidates) {
+    if (served.length >= effectiveLimit) break;
+    const validated = await validateCandidate(projectRoot, store, candidate, queryTerms);
+    if (validated) served.push(validated);
+  }
 
-  // Track each matched file as a summary_served event.
-  // Token estimate: approximate raw file tokens from lineCount (avg ~40 chars/line).
-  const tracker = new TelemetryTracker(projectRoot);
-  for (const result of matched) {
-    const entry = entries.find(e => e.path === result.path);
-    // Approximate raw file tokens from lineCount (avg ~40 chars/line, ~4 chars/token)
-    const estimatedRawTokens = entry?.summary ? entry.summary.lineCount * 10 : 0;
-    tracker.trackEvent('summary_served', result.path, estimatedRawTokens);
+  // Telemetry: ONE summary_served event per query, not per hit. Per-hit
+  // tracking booked every matched file as a full read avoided, inflating
+  // "tokens saved" by up to `limit`x. The realistic counterfactual for one
+  // search is the agent grepping and then reading roughly ONE candidate file
+  // in full, so we book the estimated raw-content tokens of one average
+  // served file (lineCount x ~40 chars/line / ~4 chars/token = lineCount x 10).
+  // Best-effort: a telemetry write failure (e.g. locked DB) must never fail
+  // the read path.
+  if (served.length > 0) {
+    try {
+      const avgLineCount =
+        served.reduce((sum, c) => sum + c.summary.lineCount, 0) / served.length;
+      new TelemetryTracker(projectRoot).trackEvent(
+        'summary_served',
+        served[0].entry.path,
+        Math.round(avgLineCount * 10),
+        { query, resultCount: served.length },
+      );
+    } catch {
+      // Telemetry is best-effort on read paths (audit invariant I8).
+    }
   }
 
   return {
     query,
-    results: matched.map(({ score: _score, ...rest }) => rest),
-    totalCached: entries.filter(e => e.summary).length,
+    results: served.map((c) => ({
+      path: c.entry.path,
+      purpose: c.summary.purpose,
+      matchedOn: c.matchedOn,
+      exports: c.summary.exports,
+      confidence: c.summary.confidence,
+    })),
+    totalCached: entries.filter((e) => e.summary).length,
     ...(normalizedPrefix ? { scope: normalizedPrefix } : {}),
   };
 }

--- a/tests/unit/search-by-purpose.test.ts
+++ b/tests/unit/search-by-purpose.test.ts
@@ -1,10 +1,14 @@
 import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { hashContents } from '../../src/cache/hash.js';
+import { CacheStore } from '../../src/cache/store.js';
+import { clearConfigCache } from '../../src/config.js';
+import { clearSummaryGenerationCache } from '../../src/indexer/summarize.js';
+import { TelemetryTracker } from '../../src/telemetry/tracker.js';
 import { getFileSummary } from '../../src/tools/get-file-summary.js';
 import { searchByPurpose } from '../../src/tools/search-by-purpose.js';
-import { CacheStore } from '../../src/cache/store.js';
 
 describe('searchByPurpose', () => {
   let tempDir: string;
@@ -49,35 +53,35 @@ describe('searchByPurpose', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('matches on purpose field', () => {
+  it('matches on purpose field', async () => {
     // index.ts has purpose "entry point"
-    const result = searchByPurpose(tempDir, 'entry');
+    const result = await searchByPurpose(tempDir, 'entry');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const entryResult = result.results.find(r => r.path === 'src/index.ts');
     expect(entryResult).toBeDefined();
     expect(entryResult!.matchedOn).toContain('purpose');
   });
 
-  it('matches on exports field', () => {
-    const result = searchByPurpose(tempDir, 'authMiddleware');
+  it('matches on exports field', async () => {
+    const result = await searchByPurpose(tempDir, 'authMiddleware');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const matched = result.results.find(r => r.path === 'src/auth/middleware.ts');
     expect(matched).toBeDefined();
     expect(matched!.matchedOn).toContain('exports');
   });
 
-  it('matches on declarations field', () => {
-    const result = searchByPurpose(tempDir, 'DatabaseConnection');
+  it('matches on declarations field', async () => {
+    const result = await searchByPurpose(tempDir, 'DatabaseConnection');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const matched = result.results.find(r => r.path === 'src/db/connection.ts');
     expect(matched).toBeDefined();
     expect(matched!.matchedOn).toContain('declarations');
   });
 
-  it('returns matchedOn array correctly with multiple field matches', () => {
+  it('returns matchedOn array correctly with multiple field matches', async () => {
     // "validate" should match exports like validateToken, validateEmail, validatePassword
     // and declarations with the same names
-    const result = searchByPurpose(tempDir, 'validate');
+    const result = await searchByPurpose(tempDir, 'validate');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     for (const r of result.results) {
       expect(r.matchedOn.length).toBeGreaterThanOrEqual(1);
@@ -88,47 +92,76 @@ describe('searchByPurpose', () => {
     }
   });
 
-  it('respects limit', () => {
+  it('respects limit', async () => {
     // Search broadly to get multiple results
-    const result = searchByPurpose(tempDir, 'source', 2);
+    const result = await searchByPurpose(tempDir, 'source', 2);
     expect(result.results.length).toBeLessThanOrEqual(2);
   });
 
-  it('returns empty results for no matches', () => {
-    const result = searchByPurpose(tempDir, 'xyznonexistent');
+  it('returns empty results for no matches', async () => {
+    const result = await searchByPurpose(tempDir, 'xyznonexistent');
     expect(result.results).toEqual([]);
     expect(result.query).toBe('xyznonexistent');
     expect(result.totalCached).toBeGreaterThan(0);
   });
 
-  it('multiple query terms boost score', () => {
+  it('multiple query terms boost score', async () => {
     // "validate" matches validation.ts and middleware.ts (validateToken)
     // "email" only matches validation.ts
     // So "validate email" should rank validation.ts higher
-    const result = searchByPurpose(tempDir, 'validate email');
+    const result = await searchByPurpose(tempDir, 'validate email');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     expect(result.results[0].path).toBe('src/auth/validation.ts');
   });
 
-  it('returns totalCached count', () => {
-    const result = searchByPurpose(tempDir, 'source');
+  it('returns totalCached count', async () => {
+    const result = await searchByPurpose(tempDir, 'source');
     expect(result.totalCached).toBe(5);
   });
 
-  it('returns query in result', () => {
-    const result = searchByPurpose(tempDir, 'database');
+  it('returns query in result', async () => {
+    const result = await searchByPurpose(tempDir, 'database');
     expect(result.query).toBe('database');
   });
 
-  it('uses default limit of 20', () => {
-    const result = searchByPurpose(tempDir, 'source');
+  it('uses default limit of 20', async () => {
+    const result = await searchByPurpose(tempDir, 'source');
     // We only have 5 files, so all should be returned
     expect(result.results.length).toBeLessThanOrEqual(20);
   });
 
-  it('scopes results to a pathPrefix directory', () => {
+  it('tracks ONE summary_served event per query, not per hit', async () => {
+    const tracker = new TelemetryTracker(tempDir);
+    const before = tracker.getEvents({ eventType: 'summary_served' }).length;
+
+    const result = await searchByPurpose(tempDir, 'validate');
+    expect(result.results.length).toBeGreaterThan(1);
+
+    const after = tracker.getEvents({ eventType: 'summary_served' });
+    expect(after.length).toBe(before + 1);
+
+    // The single event books the estimated raw tokens of one average matched
+    // file (the realistic counterfactual is reading ~1 file), not a sum over
+    // every hit. (Pick by id: timestamp ordering can tie within a millisecond.)
+    const event = after.reduce((a, b) => (b.id > a.id ? b : a));
+    expect(event.tokensEstimated).toBeGreaterThan(0);
+    expect(event.metadata).toMatchObject({ query: 'validate', resultCount: result.results.length });
+  });
+
+  it('tracks no summary_served event when nothing matched', async () => {
+    const tracker = new TelemetryTracker(tempDir);
+    const before = tracker.getEvents({ eventType: 'summary_served' }).length;
+
+    const result = await searchByPurpose(tempDir, 'xyznonexistent');
+    expect(result.results).toEqual([]);
+
+    const after = tracker.getEvents({ eventType: 'summary_served' }).length;
+    expect(after).toBe(before);
+  });
+
+  it('scopes results to a pathPrefix directory', async () => {
     // "validate" matches files in src/auth (validation.ts, middleware.ts) — scope to that dir.
-    const result = searchByPurpose(tempDir, 'validate', undefined, 'src/auth');
+    const result = await searchByPurpose(tempDir, 'validate', undefined, 'src/auth');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     expect(result.results.every(r => r.path.startsWith('src/auth/'))).toBe(true);
     expect(result.scope).toBe('src/auth');
@@ -136,34 +169,37 @@ describe('searchByPurpose', () => {
     expect(result.totalCached).toBe(2);
   });
 
-  it('normalizes the pathPrefix (trailing slash, ./, and leading /)', () => {
-    const a = searchByPurpose(tempDir, 'database', undefined, 'src/db/');
-    const b = searchByPurpose(tempDir, 'database', undefined, './src/db');
-    const c = searchByPurpose(tempDir, 'database', undefined, '/src/db');
+  it('normalizes the pathPrefix (trailing slash, ./, and leading /)', async () => {
+    const a = await searchByPurpose(tempDir, 'database', undefined, 'src/db/');
+    const b = await searchByPurpose(tempDir, 'database', undefined, './src/db');
+    const c = await searchByPurpose(tempDir, 'database', undefined, '/src/db');
     expect(a.scope).toBe('src/db');
     expect(b.scope).toBe('src/db');
     expect(c.scope).toBe('src/db');
     expect(a.results.every(r => r.path.startsWith('src/db/'))).toBe(true);
   });
 
-  it('matches on a path boundary (prefix does not catch sibling names)', () => {
+  it('matches on a path boundary (prefix does not catch sibling names)', async () => {
     // "src/d" must NOT match "src/db/..." — only a full segment boundary counts.
-    const result = searchByPurpose(tempDir, 'database', undefined, 'src/d');
+    const result = await searchByPurpose(tempDir, 'database', undefined, 'src/d');
     expect(result.results).toEqual([]);
     expect(result.totalCached).toBe(0);
   });
 
-  it('omits scope when no pathPrefix is given', () => {
-    const result = searchByPurpose(tempDir, 'database');
+  it('omits scope when no pathPrefix is given', async () => {
+    const result = await searchByPurpose(tempDir, 'database');
     expect(result.scope).toBeUndefined();
   });
 
-  it('matches Windows-style (backslash) stored paths against a forward-slash pathPrefix', () => {
+  it('matches Windows-style (backslash) stored paths against a forward-slash pathPrefix', async () => {
     // Simulate a cache populated on Windows, where path.relative() yields
-    // backslash separators, by seeding an entry directly. A forward-slash
-    // pathPrefix must still scope it.
+    // backslash separators, by seeding an entry directly (the file exists with
+    // its literal backslash name so freshness validation passes). A
+    // forward-slash pathPrefix must still scope it.
+    const winContents = 'export function handleRequest() {}\n';
+    await writeFile(join(tempDir, 'src\\win\\handler.ts'), winContents);
     const store = new CacheStore(tempDir);
-    store.setEntry('src\\win\\handler.ts', 'deadbeef', {
+    store.setEntry('src\\win\\handler.ts', hashContents(winContents), {
       purpose: 'windows request handler',
       exports: ['handleRequest'],
       imports: [],
@@ -172,14 +208,131 @@ describe('searchByPurpose', () => {
       confidence: 'high',
     });
 
-    const result = searchByPurpose(tempDir, 'windows', undefined, 'src/win');
+    const result = await searchByPurpose(tempDir, 'windows', undefined, 'src/win');
     expect(result.scope).toBe('src/win');
     expect(result.results.some(r => r.path === 'src\\win\\handler.ts')).toBe(true);
   });
 
-  it('normalizes a Windows-style (backslash) pathPrefix to posix', () => {
-    const a = searchByPurpose(tempDir, 'database', undefined, 'src\\db');
+  it('normalizes a Windows-style (backslash) pathPrefix to posix', async () => {
+    const a = await searchByPurpose(tempDir, 'database', undefined, 'src\\db');
     expect(a.scope).toBe('src/db');
     expect(a.results.every(r => r.path.startsWith('src/db/'))).toBe(true);
+  });
+});
+
+describe('searchByPurpose freshness validation (invariant I5)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'repo-memory-search-fresh-'));
+    await mkdir(join(tempDir, 'src'), { recursive: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('serves fresh exports/purpose after a file is edited post-cache, never stale', async () => {
+    const path = 'src/users.ts';
+    await writeFile(
+      join(tempDir, path),
+      `export function fetchUserData() {}\nexport function legacyHelper() {}\n`,
+    );
+    await getFileSummary(tempDir, path);
+
+    // Edit the file behind the cache's back: the cached summary is now stale.
+    await writeFile(join(tempDir, path), `export function fetchUserRecords() {}\n`);
+
+    // "fetchuser" matches both the stale and the fresh exports, so the entry
+    // must be regenerated and served fresh.
+    const result = await searchByPurpose(tempDir, 'fetchUser');
+    const match = result.results.find(r => r.path === path);
+    expect(match).toBeDefined();
+    expect(match!.exports).toContain('fetchUserRecords');
+    expect(match!.exports).not.toContain('fetchUserData');
+    expect(match!.exports).not.toContain('legacyHelper');
+
+    // The cache entry was repaired through the standard path.
+    const entry = new CacheStore(tempDir).getEntry(path);
+    expect(entry!.hash).toBe(hashContents(`export function fetchUserRecords() {}\n`));
+    expect(entry!.summary!.exports).toContain('fetchUserRecords');
+  });
+
+  it('drops a stale match whose regenerated summary no longer matches the query', async () => {
+    const path = 'src/users.ts';
+    await writeFile(join(tempDir, path), `export function legacyHelper() {}\n`);
+    await getFileSummary(tempDir, path);
+
+    // The new content no longer mentions "legacy" anywhere.
+    await writeFile(join(tempDir, path), `export function fetchUserRecords() {}\n`);
+
+    const result = await searchByPurpose(tempDir, 'legacyHelper');
+    expect(result.results.find(r => r.path === path)).toBeUndefined();
+
+    // The regenerated summary was still persisted for future lookups.
+    const entry = new CacheStore(tempDir).getEntry(path);
+    expect(entry!.summary!.exports).toContain('fetchUserRecords');
+  });
+
+  it('never returns a deleted file and evicts its cache entry', async () => {
+    const path = 'src/ghost.ts';
+    await writeFile(join(tempDir, path), `export function phantomFeature() {}\n`);
+    await getFileSummary(tempDir, path);
+
+    await rm(join(tempDir, path));
+
+    const result = await searchByPurpose(tempDir, 'phantomFeature');
+    expect(result.results.find(r => r.path === path)).toBeUndefined();
+    expect(new CacheStore(tempDir).getEntry(path)).toBeNull();
+  });
+
+  it('backfills slots freed by dropped results so the caller still gets `limit` valid results', async () => {
+    // gateway.ts outscores helper.ts on "payment refund" (matches both terms),
+    // so it ranks first — then gets deleted. With limit 1, helper.ts must
+    // backfill the freed slot.
+    await writeFile(
+      join(tempDir, 'src/gateway.ts'),
+      `export function paymentGateway() {}\nexport function refundHandler() {}\n`,
+    );
+    await writeFile(join(tempDir, 'src/helper.ts'), `export function paymentHelper() {}\n`);
+    await getFileSummary(tempDir, 'src/gateway.ts');
+    await getFileSummary(tempDir, 'src/helper.ts');
+
+    await rm(join(tempDir, 'src/gateway.ts'));
+
+    const result = await searchByPurpose(tempDir, 'payment refund', 1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].path).toBe('src/helper.ts');
+  });
+
+  it('does not serve summaries from an invalidated generation after a summarizer mode switch', async () => {
+    const path = 'src/auth.ts';
+    await writeFile(join(tempDir, path), `export function validateToken() {}\n`);
+    await getFileSummary(tempDir, path); // cached under the default (ast) generation
+
+    const before = await searchByPurpose(tempDir, 'validateToken');
+    expect(before.results).toHaveLength(1);
+
+    // Switch summarizer mode: every stored summary belongs to a now-invalid
+    // generation. (clearConfigCache mimics a fresh process seeing the file.)
+    await writeFile(join(tempDir, '.repo-memory.json'), JSON.stringify({ summarizer: 'regex' }));
+    clearConfigCache();
+
+    // The search path must run the generation check itself: the old-generation
+    // summary is invalidated (regenerates lazily) rather than served.
+    const after = await searchByPurpose(tempDir, 'validateToken');
+    expect(after.results).toEqual([]);
+    expect(after.totalCached).toBe(0);
+    const entry = new CacheStore(tempDir).getEntry(path);
+    expect(entry).not.toBeNull();
+    expect(entry!.summary).toBeNull(); // cleared, hash kept for lazy regeneration
+
+    // And the standard summary path regenerates under the new generation.
+    const regenerated = await getFileSummary(tempDir, path);
+    expect(regenerated.fromCache).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #164. Closes #166.

`search_by_purpose` now honors the never-stale invariant (audit invariant I5): calls `ensureSummaryGeneration` before reading, then validates the matched top-limit entries — missing files are dropped and evicted, hash mismatches regenerate via the standard summary path and are re-scored, and freed slots backfill from remaining candidates in one pass.

Telemetry: one `summary_served` event per query (avg one served file's raw-token estimate — the realistic counterfactual is the agent reading ~1 file) instead of per-hit `lineCount × 10` inflation; writes are best-effort (try/catch) so a locked DB can't fail a read; O(matched × entries) lookup removed.

## Testing
462 unit + 7 integration pass; search suite 16 → 23 tests (fresh-after-edit, deleted-file eviction, backfill, generation-switch, telemetry contracts).