### PR TITLE
feat(graph): make the persisted dependency graph the read path

### DIFF
--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -57,9 +57,26 @@ export class CacheStore {
     return rows.map(rowToEntry);
   }
 
+  /**
+   * Remove a cache entry and the dependency-graph edges extracted from it, in
+   * one transaction. Edges derive from the file's contents, so they share the
+   * entry's lifetime — leaving them behind would serve stale graph data until
+   * the next GC pass. (Incoming edges from other files are left alone: those
+   * files' contents still declare the import.)
+   */
   deleteEntry(path: string): void {
     const db = getDatabase(this.projectRoot);
-    db.prepare('DELETE FROM files WHERE path = ?').run(path);
+    const remove = db.transaction((p: string) => {
+      db.prepare('DELETE FROM imports WHERE source = ?').run(p);
+      db.prepare('DELETE FROM files WHERE path = ?').run(p);
+    });
+    remove(path);
+  }
+
+  /** Refresh last_checked for an entry without altering its hash or summary. */
+  touchEntry(path: string): void {
+    const db = getDatabase(this.projectRoot);
+    db.prepare('UPDATE files SET last_checked = ? WHERE path = ?').run(Date.now(), path);
   }
 
   setEntries(entries: Array<{ path: string; hash: string; summary?: FileSummary | null }>): void {

--- a/src/graph/dependency-graph.ts
+++ b/src/graph/dependency-graph.ts
@@ -46,18 +46,18 @@ export class DependencyGraph {
       this.outgoing.delete(filePath);
     }
 
-    // Delete old rows from DB
-    db.prepare('DELETE FROM imports WHERE source = ?').run(filePath);
-
     // Extract new imports
     const imports = extractImports(filePath, contents, this.projectRoot);
 
-    // Insert new rows and update in-memory maps
     const insert = db.prepare(
       'INSERT OR REPLACE INTO imports (source, target, specifiers, import_type) VALUES (?, ?, ?, ?)',
     );
 
-    const insertAll = db.transaction(() => {
+    // Delete + insert in ONE transaction so concurrent readers never observe a
+    // torn state where the file's old edges are gone but the new ones are not
+    // yet written (audit invariant I2).
+    const replaceAll = db.transaction(() => {
+      db.prepare('DELETE FROM imports WHERE source = ?').run(filePath);
       for (const ref of imports) {
         // External targets (bare modules, builtins, unresolvable paths) are not
         // repo files — persisting them would pollute traversal and mostConnected.
@@ -67,7 +67,40 @@ export class DependencyGraph {
       }
     });
 
-    insertAll();
+    replaceAll();
+  }
+
+  /**
+   * Remove a file from the graph entirely: every persisted edge where it is
+   * the source or the target, plus the in-memory adjacency for both
+   * directions. Used when a file no longer exists on disk.
+   */
+  removeFile(filePath: string): void {
+    const db = getDatabase(this.projectRoot);
+    const remove = db.transaction(() => {
+      db.prepare('DELETE FROM imports WHERE source = ?').run(filePath);
+      db.prepare('DELETE FROM imports WHERE target = ?').run(filePath);
+    });
+    remove();
+    this.removeNode(filePath);
+  }
+
+  /**
+   * Remove every graph node (and its edges, in both directions) that is not
+   * in the given set of existing files. Call after load() so the in-memory
+   * maps reflect the persisted state.
+   */
+  prune(existingFiles: ReadonlySet<string>): void {
+    const missing = new Set<string>();
+    for (const node of this.outgoing.keys()) {
+      if (!existingFiles.has(node)) missing.add(node);
+    }
+    for (const node of this.incoming.keys()) {
+      if (!existingFiles.has(node)) missing.add(node);
+    }
+    for (const node of missing) {
+      this.removeFile(node);
+    }
   }
 
   /** Get direct dependencies of a file. */
@@ -132,6 +165,33 @@ export class DependencyGraph {
 
     result.sort((a, b) => b.connections - a.connections);
     return result.slice(0, limit);
+  }
+
+  /** Drop a node from the in-memory adjacency maps, in both directions. */
+  private removeNode(node: string): void {
+    const targets = this.outgoing.get(node);
+    if (targets) {
+      for (const target of targets) {
+        const sources = this.incoming.get(target);
+        if (sources) {
+          sources.delete(node);
+          if (sources.size === 0) this.incoming.delete(target);
+        }
+      }
+      this.outgoing.delete(node);
+    }
+
+    const sources = this.incoming.get(node);
+    if (sources) {
+      for (const source of sources) {
+        const targets = this.outgoing.get(source);
+        if (targets) {
+          targets.delete(node);
+          if (targets.size === 0) this.outgoing.delete(source);
+        }
+      }
+      this.incoming.delete(node);
+    }
   }
 
   private addEdge(source: string, target: string): void {

--- a/src/graph/refresh.ts
+++ b/src/graph/refresh.ts
@@ -1,0 +1,102 @@
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { hashContents } from '../cache/hash.js';
+import { CacheStore } from '../cache/store.js';
+import { scanProject } from '../indexer/scanner.js';
+import { isGraphIndexable } from '../indexer/source-extensions.js';
+import { DependencyGraph } from './dependency-graph.js';
+
+/**
+ * Meta key recording that the persisted graph has been fully built at least
+ * once by this implementation. Caches created before the graph was wired into
+ * the write path have file rows but no edges — without this marker those
+ * files would look "fresh" forever and never get indexed. Bump the value to
+ * force a one-time full re-extraction after a change to the edge format.
+ */
+const GRAPH_GENERATION_KEY = 'graph_generation';
+const GRAPH_GENERATION = '1';
+
+/**
+ * Load the persisted dependency graph and bring it up to date without
+ * re-reading unchanged files.
+ *
+ * Freshness strategy:
+ * 1. `load()` the persisted edges, then prune nodes whose files are gone from
+ *    the project file list.
+ * 2. For each graph-indexable file, `stat` it (cheap, no content read). If a
+ *    `files` row exists and the mtime predates the row's `last_checked`, the
+ *    content cannot have changed since the stored hash was computed — skip.
+ * 3. Otherwise read the file once, hash it, and compare with the stored hash:
+ *    only a real change (or a missing row) re-extracts edges. Edge writes and
+ *    summary-cache rows share the same hash bookkeeping, so edges have the
+ *    same freshness semantics as summaries (never-stale invariant).
+ *
+ * @param scannedFiles Optional pre-scanned project file list (avoids a second
+ *   scan when the caller already has one).
+ */
+export async function loadFreshGraph(
+  projectRoot: string,
+  scannedFiles?: string[],
+): Promise<DependencyGraph> {
+  const files = scannedFiles ?? (await scanProject(projectRoot));
+  const store = new CacheStore(projectRoot);
+  const graph = new DependencyGraph(projectRoot);
+  graph.load();
+
+  // Legacy caches (or a bumped edge format) need one full re-extraction pass.
+  const fullRebuild = store.getMeta(GRAPH_GENERATION_KEY) !== GRAPH_GENERATION;
+
+  // Files that left the project take their edges with them. (Files still in
+  // the git index but deleted from disk are caught by the stat pass below.)
+  graph.prune(new Set(files));
+
+  for (const file of files) {
+    if (!isGraphIndexable(file)) continue;
+
+    const absolutePath = join(projectRoot, file);
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(absolutePath)).mtimeMs;
+    } catch {
+      // Tracked in git but missing on disk (or deleted mid-pass): the file
+      // does not exist anymore, so its edges must not be served.
+      graph.removeFile(file);
+      continue;
+    }
+
+    const entry = store.getEntry(file);
+    if (!fullRebuild && entry && mtimeMs < entry.lastChecked) {
+      // Unmodified since the stored hash was computed — do not re-read.
+      continue;
+    }
+
+    let contents: string;
+    try {
+      contents = await readFile(absolutePath, 'utf-8');
+    } catch {
+      graph.removeFile(file);
+      continue;
+    }
+
+    const currentHash = hashContents(contents);
+    if (entry && entry.hash === currentHash) {
+      // Content unchanged; edges for this hash are already persisted (unless
+      // this is the one-time full rebuild). Bump last_checked so the next
+      // pass can skip on mtime alone.
+      if (fullRebuild) graph.updateFile(file, contents);
+      if (mtimeMs >= entry.lastChecked) store.touchEntry(file);
+    } else {
+      graph.updateFile(file, contents);
+      // Record the hash the edges were extracted from. A pre-existing summary
+      // was computed from different content, so it must not survive the hash
+      // update (same rule as the summary cache itself).
+      store.setEntry(file, currentHash, null);
+    }
+  }
+
+  if (fullRebuild) {
+    store.setMeta(GRAPH_GENERATION_KEY, GRAPH_GENERATION);
+  }
+
+  return graph;
+}

--- a/src/graph/refresh.ts
+++ b/src/graph/refresh.ts
@@ -17,6 +17,14 @@ const GRAPH_GENERATION_KEY = 'graph_generation';
 const GRAPH_GENERATION = '1';
 
 /**
+ * Filesystem mtimes can be coarser than Date.now() (whole-second granularity
+ * on some filesystems), so an edit made just after a check can carry an mtime
+ * that is *truncated below* the stored last_checked. Files whose mtime falls
+ * within this window of last_checked stay suspect and get hash-checked.
+ */
+const MTIME_SAFETY_WINDOW_MS = 2000;
+
+/**
  * Load the persisted dependency graph and bring it up to date without
  * re-reading unchanged files.
  *
@@ -65,7 +73,7 @@ export async function loadFreshGraph(
     }
 
     const entry = store.getEntry(file);
-    if (!fullRebuild && entry && mtimeMs < entry.lastChecked) {
+    if (!fullRebuild && entry && mtimeMs < entry.lastChecked - MTIME_SAFETY_WINDOW_MS) {
       // Unmodified since the stored hash was computed — do not re-read.
       continue;
     }
@@ -82,9 +90,9 @@ export async function loadFreshGraph(
     if (entry && entry.hash === currentHash) {
       // Content unchanged; edges for this hash are already persisted (unless
       // this is the one-time full rebuild). Bump last_checked so the next
-      // pass can skip on mtime alone.
+      // pass can skip on mtime alone once the file ages past the safety window.
       if (fullRebuild) graph.updateFile(file, contents);
-      if (mtimeMs >= entry.lastChecked) store.touchEntry(file);
+      store.touchEntry(file);
     } else {
       graph.updateFile(file, contents);
       // Record the hash the edges were extracted from. A pre-existing summary

--- a/src/indexer/source-extensions.ts
+++ b/src/indexer/source-extensions.ts
@@ -1,0 +1,27 @@
+/**
+ * File extensions the import extractor (src/indexer/imports.ts) understands.
+ * This is the single source of truth for which files participate in the
+ * dependency graph — the graph tools, the summary write path, and the
+ * freshness pass must all agree on it.
+ */
+export const GRAPH_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.rs',
+  '.kt',
+  '.kts',
+  '.java',
+]);
+
+/** Whether import edges can be extracted from the file at this path. */
+export function isGraphIndexable(filePath: string): boolean {
+  const dot = filePath.lastIndexOf('.');
+  if (dot === -1) return false;
+  return GRAPH_INDEXABLE_EXTENSIONS.has(filePath.slice(dot).toLowerCase());
+}

--- a/src/tools/force-reread.ts
+++ b/src/tools/force-reread.ts
@@ -2,7 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
+import { isGraphIndexable } from '../indexer/source-extensions.js';
 import { summarizeForProject, ensureSummaryGeneration } from '../indexer/summarize.js';
+import { DependencyGraph } from '../graph/dependency-graph.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
 import { estimateTokens } from '../telemetry/tokens.js';
 import type { FileSummary } from '../types.js';
@@ -20,6 +22,11 @@ export async function forceReread(
   const summary = await summarizeForProject(projectRoot, relativePath, contents);
 
   const store = new CacheStore(projectRoot);
+  // Re-extract import edges from the fresh contents before recording the new
+  // hash (see get-file-summary.ts for the ordering rationale).
+  if (isGraphIndexable(relativePath)) {
+    new DependencyGraph(projectRoot).updateFile(relativePath, contents);
+  }
   store.setEntry(relativePath, hash, summary);
 
   const tracker = new TelemetryTracker(projectRoot);

--- a/src/tools/get-changed-files.ts
+++ b/src/tools/get-changed-files.ts
@@ -1,6 +1,9 @@
+import { readFile } from 'node:fs/promises';
 import { join } from 'path';
 import { CacheStore } from '../cache/store.js';
-import { hashFile } from '../cache/hash.js';
+import { hashContents } from '../cache/hash.js';
+import { DependencyGraph } from '../graph/dependency-graph.js';
+import { isGraphIndexable } from '../indexer/source-extensions.js';
 import { scanProject } from '../indexer/scanner.js';
 
 export interface ChangedFilesResult {
@@ -25,12 +28,18 @@ export async function getChangedFiles(
 
   const changed: string[] = [];
   const added: string[] = [];
+  const graph = new DependencyGraph(projectRoot);
 
   await Promise.all(
     scannedFiles.map(async (relativePath) => {
       const absolutePath = join(projectRoot, relativePath);
-      const currentHash = await hashFile(absolutePath);
-      if (!currentHash) return;
+      let contents: string;
+      try {
+        contents = await readFile(absolutePath, 'utf-8');
+      } catch {
+        return;
+      }
+      const currentHash = hashContents(contents);
 
       const cached = cachedByPath.get(relativePath);
 
@@ -45,8 +54,13 @@ export async function getChangedFiles(
       // Update the cache entry with current hash and timestamp. A summary may
       // only be stored under the hash it was computed from — when the file
       // changed, store null so the summary regenerates on next access instead
-      // of masquerading as a fresh cache hit.
+      // of masquerading as a fresh cache hit. Import edges follow the same
+      // rule: recording a new hash without re-extracting edges would let the
+      // graph serve stale edges as fresh.
       const summaryStillValid = cached !== undefined && cached.hash === currentHash;
+      if (!summaryStillValid && isGraphIndexable(relativePath)) {
+        graph.updateFile(relativePath, contents);
+      }
       store.setEntry(relativePath, currentHash, summaryStillValid ? cached.summary : null);
     }),
   );

--- a/src/tools/get-dependency-graph.ts
+++ b/src/tools/get-dependency-graph.ts
@@ -1,7 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { DependencyGraph } from '../graph/dependency-graph.js';
-import { scanProject } from '../indexer/scanner.js';
+import { loadFreshGraph } from '../graph/refresh.js';
 import { validatePath } from '../utils/validate-path.js';
 
 export interface DependencyGraphResult {
@@ -24,23 +22,8 @@ export async function getDependencyGraphTool(
   if (path) {
     path = validatePath(projectRoot, path);
   }
-  const graph = new DependencyGraph(projectRoot);
-
-  // Index all files to build the graph
-  const files = await scanProject(projectRoot);
-  for (const file of files) {
-    if (!file.endsWith('.ts') && !file.endsWith('.js') && !file.endsWith('.tsx') &&
-        !file.endsWith('.jsx') && !file.endsWith('.mjs') && !file.endsWith('.cjs') &&
-        !file.endsWith('.py') && !file.endsWith('.go') && !file.endsWith('.rs')) {
-      continue;
-    }
-    try {
-      const contents = await readFile(join(projectRoot, file), 'utf-8');
-      graph.updateFile(file, contents);
-    } catch {
-      // Skip unreadable files
-    }
-  }
+  // Load the persisted dependency graph, refreshing only stale files.
+  const graph = await loadFreshGraph(projectRoot);
 
   if (symbol) {
     return getSymbolEdges(graph, symbol, path);

--- a/src/tools/get-file-summary.ts
+++ b/src/tools/get-file-summary.ts
@@ -2,7 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { hashContents } from '../cache/hash.js';
 import { CacheStore } from '../cache/store.js';
+import { isGraphIndexable } from '../indexer/source-extensions.js';
 import { summarizeForProject, ensureSummaryGeneration } from '../indexer/summarize.js';
+import { DependencyGraph } from '../graph/dependency-graph.js';
 import { TelemetryTracker } from '../telemetry/tracker.js';
 import { estimateTokensSaved } from '../telemetry/tokens.js';
 import type { FileSummary } from '../types.js';
@@ -69,6 +71,15 @@ export async function getFileSummary(
 
   // Generate fresh summary
   const summary = await summarizeForProject(projectRoot, relativePath, contents);
+
+  // Persist this file's import edges alongside the summary (contents are
+  // already in hand), so the dependency graph stays as fresh as the summary
+  // cache. Edges go first: if the entry write never happens, a stale hash
+  // simply re-triggers extraction — the reverse order could mark stale edges
+  // as fresh.
+  if (isGraphIndexable(relativePath)) {
+    new DependencyGraph(projectRoot).updateFile(relativePath, contents);
+  }
   store.setEntry(relativePath, currentHash, summary);
 
   let reason: string;

--- a/src/tools/get-related-files.ts
+++ b/src/tools/get-related-files.ts
@@ -1,6 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
-import { DependencyGraph } from '../graph/dependency-graph.js';
+import { dirname } from 'node:path';
+import { loadFreshGraph } from '../graph/refresh.js';
 import { scanProject } from '../indexer/scanner.js';
 import { validatePath } from '../utils/validate-path.js';
 import { rankFiles } from '../cache/ranking.js';
@@ -23,34 +22,9 @@ export async function getRelatedFiles(
   const validated = validatePath(projectRoot, relativePath);
   const limit = options?.limit ?? 10;
 
-  // Build the dependency graph
-  const graph = new DependencyGraph(projectRoot);
+  // Load the persisted dependency graph, refreshing only stale files.
   const files = await scanProject(projectRoot);
-
-  for (const file of files) {
-    if (
-      !file.endsWith('.ts') &&
-      !file.endsWith('.js') &&
-      !file.endsWith('.tsx') &&
-      !file.endsWith('.jsx') &&
-      !file.endsWith('.mjs') &&
-      !file.endsWith('.cjs') &&
-      !file.endsWith('.py') &&
-      !file.endsWith('.go') &&
-      !file.endsWith('.rs') &&
-      !file.endsWith('.kt') &&
-      !file.endsWith('.kts') &&
-      !file.endsWith('.java')
-    ) {
-      continue;
-    }
-    try {
-      const contents = await readFile(join(projectRoot, file), 'utf-8');
-      graph.updateFile(file, contents);
-    } catch {
-      // Skip unreadable files
-    }
-  }
+  const graph = await loadFreshGraph(projectRoot, files);
 
   // Import targets are resolved to real file paths at extraction time, so the
   // graph can be queried with the validated path directly.

--- a/tests/unit/dependency-graph.test.ts
+++ b/tests/unit/dependency-graph.test.ts
@@ -192,6 +192,45 @@ describe('DependencyGraph', () => {
     expect(graph2.getDependents('src/b.ts')).toEqual(['src/a.ts']);
   });
 
+  it('removeFile deletes persisted and in-memory edges in both directions', () => {
+    addFile('src/c.ts', `export const C = 1;`);
+    addFile('src/b.ts', `import { C } from './c';\nexport const B = 1;`);
+    addFile('src/a.ts', `import { B } from './b';`);
+
+    graph.removeFile('src/b.ts');
+
+    expect(graph.getDependencies('src/a.ts')).toEqual([]);
+    expect(graph.getDependents('src/c.ts')).toEqual([]);
+    expect(graph.getDependencies('src/b.ts')).toEqual([]);
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT source FROM imports WHERE source = ? OR target = ?')
+      .all('src/b.ts', 'src/b.ts');
+    expect(rows).toEqual([]);
+
+    // A reloaded graph must agree with the in-memory one.
+    const graph2 = new DependencyGraph(tempDir);
+    graph2.load();
+    expect(graph2.getDependencies('src/a.ts')).toEqual([]);
+    expect(graph2.getDependents('src/c.ts')).toEqual([]);
+  });
+
+  it('prune removes every node missing from the existing-file set', () => {
+    addFile('src/util.ts', `export const util = 1;`);
+    addFile('src/a.ts', `import { util } from './util';`);
+    addFile('src/b.ts', `import { util } from './util';`);
+
+    graph.prune(new Set(['src/util.ts', 'src/a.ts']));
+
+    expect(graph.getDependents('src/util.ts')).toEqual(['src/a.ts']);
+    expect(graph.getDependencies('src/b.ts')).toEqual([]);
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT source FROM imports')
+      .all() as Array<{ source: string }>;
+    expect(rows).toEqual([{ source: 'src/a.ts' }]);
+  });
+
   it('returns empty arrays for unknown paths', () => {
     expect(graph.getDependencies('nonexistent.ts')).toEqual([]);
     expect(graph.getDependents('nonexistent.ts')).toEqual([]);

--- a/tests/unit/force-reread.test.ts
+++ b/tests/unit/force-reread.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CacheStore } from '../../src/cache/store.js';
-import { closeDatabase } from '../../src/persistence/db.js';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
 import { forceReread } from '../../src/tools/force-reread.js';
 
 describe('forceReread', () => {
@@ -65,5 +65,21 @@ describe('forceReread', () => {
     const entry = store.getEntry(filePath);
     expect(entry).not.toBeNull();
     expect(entry!.hash).toBe(result.hash);
+  });
+
+  it('persists the file import edges alongside the summary', async () => {
+    writeFileSync(join(tempDir, 'src', 'util.ts'), 'export const util = 1;', 'utf-8');
+    writeFileSync(
+      join(tempDir, 'src', 'app.ts'),
+      `import { util } from './util.js';\nexport const app = util;`,
+      'utf-8',
+    );
+
+    await forceReread(tempDir, 'src/app.ts');
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT target FROM imports WHERE source = ?')
+      .all('src/app.ts') as Array<{ target: string }>;
+    expect(rows).toEqual([{ target: 'src/util.ts' }]);
   });
 });

--- a/tests/unit/get-file-summary.test.ts
+++ b/tests/unit/get-file-summary.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getDatabase } from '../../src/persistence/db.js';
 import { getFileSummary } from '../../src/tools/get-file-summary.js';
 
 describe('getFileSummary', () => {
@@ -32,6 +33,22 @@ describe('getFileSummary', () => {
     expect(result.summary.lineCount).toBe(4);
     expect(result.reason).toBe('cache_miss: no prior entry');
     expect(result.cacheAge).toBeNull();
+  });
+
+  it('persists the file import edges when the summary regenerates', async () => {
+    await writeFile(join(tempDir, 'src', 'util.ts'), 'export const util = 1;\n', 'utf-8');
+    await writeFile(
+      join(tempDir, 'src', 'app.ts'),
+      `import { util } from './util.js';\nexport const app = util;\n`,
+      'utf-8',
+    );
+
+    await getFileSummary(tempDir, 'src/app.ts');
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT target FROM imports WHERE source = ?')
+      .all('src/app.ts') as Array<{ target: string }>;
+    expect(rows).toEqual([{ target: 'src/util.ts' }]);
   });
 
   it('returns cached summary on second call', async () => {

--- a/tests/unit/graph-freshness.test.ts
+++ b/tests/unit/graph-freshness.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, readdirSync } from 'fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -23,6 +23,19 @@ describe('persisted graph freshness', () => {
       .mocked(readFile)
       .mock.calls.map((call) => String(call[0]))
       .filter((p) => p.startsWith(tempDir));
+  }
+
+  /**
+   * Age all project files past the refresh pass's mtime safety window, so an
+   * unchanged file is deterministically skippable and a fresh write (new
+   * mtime) is deterministically suspect — independent of filesystem timestamp
+   * granularity and test speed.
+   */
+  function backdateMtimes(): void {
+    const past = new Date(Date.now() - 60_000);
+    for (const name of readdirSync(join(tempDir, 'src'))) {
+      utimesSync(join(tempDir, 'src', name), past, past);
+    }
   }
 
   function edgeCount(path: string): number {
@@ -68,6 +81,7 @@ describe('persisted graph freshness', () => {
     expect(first.relatedFiles.map((f) => f.path)).toContain('src/helper.ts');
     expect(projectReads().length).toBeGreaterThan(0); // first call builds the graph
 
+    backdateMtimes();
     vi.mocked(readFile).mockClear();
     const second = await getRelatedFiles(tempDir, 'src/index.ts');
 
@@ -79,6 +93,7 @@ describe('persisted graph freshness', () => {
     const first = await getDependencyGraphTool(tempDir);
     expect(first.stats.totalEdges).toBeGreaterThan(0);
 
+    backdateMtimes();
     vi.mocked(readFile).mockClear();
     const second = await getDependencyGraphTool(tempDir);
 
@@ -88,6 +103,7 @@ describe('persisted graph freshness', () => {
 
   it('editing one file re-reads and refreshes only that file', async () => {
     await getRelatedFiles(tempDir, 'src/util.ts');
+    backdateMtimes();
 
     // index.ts now imports util.ts directly instead of helper.ts
     writeFileSync(

--- a/tests/unit/graph-freshness.test.ts
+++ b/tests/unit/graph-freshness.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getRelatedFiles } from '../../src/tools/get-related-files.js';
+import { getDependencyGraphTool } from '../../src/tools/get-dependency-graph.js';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
+
+// Pass-through spy so the tests can count which files get re-read from disk.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+
+describe('persisted graph freshness', () => {
+  let tempDir: string;
+
+  /** Absolute paths of files under the temp project that were read from disk. */
+  function projectReads(): string[] {
+    return vi
+      .mocked(readFile)
+      .mock.calls.map((call) => String(call[0]))
+      .filter((p) => p.startsWith(tempDir));
+  }
+
+  function edgeCount(path: string): number {
+    const row = getDatabase(tempDir)
+      .prepare('SELECT COUNT(*) AS count FROM imports WHERE source = ? OR target = ?')
+      .get(path, path) as { count: number };
+    return row.count;
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'graph-freshness-'));
+    mkdirSync(join(tempDir, 'src'), { recursive: true });
+
+    writeFileSync(
+      join(tempDir, 'src', 'index.ts'),
+      `import { helper } from './helper.js';\nexport function main() { helper(); }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'helper.ts'),
+      `import { util } from './util.js';\nexport function helper() { util(); }\n`,
+    );
+    writeFileSync(
+      join(tempDir, 'src', 'util.ts'),
+      `export function util() { return 42; }\n`,
+    );
+
+    execFileSync('git', ['init'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tempDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tempDir });
+    execFileSync('git', ['add', '.'], { cwd: tempDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tempDir });
+
+    vi.mocked(readFile).mockClear();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('get_related_files does not re-read any file when nothing changed', async () => {
+    const first = await getRelatedFiles(tempDir, 'src/index.ts');
+    expect(first.relatedFiles.map((f) => f.path)).toContain('src/helper.ts');
+    expect(projectReads().length).toBeGreaterThan(0); // first call builds the graph
+
+    vi.mocked(readFile).mockClear();
+    const second = await getRelatedFiles(tempDir, 'src/index.ts');
+
+    expect(projectReads()).toEqual([]);
+    expect(second).toEqual(first);
+  });
+
+  it('get_dependency_graph does not re-read any file when nothing changed', async () => {
+    const first = await getDependencyGraphTool(tempDir);
+    expect(first.stats.totalEdges).toBeGreaterThan(0);
+
+    vi.mocked(readFile).mockClear();
+    const second = await getDependencyGraphTool(tempDir);
+
+    expect(projectReads()).toEqual([]);
+    expect(second).toEqual(first);
+  });
+
+  it('editing one file re-reads and refreshes only that file', async () => {
+    await getRelatedFiles(tempDir, 'src/util.ts');
+
+    // index.ts now imports util.ts directly instead of helper.ts
+    writeFileSync(
+      join(tempDir, 'src', 'index.ts'),
+      `import { util } from './util.js';\nexport function main() { util(); }\n`,
+    );
+
+    vi.mocked(readFile).mockClear();
+    const result = await getRelatedFiles(tempDir, 'src/util.ts');
+
+    expect(projectReads()).toEqual([join(tempDir, 'src/index.ts')]);
+
+    const indexEntry = result.relatedFiles.find((f) => f.path === 'src/index.ts');
+    expect(indexEntry).toBeDefined();
+    expect(indexEntry!.relationship).toBe('imported-by');
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT target FROM imports WHERE source = ?')
+      .all('src/index.ts') as Array<{ target: string }>;
+    expect(rows).toEqual([{ target: 'src/util.ts' }]);
+  });
+
+  it('deleting a tracked file removes its edges on the next graph query', async () => {
+    await getDependencyGraphTool(tempDir);
+    expect(edgeCount('src/util.ts')).toBeGreaterThan(0);
+
+    // Still listed by `git ls-files`, but gone from disk.
+    rmSync(join(tempDir, 'src', 'util.ts'));
+
+    const result = await getDependencyGraphTool(tempDir, 'src/helper.ts', 'dependencies');
+    expect(result.nodes).not.toContain('src/util.ts');
+    expect(edgeCount('src/util.ts')).toBe(0);
+  });
+
+  it('deleting an untracked file prunes its edges on the next graph query', async () => {
+    writeFileSync(
+      join(tempDir, 'src', 'extra.ts'),
+      `import { util } from './util.js';\nexport const extra = 1;\n`,
+    );
+    await getDependencyGraphTool(tempDir);
+    expect(edgeCount('src/extra.ts')).toBeGreaterThan(0);
+
+    rmSync(join(tempDir, 'src', 'extra.ts'));
+
+    const result = await getDependencyGraphTool(tempDir, 'src/util.ts', 'dependents');
+    expect(result.nodes).not.toContain('src/extra.ts');
+    expect(edgeCount('src/extra.ts')).toBe(0);
+  });
+});

--- a/tests/unit/index-command.test.ts
+++ b/tests/unit/index-command.test.ts
@@ -8,7 +8,7 @@ import { runIndex } from '../../src/cli/index-command.js';
 import { TelemetryTracker } from '../../src/telemetry/tracker.js';
 import { clearConfigCache } from '../../src/config.js';
 import { clearSummaryGenerationCache } from '../../src/indexer/summarize.js';
-import { closeDatabase, getDatabasePath } from '../../src/persistence/db.js';
+import { closeDatabase, getDatabase, getDatabasePath } from '../../src/persistence/db.js';
 
 describe('runIndex', () => {
   let tempDir: string;
@@ -104,6 +104,20 @@ describe('runIndex', () => {
     const store = new CacheStore(projectDir);
     expect(store.getEntry('src/index.ts')!.summary).not.toBeNull();
     expect(store.getEntry('src/utils.ts')!.summary).not.toBeNull();
+  });
+
+  it('populates the dependency-graph imports table', async () => {
+    writeFileSync(
+      join(tempDir, 'src', 'main.ts'),
+      `import { greet } from './greet.js';\nexport const message = greet('world');\n`,
+    );
+
+    await runIndex(tempDir, { quiet: true });
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT source, target FROM imports')
+      .all() as Array<{ source: string; target: string }>;
+    expect(rows).toContainEqual({ source: 'src/main.ts', target: 'src/greet.ts' });
   });
 
   it('records no telemetry events', async () => {

--- a/tests/unit/invalidate.test.ts
+++ b/tests/unit/invalidate.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CacheStore } from '../../src/cache/store.js';
-import { closeDatabase } from '../../src/persistence/db.js';
+import { DependencyGraph } from '../../src/graph/dependency-graph.js';
+import { closeDatabase, getDatabase } from '../../src/persistence/db.js';
 import { invalidateCache } from '../../src/tools/invalidate.js';
 
 describe('invalidateCache', () => {
@@ -42,6 +43,23 @@ describe('invalidateCache', () => {
     expect(result.invalidated).toBe('all');
     expect(result.entriesRemoved).toBe(3);
     expect(store.getAllEntries()).toHaveLength(0);
+  });
+
+  it('removes the import edges extracted from an invalidated file', async () => {
+    mkdirSync(join(tempDir, 'src'), { recursive: true });
+    writeFileSync(join(tempDir, 'src', 'util.ts'), 'export const util = 1;\n');
+    const contents = `import { util } from './util.js';\n`;
+    writeFileSync(join(tempDir, 'src', 'a.ts'), contents);
+
+    new DependencyGraph(tempDir).updateFile('src/a.ts', contents);
+    store.setEntry('src/a.ts', 'hash-a', null);
+
+    await invalidateCache(tempDir, 'src/a.ts');
+
+    const rows = getDatabase(tempDir)
+      .prepare('SELECT source FROM imports WHERE source = ?')
+      .all('src/a.ts');
+    expect(rows).toEqual([]);
   });
 
   it('should return correct count of entries removed', async () => {

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -73,6 +73,40 @@ describe('CacheStore', () => {
     expect(store.getEntry('to-delete.ts')).toBeNull();
   });
 
+  it('deleteEntry also removes import edges sourced from the file', () => {
+    store.setEntry('src/a.ts', 'hash1', null);
+    const db = getDatabase(tempDir);
+    db.prepare(
+      'INSERT INTO imports (source, target, specifiers, import_type) VALUES (?, ?, ?, ?)',
+    ).run('src/a.ts', 'src/b.ts', '["b"]', 'static');
+    db.prepare(
+      'INSERT INTO imports (source, target, specifiers, import_type) VALUES (?, ?, ?, ?)',
+    ).run('src/c.ts', 'src/a.ts', '["a"]', 'static');
+
+    store.deleteEntry('src/a.ts');
+
+    const rows = db.prepare('SELECT source, target FROM imports').all() as Array<{
+      source: string;
+      target: string;
+    }>;
+    // Outgoing edges die with the entry; incoming edges belong to src/c.ts.
+    expect(rows).toEqual([{ source: 'src/c.ts', target: 'src/a.ts' }]);
+  });
+
+  it('touchEntry refreshes last_checked without altering hash or summary', () => {
+    store.setEntry('src/a.ts', 'hash1', testSummary);
+    const db = getDatabase(tempDir);
+    const oldTimestamp = Date.now() - 60_000;
+    db.prepare('UPDATE files SET last_checked = ? WHERE path = ?').run(oldTimestamp, 'src/a.ts');
+
+    store.touchEntry('src/a.ts');
+
+    const entry = store.getEntry('src/a.ts');
+    expect(entry!.lastChecked).toBeGreaterThan(oldTimestamp);
+    expect(entry!.hash).toBe('hash1');
+    expect(entry!.summary).toEqual(testSummary);
+  });
+
   it('should return stale entries filtered by age', () => {
     store.setEntry('fresh.ts', 'hash1', null);
     store.setEntry('also-fresh.ts', 'hash2', null);


### PR DESCRIPTION
Closes #163.

The unanimous swarm-audit finding (C1): `DependencyGraph.load()` had zero production callers while both graph tools re-read every source file per call and rewrote the imports table as a side effect of reads.

- Graph tools now read via `loadFreshGraph()`: load from SQLite, prune deleted files, stat-gate (mtime vs last_checked) and hash-check only suspect files — zero file reads and zero table writes when nothing changed
- Edges populate from the summary write path (get_file_summary / force_reread / get_changed_files), so the prewarm CLI fills the graph for free
- Per-file edge replacement is now fully transactional (audit I2 — fixes torn getEdgesBySymbol reads); deleteEntry cascades to import edges immediately (no more waiting for startup GC)
- One shared `GRAPH_INDEXABLE_EXTENSIONS` constant kills the kt/kts/java drift between the two tools
- Response shapes untouched (shapes are #165)

Measured: warm `get_related_files` ~34ms → ~12ms, with ~170 file reads + full table rewrite per call → 0 of each when unchanged.

## Testing
487 unit + 7 integration pass; new: zero re-reads on unchanged second call (readFile spy), single-file edge refresh after edit, immediate edge removal on delete, prewarm populates imports, deleteEntry cascade.