### PR TITLE
fix(persistence): harden multi-process and multi-version concurrency

### DIFF
--- a/src/cache/generation.ts
+++ b/src/cache/generation.ts
@@ -1,0 +1,68 @@
+/**
+ * Summarizer generation bookkeeping, shared by the cache store and the
+ * indexer. This lives below both layers so `CacheStore` can enforce the
+ * generation rules on summary writes without importing the indexer (which
+ * itself imports the store).
+ *
+ * The generation tag stored in the meta table has the form `<mode>:<N>`
+ * (e.g. `ast:3`). Two rules govern it:
+ *
+ * - **Numeric monotonicity.** The numeric generation `N` may only increase.
+ *   A process running an older package version than the one that last tagged
+ *   the database must never clear summaries, never write summaries, and never
+ *   regress the tag. Real workflows hit this: a long-running MCP server and an
+ *   `npx` post-merge hook can share one cache at different package versions.
+ * - **Mode is last-writer-wins.** A mode difference (regex vs ast) at the same
+ *   `N` means per-process configuration disagrees, which is a user
+ *   misconfiguration; flipping the mode legitimately clears and re-tags, so
+ *   the monotonicity rule applies to the numeric generation only.
+ */
+
+/**
+ * Bump when summary output changes in a way that should invalidate previously
+ * cached summaries (combined with the mode into the generation tag).
+ *
+ * Generation 2: the AST summarizer gained Python/Go/Rust support, so summaries
+ * for those languages cached under ast mode (which were regex-produced
+ * fallbacks at generation 1) must lazily regenerate.
+ *
+ * Generation 3: the AST summarizer gained Kotlin/Java support, so summaries
+ * for those languages cached under ast mode (regex-produced generic
+ * classifications at earlier generations) must lazily regenerate.
+ */
+export const SUMMARIZER_GENERATION = 3;
+
+/** Meta table key holding the generation tag (`<mode>:<N>`). */
+export const GENERATION_META_KEY = 'summarizer_generation';
+
+let generationOverride: number | null = null;
+
+/** Test hook: pretend this process runs a different package generation. */
+export function setSummarizerGenerationForTests(generation: number | null): void {
+  generationOverride = generation;
+}
+
+/** The summarizer generation this process writes. */
+export function currentSummarizerGeneration(): number {
+  return generationOverride ?? SUMMARIZER_GENERATION;
+}
+
+/** Parse a stored `<mode>:<N>` tag. Returns null for missing or unparseable tags. */
+export function parseGenerationTag(
+  tag: string | null,
+): { mode: string; generation: number } | null {
+  if (tag === null) return null;
+  const match = /^([a-z]+):(\d+)$/.exec(tag);
+  if (!match) return null;
+  return { mode: match[1], generation: Number(match[2]) };
+}
+
+/**
+ * True when the stored tag was written by a strictly newer generation than
+ * this process — in which case this process must not persist summaries or
+ * touch the tag (see module doc).
+ */
+export function isStoredGenerationNewer(storedTag: string | null): boolean {
+  const parsed = parseGenerationTag(storedTag);
+  return parsed !== null && parsed.generation > currentSummarizerGeneration();
+}

--- a/src/cache/invalidation.ts
+++ b/src/cache/invalidation.ts
@@ -40,13 +40,12 @@ export class CacheInvalidator {
   }
 
   /**
-   * Delete all cache entries.
+   * Delete all cache entries in one atomic statement — entries written by a
+   * concurrent process cannot slip through the way they could with a
+   * snapshot-then-delete loop.
    */
   invalidateAll(): void {
-    const entries = this.store.getAllEntries();
-    for (const entry of entries) {
-      this.store.deleteEntry(entry.path);
-    }
+    this.store.deleteAllEntries();
   }
 
   /**

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -1,4 +1,6 @@
+import type { Database } from 'better-sqlite3';
 import { getDatabase } from '../persistence/db.js';
+import { GENERATION_META_KEY, isStoredGenerationNewer } from './generation.js';
 import type { CacheEntry, FileSummary } from '../types.js';
 
 interface FileRow {
@@ -7,6 +9,27 @@ interface FileRow {
   last_checked: number;
   summary_json: string | null;
 }
+
+const UPSERT_ENTRY = `INSERT INTO files (path, hash, last_checked, summary_json)
+   VALUES (?, ?, ?, ?)
+   ON CONFLICT(path) DO UPDATE SET
+     hash = excluded.hash,
+     last_checked = excluded.last_checked,
+     summary_json = excluded.summary_json`;
+
+/**
+ * Upsert used when a lower-generation process tried to write a summary
+ * (read-through mode): the hash and timestamp are persisted so change
+ * detection stays correct, but the summary is not — and a newer-generation
+ * summary already stored for the *same hash* is preserved rather than nulled.
+ * (`files.hash` in the CASE refers to the pre-update row value.)
+ */
+const UPSERT_ENTRY_WITHOUT_SUMMARY = `INSERT INTO files (path, hash, last_checked, summary_json)
+   VALUES (?, ?, ?, NULL)
+   ON CONFLICT(path) DO UPDATE SET
+     summary_json = CASE WHEN files.hash = excluded.hash THEN files.summary_json ELSE NULL END,
+     hash = excluded.hash,
+     last_checked = excluded.last_checked`;
 
 function rowToEntry(row: FileRow): CacheEntry {
   return {
@@ -35,17 +58,28 @@ export class CacheStore {
 
   setEntry(path: string, hash: string, summary: FileSummary | null): void {
     const db = getDatabase(this.projectRoot);
-    const summaryJson = summary ? JSON.stringify(summary) : null;
     const now = Date.now();
 
-    db.prepare(
-      `INSERT INTO files (path, hash, last_checked, summary_json)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(path) DO UPDATE SET
-         hash = excluded.hash,
-         last_checked = excluded.last_checked,
-         summary_json = excluded.summary_json`,
-    ).run(path, hash, now, summaryJson);
+    if (summary === null) {
+      // A single statement is already atomic, and a null summary is safe to
+      // write at any generation — no guard needed.
+      db.prepare(UPSERT_ENTRY).run(path, hash, now, null);
+      return;
+    }
+
+    // Summary writes re-check the stored generation tag every time (cheap
+    // single-row read) instead of trusting the per-process memoization in
+    // ensureSummaryGeneration: an external writer (e.g. a newer package
+    // version run by a post-merge hook) may have bumped the generation since
+    // this process last looked. BEGIN IMMEDIATE holds the write lock across
+    // the check and the write so the tag cannot change in between.
+    db.transaction(() => {
+      if (this.summaryWritesBlocked(db)) {
+        db.prepare(UPSERT_ENTRY_WITHOUT_SUMMARY).run(path, hash, now);
+      } else {
+        db.prepare(UPSERT_ENTRY).run(path, hash, now, JSON.stringify(summary));
+      }
+    }).immediate();
   }
 
   getAllEntries(): CacheEntry[] {
@@ -82,23 +116,35 @@ export class CacheStore {
   setEntries(entries: Array<{ path: string; hash: string; summary?: FileSummary | null }>): void {
     const db = getDatabase(this.projectRoot);
     const now = Date.now();
-    const stmt = db.prepare(
-      `INSERT INTO files (path, hash, last_checked, summary_json)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(path) DO UPDATE SET
-         hash = excluded.hash,
-         last_checked = excluded.last_checked,
-         summary_json = excluded.summary_json`,
-    );
+    const upsert = db.prepare(UPSERT_ENTRY);
+    const upsertWithoutSummary = db.prepare(UPSERT_ENTRY_WITHOUT_SUMMARY);
 
-    const runBatch = db.transaction(() => {
+    // IMMEDIATE so the generation check and the batch write happen under one
+    // uninterrupted write lock (see setEntry).
+    db.transaction(() => {
+      const blocked = this.summaryWritesBlocked(db);
       for (const entry of entries) {
-        const summaryJson = entry.summary ? JSON.stringify(entry.summary) : null;
-        stmt.run(entry.path, entry.hash, now, summaryJson);
+        if (entry.summary && blocked) {
+          upsertWithoutSummary.run(entry.path, entry.hash, now);
+        } else {
+          const summaryJson = entry.summary ? JSON.stringify(entry.summary) : null;
+          upsert.run(entry.path, entry.hash, now, summaryJson);
+        }
       }
-    });
+    }).immediate();
+  }
 
-    runBatch();
+  /**
+   * Whether the stored generation tag belongs to a strictly newer package
+   * generation than this process, in which case summary writes from this
+   * process must not be persisted (Guardian I3). Must be called while the
+   * write lock is held so the answer cannot change before the write lands.
+   */
+  private summaryWritesBlocked(db: Database): boolean {
+    const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(GENERATION_META_KEY) as
+      | { value: string }
+      | undefined;
+    return isStoredGenerationNewer(row?.value ?? null);
   }
 
   /** Read a value from the meta key/value table. */
@@ -127,6 +173,40 @@ export class CacheStore {
   clearAllSummaries(): void {
     const db = getDatabase(this.projectRoot);
     db.prepare('UPDATE files SET summary_json = NULL').run();
+  }
+
+  /**
+   * Atomically drop all summaries and write a meta value in one IMMEDIATE
+   * transaction (Guardian I4). Used for generation bumps: no other process
+   * can insert an old-generation summary between the clear and the tag write,
+   * and a crash between the two is unobservable.
+   */
+  clearAllSummariesAndSetMeta(key: string, value: string): void {
+    const db = getDatabase(this.projectRoot);
+    db.transaction(() => {
+      db.prepare('UPDATE files SET summary_json = NULL').run();
+      db.prepare(
+        `INSERT INTO meta (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      ).run(key, value);
+    }).immediate();
+  }
+
+  /**
+   * Run `fn` while holding the database write lock (BEGIN IMMEDIATE). Use for
+   * read-decide-write sequences that must not interleave with writes from
+   * other processes. Nested store calls that open their own transactions
+   * collapse into savepoints inside this one.
+   */
+  withWriteLock<T>(fn: () => T): T {
+    const db = getDatabase(this.projectRoot);
+    return db.transaction(fn).immediate();
+  }
+
+  /** Delete every cache entry in a single atomic statement. */
+  deleteAllEntries(): void {
+    const db = getDatabase(this.projectRoot);
+    db.prepare('DELETE FROM files').run();
   }
 
   getStaleEntries(maxAge: number): CacheEntry[] {

--- a/src/indexer/summarize.ts
+++ b/src/indexer/summarize.ts
@@ -1,5 +1,10 @@
 import { loadConfig } from '../config.js';
 import { CacheStore } from '../cache/store.js';
+import {
+  GENERATION_META_KEY,
+  currentSummarizerGeneration,
+  isStoredGenerationNewer,
+} from '../cache/generation.js';
 import { summarizeFile } from './summarizer.js';
 import { summarizeFileAst } from './ast-summarizer.js';
 import type { FileSummary } from '../types.js';
@@ -7,25 +12,12 @@ import type { FileSummary } from '../types.js';
 /**
  * Config-aware summarizer dispatch. Call sites that generate summaries go
  * through here so the `summarizer` setting in .repo-memory.json takes effect.
+ *
+ * The generation constant and tag rules live in src/cache/generation.ts so
+ * the cache store can enforce them on every summary write.
  */
 
 export type SummarizerMode = 'regex' | 'ast';
-
-/**
- * Bump when summary output changes in a way that should invalidate previously
- * cached summaries (combined with the mode into the generation tag).
- *
- * Generation 2: the AST summarizer gained Python/Go/Rust support, so summaries
- * for those languages cached under ast mode (which were regex-produced
- * fallbacks at generation 1) must lazily regenerate.
- *
- * Generation 3: the AST summarizer gained Kotlin/Java support, so summaries
- * for those languages cached under ast mode (regex-produced generic
- * classifications at earlier generations) must lazily regenerate.
- */
-const SUMMARIZER_GENERATION = 3;
-
-const META_KEY = 'summarizer_generation';
 
 const generationChecked = new Map<string, string>();
 
@@ -49,28 +41,54 @@ export async function summarizeForProject(
  * Ensure cached summaries were produced by the currently configured
  * summarizer. When the mode (or generation) changes, all stored summaries are
  * dropped — hashes stay, so change detection is unaffected and summaries
- * regenerate lazily — and the new generation tag is recorded.
+ * regenerate lazily — and the new generation tag is recorded, atomically with
+ * the clear.
+ *
+ * Generations are monotonic: when the stored tag belongs to a *newer*
+ * generation than this process (e.g. an npx post-merge hook at a newer
+ * package version retagged the cache while this long-running server kept an
+ * older build in memory), this process must not clear, must not regress the
+ * tag, and must not persist its own summaries. It keeps working read-through:
+ * summaries it computes are served from memory, and CacheStore strips them on
+ * write (see setEntry/setEntries), so the cache never mixes generations and
+ * old/new version alternation cannot cause clear-storms. Mode flips (regex vs
+ * ast) at the same numeric generation are last-writer-wins by design — see
+ * src/cache/generation.ts.
  *
  * Must run before any cache lookup that can return a stored summary.
  */
 export function ensureSummaryGeneration(projectRoot: string): void {
-  const tag = `${getSummarizerMode(projectRoot)}:${SUMMARIZER_GENERATION}`;
+  const tag = `${getSummarizerMode(projectRoot)}:${currentSummarizerGeneration()}`;
   if (generationChecked.get(projectRoot) === tag) return;
 
   const store = new CacheStore(projectRoot);
-  const stored = store.getMeta(META_KEY);
-  if (stored !== tag) {
+  // Read-decide-write under the write lock, so another process cannot bump
+  // the generation between our read of the tag and our clear (Guardian I3).
+  const reconciled = store.withWriteLock(() => {
+    const stored = store.getMeta(GENERATION_META_KEY);
+    if (stored === tag) return true;
+    if (isStoredGenerationNewer(stored)) {
+      // Never downgrade — a newer package version owns this cache.
+      return false;
+    }
     // Regex output is unchanged since generation 1, so summaries produced by
     // any earlier regex generation — including pre-marker databases, which
     // carried no tag — are still valid under regex generation 3 and only need
     // re-tagging.
     const stillValid = tag === 'regex:3' && (stored === null || /^regex:[12]$/.test(stored));
-    if (!stillValid) {
-      store.clearAllSummaries();
+    if (stillValid) {
+      store.setMeta(GENERATION_META_KEY, tag);
+    } else {
+      store.clearAllSummariesAndSetMeta(GENERATION_META_KEY, tag);
     }
-    store.setMeta(META_KEY, tag);
-  }
-  generationChecked.set(projectRoot, tag);
+    return true;
+  });
+
+  // Memoize the happy path only. A process running behind the stored
+  // generation re-checks on every call (one cheap row read) so it recovers
+  // immediately if it is ever upgraded in place; its summary writes are
+  // independently guarded inside CacheStore either way.
+  if (reconciled) generationChecked.set(projectRoot, tag);
 }
 
 /** Test hook: forget which projects already had their generation verified. */

--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -106,26 +106,46 @@ const MIGRATIONS: Array<{ version: number; up: (db: Database.Database) => void }
   },
 ];
 
-function runMigrations(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS schema_version (
-      version INTEGER PRIMARY KEY,
-      applied_at INTEGER NOT NULL
-    );
-  `);
+function latestMigrationVersion(): number {
+  return Math.max(...MIGRATIONS.map((m) => m.version));
+}
 
+function appliedSchemaVersion(db: Database.Database): number {
   const applied = db
     .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
     .get() as { version: number } | undefined;
+  return applied?.version ?? 0;
+}
 
-  const currentVersion = applied?.version ?? 0;
-
-  const sortedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
-  const insertVersion = db.prepare(
-    'INSERT INTO schema_version (version, applied_at) VALUES (?, ?)',
-  );
-
+/**
+ * Concurrent-safe migrations (Guardian I9). Two processes opening a fresh
+ * database at the same time (MCP server start + post-merge hook prewarm) must
+ * both succeed:
+ *
+ * - The whole sequence runs under BEGIN IMMEDIATE, so competing processes
+ *   serialize: the loser waits on the write lock (up to busy_timeout) instead
+ *   of interleaving.
+ * - `schema_version` is read *inside* the transaction, so the loser sees the
+ *   winner's rows once it gets the lock and applies nothing.
+ * - If the transaction still fails (busy_timeout exceeded, or a constraint
+ *   from a writer not using this protocol), the failure is tolerated when
+ *   another process has already completed the migrations.
+ */
+function runMigrations(db: Database.Database): void {
   const applyMigrations = db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+      );
+    `);
+
+    const currentVersion = appliedSchemaVersion(db);
+    const sortedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
+    const insertVersion = db.prepare(
+      'INSERT INTO schema_version (version, applied_at) VALUES (?, ?)',
+    );
+
     for (const migration of sortedMigrations) {
       if (migration.version > currentVersion) {
         migration.up(db);
@@ -134,7 +154,51 @@ function runMigrations(db: Database.Database): void {
     }
   });
 
-  applyMigrations();
+  try {
+    applyMigrations.immediate();
+  } catch (err) {
+    if (migrationsAlreadyApplied(db)) {
+      return; // lost the race; another process migrated the database
+    }
+    throw err;
+  }
+}
+
+function migrationsAlreadyApplied(db: Database.Database): boolean {
+  try {
+    return appliedSchemaVersion(db) >= latestMigrationVersion();
+  } catch {
+    return false; // schema_version table itself is missing or unreadable
+  }
+}
+
+/**
+ * Switching a fresh database into WAL takes a brief exclusive lock, and SQLite
+ * returns SQLITE_BUSY from a journal-mode change *without invoking the busy
+ * handler* when another connection holds a conflicting lock — so the
+ * connection's busy_timeout does not cover this one statement. Two processes
+ * opening a brand-new database together (MCP server start + post-merge hook
+ * prewarm) hit exactly that, so retry briefly. Once the database is in WAL
+ * the pragma is a no-op and never contends again.
+ */
+function enableWalMode(db: Database.Database): void {
+  const deadline = Date.now() + 5000;
+  for (;;) {
+    try {
+      db.pragma('journal_mode = WAL');
+      return;
+    } catch (err) {
+      if ((err as { code?: string }).code !== 'SQLITE_BUSY' || Date.now() >= deadline) {
+        throw err;
+      }
+      sleepSync(10);
+    }
+  }
+}
+
+/** Synchronous sleep without blocking-spin (better-sqlite3 is a sync API). */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /** Absolute path of the cache database for a project (whether or not it exists yet). */
@@ -160,8 +224,9 @@ export function getDatabase(projectRoot: string): Database.Database {
     mkdirSync(dbDir, { recursive: true });
   }
 
-  const db = new Database(dbPath);
-  db.pragma('journal_mode = WAL');
+  const db = new Database(dbPath, { timeout: 5000 });
+  enableWalMode(db);
+  db.pragma('busy_timeout = 5000');
   db.pragma('foreign_keys = ON');
 
   runMigrations(db);

--- a/tests/integration/migration-race.test.ts
+++ b/tests/integration/migration-race.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import Database from 'better-sqlite3';
+
+/**
+ * Guardian I9: two processes opening a fresh database concurrently must both
+ * run the migrations safely and exit 0. Before the BEGIN IMMEDIATE +
+ * in-transaction version re-read fix, the loser of the race crashed on the
+ * schema_version PRIMARY KEY constraint — exactly the documented workflow of
+ * an MCP server starting while a post-merge hook prewarms the cache.
+ *
+ * The persistence module is compiled standalone into node_modules/.cache so
+ * the children run real `node` processes without needing a full dist/ build.
+ */
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const harnessDir = join(projectRoot, 'node_modules', '.cache', 'repo-memory-migration-race');
+const childScript = join(harnessDir, 'child.mjs');
+
+const CHILD_SOURCE = `import { getDatabase, closeDatabase } from './db.js';
+
+const projectDir = process.argv[2];
+getDatabase(projectDir);
+closeDatabase();
+`;
+
+function runChild(projectDir: string): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [childScript, projectDir], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stderr }));
+  });
+}
+
+describe('concurrent first-run migrations (multi-process)', () => {
+  beforeAll(() => {
+    rmSync(harnessDir, { recursive: true, force: true });
+    mkdirSync(harnessDir, { recursive: true });
+    execFileSync(
+      process.execPath,
+      [
+        join(projectRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+        'src/persistence/db.ts',
+        '--outDir',
+        harnessDir,
+        '--module',
+        'nodenext',
+        '--moduleResolution',
+        'nodenext',
+        '--target',
+        'es2022',
+        '--skipLibCheck',
+      ],
+      { cwd: projectRoot },
+    );
+    // Pin the harness to ESM regardless of what else lives under .cache.
+    writeFileSync(join(harnessDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    writeFileSync(childScript, CHILD_SOURCE);
+  });
+
+  afterAll(() => {
+    rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it('multiple processes racing on a fresh database all exit 0 and migrations apply once', async () => {
+    // A few rounds to give the processes a real chance to collide.
+    for (let round = 0; round < 3; round++) {
+      const projectDir = mkdtempSync(join(tmpdir(), 'migration-race-'));
+      try {
+        const results = await Promise.all(
+          Array.from({ length: 4 }, () => runChild(projectDir)),
+        );
+        for (const result of results) {
+          expect(result.code, result.stderr).toBe(0);
+        }
+
+        const db = new Database(join(projectDir, '.repo-memory', 'cache.db'), {
+          readonly: true,
+        });
+        const versions = (
+          db.prepare('SELECT version FROM schema_version ORDER BY version').all() as Array<{
+            version: number;
+          }>
+        ).map((r) => r.version);
+        db.close();
+
+        // Applied exactly once each, contiguous from 1.
+        expect(versions).toEqual(Array.from({ length: versions.length }, (_, i) => i + 1));
+        expect(versions.length).toBeGreaterThanOrEqual(6);
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
 import { getDatabase, closeDatabase } from '../../src/persistence/db.js';
 
 describe('persistence layer', () => {
@@ -62,5 +63,57 @@ describe('persistence layer', () => {
     const row = db.prepare('SELECT * FROM files WHERE path = ?').get('src/test.ts') as { path: string; hash: string };
     expect(row.path).toBe('src/test.ts');
     expect(row.hash).toBe('abc123');
+  });
+
+  it('sets an explicit busy_timeout', () => {
+    const db = getDatabase(tempDir);
+    const timeout = db.pragma('busy_timeout', { simple: true }) as number;
+    expect(timeout).toBe(5000);
+  });
+
+  it('opens a database another connection already fully migrated (race loser path)', () => {
+    // "Process 1" migrates the fresh database and closes.
+    getDatabase(tempDir);
+    closeDatabase();
+
+    // "Process 2" opens it: the in-transaction version re-read must see the
+    // applied migrations and apply nothing, without throwing.
+    const db = getDatabase(tempDir);
+    const count = db.prepare('SELECT COUNT(*) AS n FROM schema_version').get() as { n: number };
+    const max = db.prepare('SELECT MAX(version) AS v FROM schema_version').get() as { v: number };
+    expect(count.n).toBe(max.v); // one row per version, no duplicates
+  });
+
+  it('completes a partially migrated database left by another process', () => {
+    // Simulate an older package version that only knew migrations 1-3.
+    const dbDir = join(tempDir, '.repo-memory');
+    mkdirSync(dbDir, { recursive: true });
+    const raw = new Database(join(dbDir, 'cache.db'));
+    raw.pragma('journal_mode = WAL');
+    raw.exec(`
+      CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+      CREATE TABLE files (path TEXT PRIMARY KEY, hash TEXT NOT NULL, last_checked INTEGER NOT NULL, summary_json TEXT);
+      CREATE TABLE tasks (id TEXT PRIMARY KEY, name TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'created', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, session_id TEXT, metadata_json TEXT);
+      CREATE TABLE task_files (task_id TEXT NOT NULL, file_path TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'explored', notes TEXT, explored_at INTEGER NOT NULL, PRIMARY KEY (task_id, file_path), FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE);
+      CREATE TABLE imports (source TEXT NOT NULL, target TEXT NOT NULL, specifiers TEXT NOT NULL, import_type TEXT NOT NULL, PRIMARY KEY (source, target, import_type));
+      CREATE INDEX idx_imports_target ON imports (target);
+      INSERT INTO schema_version (version, applied_at) VALUES (1, 1), (2, 2), (3, 3);
+    `);
+    raw.close();
+
+    const db = getDatabase(tempDir);
+    const versions = (
+      db.prepare('SELECT version FROM schema_version ORDER BY version').all() as Array<{
+        version: number;
+      }>
+    ).map((r) => r.version);
+    expect(versions.slice(0, 3)).toEqual([1, 2, 3]);
+    expect(versions.length).toBeGreaterThanOrEqual(6);
+    for (const table of ['telemetry', 'sessions', 'meta']) {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+        .get(table);
+      expect(row, `table ${table} should exist`).toBeDefined();
+    }
   });
 });

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -137,4 +137,49 @@ describe('CacheStore', () => {
     const all = store.getAllEntries();
     expect(all).toHaveLength(1);
   });
+
+  it('clearAllSummariesAndSetMeta clears summaries and writes the tag together', () => {
+    store.setEntry('a.ts', 'hash-a', testSummary);
+    store.setEntry('b.ts', 'hash-b', testSummary);
+
+    store.clearAllSummariesAndSetMeta('summarizer_generation', 'ast:99');
+
+    expect(store.getEntry('a.ts')!.summary).toBeNull();
+    expect(store.getEntry('b.ts')!.summary).toBeNull();
+    expect(store.getEntry('a.ts')!.hash).toBe('hash-a'); // hashes survive
+    expect(store.getMeta('summarizer_generation')).toBe('ast:99');
+  });
+
+  it('clearAllSummariesAndSetMeta rolls back the clear when the tag write fails (I4)', () => {
+    store.setEntry('a.ts', 'hash-a', testSummary);
+    store.setMeta('summarizer_generation', 'ast:1');
+
+    // meta.value is NOT NULL — binding null makes the second statement of the
+    // transaction fail, and the clear must roll back with it.
+    expect(() =>
+      store.clearAllSummariesAndSetMeta('summarizer_generation', null as unknown as string),
+    ).toThrow();
+
+    expect(store.getEntry('a.ts')!.summary).toEqual(testSummary);
+    expect(store.getMeta('summarizer_generation')).toBe('ast:1');
+  });
+
+  it('deleteAllEntries removes every row', () => {
+    store.setEntry('a.ts', 'hash-a', null);
+    store.setEntry('b.ts', 'hash-b', testSummary);
+
+    store.deleteAllEntries();
+
+    expect(store.getAllEntries()).toHaveLength(0);
+  });
+
+  it('withWriteLock returns the callback result and commits its writes', () => {
+    const result = store.withWriteLock(() => {
+      store.setEntry('locked.ts', 'hash-l', null);
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(store.getEntry('locked.ts')).not.toBeNull();
+  });
 });

--- a/tests/unit/summarize-generation.test.ts
+++ b/tests/unit/summarize-generation.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  ensureSummaryGeneration,
+  clearSummaryGenerationCache,
+} from '../../src/indexer/summarize.js';
+import {
+  GENERATION_META_KEY,
+  setSummarizerGenerationForTests,
+  parseGenerationTag,
+  isStoredGenerationNewer,
+} from '../../src/cache/generation.js';
+import { CacheStore } from '../../src/cache/store.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { clearConfigCache } from '../../src/config.js';
+import type { FileSummary } from '../../src/types.js';
+
+function summaryFor(generation: number): FileSummary {
+  return {
+    purpose: `gen${generation}`,
+    exports: [],
+    imports: [],
+    lineCount: 1,
+    topLevelDeclarations: [],
+    confidence: 'high',
+  };
+}
+
+describe('summarizer generation monotonicity (Guardian I3)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'summarize-gen-test-'));
+    clearConfigCache();
+    clearSummaryGenerationCache();
+    setSummarizerGenerationForTests(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setSummarizerGenerationForTests(null);
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('interleaved gen-N and gen-N+1 processes leave only gen-N+1 summaries and clear exactly once', () => {
+    const clearSpy = vi.spyOn(CacheStore.prototype, 'clearAllSummariesAndSetMeta');
+
+    // "Process A" (generation 3) boots and tags the fresh database.
+    setSummarizerGenerationForTests(3);
+    ensureSummaryGeneration(tempDir);
+    const storeA = new CacheStore(tempDir);
+    storeA.setEntry('a.ts', 'hash-a', summaryFor(3));
+    expect(storeA.getEntry('a.ts')?.summary?.purpose).toBe('gen3');
+    expect(storeA.getMeta(GENERATION_META_KEY)).toBe('ast:3');
+    const clearsAfterBootstrap = clearSpy.mock.calls.length;
+
+    // "Process B" (generation 4) starts — fresh memoization — and upgrades.
+    setSummarizerGenerationForTests(4);
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    const storeB = new CacheStore(tempDir);
+    expect(storeB.getMeta(GENERATION_META_KEY)).toBe('ast:4');
+    expect(storeB.getEntry('a.ts')?.summary).toBeNull(); // gen-3 summary cleared
+    expect(clearSpy.mock.calls.length).toBe(clearsAfterBootstrap + 1); // the upgrade clear
+    storeB.setEntry('b.ts', 'hash-b', summaryFor(4));
+
+    // Process A again, still memoized at generation 3: its summary writes
+    // must not persist (read-through) but hashes must, so change detection
+    // keeps working.
+    setSummarizerGenerationForTests(3);
+    storeA.setEntry('c.ts', 'hash-c', summaryFor(3));
+    expect(storeA.getEntry('c.ts')?.hash).toBe('hash-c');
+    expect(storeA.getEntry('c.ts')?.summary).toBeNull();
+
+    // A re-writes b.ts at the same hash: B's newer summary is preserved, not
+    // overwritten and not nulled.
+    storeA.setEntry('b.ts', 'hash-b', summaryFor(3));
+    expect(storeA.getEntry('b.ts')?.summary?.purpose).toBe('gen4');
+
+    // A re-runs its generation check (memo no longer matches): it must not
+    // clear and must not regress the tag.
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    expect(storeA.getMeta(GENERATION_META_KEY)).toBe('ast:4');
+    expect(clearSpy.mock.calls.length).toBe(clearsAfterBootstrap + 1);
+
+    // B re-checks: tag already current, nothing to do.
+    setSummarizerGenerationForTests(4);
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    expect(clearSpy.mock.calls.length).toBe(clearsAfterBootstrap + 1);
+
+    // Final state: exactly one clear for the upgrade, only gen-4 summaries.
+    const persisted = new CacheStore(tempDir).getAllEntries().filter((e) => e.summary !== null);
+    expect(persisted.map((e) => `${e.path}:${e.summary?.purpose}`)).toEqual(['b.ts:gen4']);
+  });
+
+  it('strips summaries (but keeps hashes) from lower-generation batch writes', () => {
+    setSummarizerGenerationForTests(4);
+    ensureSummaryGeneration(tempDir);
+
+    setSummarizerGenerationForTests(3);
+    const store = new CacheStore(tempDir);
+    store.setEntries([
+      { path: 'x.ts', hash: 'hash-x', summary: summaryFor(3) },
+      { path: 'y.ts', hash: 'hash-y' },
+    ]);
+
+    expect(store.getEntry('x.ts')?.hash).toBe('hash-x');
+    expect(store.getEntry('x.ts')?.summary).toBeNull();
+    expect(store.getEntry('y.ts')?.hash).toBe('hash-y');
+    expect(store.getEntry('y.ts')?.summary).toBeNull();
+  });
+
+  it('compares generations numerically, not lexicographically', () => {
+    setSummarizerGenerationForTests(10);
+    ensureSummaryGeneration(tempDir);
+    const store = new CacheStore(tempDir);
+    expect(store.getMeta(GENERATION_META_KEY)).toBe('ast:10');
+
+    // '9' > '10' as strings; numerically 9 < 10, so gen 9 must stand down.
+    setSummarizerGenerationForTests(9);
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    expect(store.getMeta(GENERATION_META_KEY)).toBe('ast:10');
+    store.setEntry('z.ts', 'hash-z', summaryFor(9));
+    expect(store.getEntry('z.ts')?.summary).toBeNull();
+
+    // And gen 11 may upgrade.
+    setSummarizerGenerationForTests(11);
+    clearSummaryGenerationCache();
+    ensureSummaryGeneration(tempDir);
+    expect(store.getMeta(GENERATION_META_KEY)).toBe('ast:11');
+  });
+
+  it('treats an unparseable stored tag as upgradeable, never as newer', () => {
+    const store = new CacheStore(tempDir);
+    store.setMeta(GENERATION_META_KEY, 'not-a-tag');
+
+    setSummarizerGenerationForTests(3);
+    store.setEntry('a.ts', 'hash-a', summaryFor(3));
+    expect(store.getEntry('a.ts')?.summary?.purpose).toBe('gen3'); // writes allowed
+
+    ensureSummaryGeneration(tempDir);
+    expect(store.getMeta(GENERATION_META_KEY)).toBe('ast:3'); // re-tagged
+  });
+
+  it('parses tags strictly', () => {
+    expect(parseGenerationTag('ast:3')).toEqual({ mode: 'ast', generation: 3 });
+    expect(parseGenerationTag('regex:12')).toEqual({ mode: 'regex', generation: 12 });
+    expect(parseGenerationTag(null)).toBeNull();
+    expect(parseGenerationTag('ast')).toBeNull();
+    expect(parseGenerationTag('ast:')).toBeNull();
+    expect(parseGenerationTag(':3')).toBeNull();
+    expect(parseGenerationTag('ast:3:4')).toBeNull();
+  });
+
+  it('mode differences at the same generation are not "newer" (last-writer-wins)', () => {
+    setSummarizerGenerationForTests(3);
+    expect(isStoredGenerationNewer('regex:3')).toBe(false);
+    expect(isStoredGenerationNewer('ast:3')).toBe(false);
+    expect(isStoredGenerationNewer('regex:4')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #167.

Implements Guardian audit invariants I3/I4/I8/I9 for the documented real workflow: long-running MCP server + npx post-merge hooks at potentially different package versions sharing one cache.db.

- **Generation monotonicity (I3):** generation tags compared numerically; a process behind the stored generation computes and returns summaries in-memory but persists only hash+timestamp (read-through), never clears, never regresses the tag. Recheck happens at the CacheStore.setEntry/setEntries choke points under BEGIN IMMEDIATE, so the tag can't move between check and write.
- **Atomic clear+tag (I4):** `clearAllSummariesAndSetMeta` in one transaction (rollback proven by fault-injection test)
- **Concurrent-safe migrations (I9):** IMMEDIATE transaction, in-transaction version re-read, race-loser tolerance; real 4-process spawn test, all exit 0, migrations applied exactly once
- Explicit `busy_timeout=5000`; `invalidateAll` now atomic
- **Bonus bug found by the spawn test:** `PRAGMA journal_mode=WAL` on a brand-new DB returns SQLITE_BUSY without invoking the busy handler when two processes race it — the server-start + post-merge-hook workflow crashed there. Fixed with a bounded retry.

## Testing
500 unit + 8 integration pass (rebased on #172 and re-verified); 14 new tests incl. the I3 interleave proof (only newer-generation summaries survive, exactly one clear) and the multi-process migration race.