### PR TITLE
fix(cache): make relevance ranking rank (live signals, relationship, centrality)

### DIFF
--- a/src/cache/ranking.ts
+++ b/src/cache/ranking.ts
@@ -3,19 +3,21 @@ import type { DependencyGraph } from '../graph/dependency-graph.js';
 import type { CacheStore } from './store.js';
 
 export interface RankingSignals {
+  relationship: number;         // 0-1, how the candidate relates to the query file
   dependencyProximity: number;  // 0-1, how close in dependency graph
   recency: number;              // 0-1, how recently accessed/modified
   fileTypeRelevance: number;    // 0-1, source > config > test
   taskContextRelevance: number; // 0-1, related to task's explored set
-  changeFrequency: number;      // 0-1, how often the file changes
+  centrality: number;           // 0-1, degree centrality (hub files score higher)
 }
 
 export interface RankingWeights {
+  relationship: number;
   dependencyProximity: number;
   recency: number;
   fileTypeRelevance: number;
   taskContextRelevance: number;
-  changeFrequency: number;
+  centrality: number;
 }
 
 export interface RankedFile {
@@ -31,15 +33,58 @@ export interface RankingOptions {
   flaggedFiles?: string[];
   graph?: DependencyGraph;
   cacheStore?: CacheStore;
+  /**
+   * The file the caller asked about. Used as a proximity anchor so
+   * dependencyProximity works even without task-explored files.
+   */
+  queryFile?: string;
+  /**
+   * Pre-classified relationship of each candidate to the query file
+   * (e.g. 'imports', 'imported-by', 'transitive-dependency', 'same-directory').
+   * Candidates absent from the map get a relationship score of 0.
+   */
+  relationships?: ReadonlyMap<string, string>;
   limit?: number;
 }
 
+/**
+ * Default signal weights (sum to 1.0 so composite scores stay in [0, 1]).
+ *
+ * Rationale:
+ * - relationship (0.30): the strongest evidence available — *why* the
+ *   candidate is in the result set. Direct imports/dependents beat
+ *   transitive links beat same-directory bystanders.
+ * - dependencyProximity (0.25): hop distance in the import graph from the
+ *   query file (and from task-explored files when a task is active).
+ *   Reinforces relationship and differentiates within the transitive bucket.
+ * - recency (0.15): files indexed/seen recently in this session are more
+ *   likely part of the current working set (4-hour half-life decay).
+ * - taskContextRelevance (0.15): directory adjacency to the active task's
+ *   explored/flagged files; constant when no task is active.
+ * - fileTypeRelevance (0.10): mild prior for source over config over tests.
+ * - centrality (0.05): log-scaled degree centrality — a deliberate
+ *   tiebreaker so hub files edge out leaf files when structural signals
+ *   tie, without importance ever outranking a direct relationship.
+ */
 export const DEFAULT_WEIGHTS: RankingWeights = {
-  dependencyProximity: 0.3,
-  recency: 0.2,
-  fileTypeRelevance: 0.15,
-  taskContextRelevance: 0.25,
-  changeFrequency: 0.1,
+  relationship: 0.3,
+  dependencyProximity: 0.25,
+  recency: 0.15,
+  fileTypeRelevance: 0.1,
+  taskContextRelevance: 0.15,
+  centrality: 0.05,
+};
+
+/**
+ * Relationship-type ordering: direct edges (imports/imported-by) are the
+ * strongest relevance evidence, transitive links weaker, directory
+ * neighbors weakest. Unknown/unclassified relationships score 0.
+ */
+const RELATIONSHIP_SCORES: Record<string, number> = {
+  'imports': 1.0,
+  'imported-by': 1.0,
+  'transitive-dependency': 0.5,
+  'same-directory': 0.25,
 };
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.js', '.tsx', '.jsx']);
@@ -99,7 +144,9 @@ export function computeFileTypeRelevance(filePath: string): number {
 /**
  * Exponential decay based on how recently the file was checked.
  * Files checked in the last hour get ~1.0, files checked days ago get ~0.0.
- * Uses a half-life of 4 hours.
+ * Uses a half-life of 4 hours. Age is quantized to whole minutes so scores
+ * are deterministic across back-to-back calls (sub-minute age differences
+ * are noise at a 4-hour half-life).
  */
 export function computeRecency(lastChecked: number, now?: number): number {
   const currentTime = now ?? Date.now();
@@ -107,25 +154,46 @@ export function computeRecency(lastChecked: number, now?: number): number {
 
   if (ageMs <= 0) return 1.0;
 
+  const MINUTE_MS = 60 * 1000;
   const HALF_LIFE_MS = 4 * 60 * 60 * 1000; // 4 hours
-  return Math.pow(2, -ageMs / HALF_LIFE_MS);
+  const quantizedAgeMs = Math.floor(ageMs / MINUTE_MS) * MINUTE_MS;
+  return Math.pow(2, -quantizedAgeMs / HALF_LIFE_MS);
+}
+
+/** Score the candidate's classified relationship to the query file. */
+export function computeRelationshipScore(relationship: string | undefined): number {
+  if (!relationship) return 0;
+  return RELATIONSHIP_SCORES[relationship] ?? 0;
 }
 
 /**
- * Score based on distance in the dependency graph from explored files.
+ * Log-scaled degree centrality relative to the most-connected candidate.
+ * Returns 0 when the file has no connections or no maximum is known, 1.0
+ * for the best-connected candidate. Log scaling compresses the range so a
+ * 50-edge hub does not score 50x a 1-edge leaf — it is a tiebreaker prior,
+ * not a dominator.
+ */
+export function computeCentrality(degree: number, maxDegree: number): number {
+  if (degree <= 0 || maxDegree <= 0) return 0;
+  return Math.log1p(degree) / Math.log1p(maxDegree);
+}
+
+/**
+ * Score based on distance in the dependency graph from anchor files (the
+ * query file and/or task-explored files).
  * 1.0 if directly connected, 0.5 if 2 hops away, decaying by 1/2^(distance-1).
- * Returns 0 if no graph or no explored files.
+ * Returns 0 if no graph or no anchor files.
  */
 export function computeDependencyProximity(
   filePath: string,
-  exploredFiles: string[],
+  anchorFiles: string[],
   graph: DependencyGraph,
 ): number {
-  if (exploredFiles.length === 0) return 0;
+  if (anchorFiles.length === 0) return 0;
 
   let bestScore = 0;
 
-  for (const explored of exploredFiles) {
+  for (const explored of anchorFiles) {
     // Check direct connection (1 hop)
     const deps = graph.getDependencies(explored);
     const dependents = graph.getDependents(explored);
@@ -220,6 +288,26 @@ export function rankFiles(files: string[], options: RankingOptions): RankedFile[
   const flaggedFiles = options.flaggedFiles ?? [];
   const now = Date.now();
 
+  // Proximity anchors: the query file (so the signal works without a task)
+  // plus any task-explored files.
+  const anchorFiles = options.queryFile
+    ? [options.queryFile, ...exploredFiles]
+    : exploredFiles;
+
+  // Degree centrality, normalized against the best-connected candidate so
+  // the signal is relative to the result set being ranked.
+  const degrees = new Map<string, number>();
+  let maxDegree = 0;
+  if (options.graph) {
+    for (const filePath of files) {
+      const degree =
+        options.graph.getDependencies(filePath).length +
+        options.graph.getDependents(filePath).length;
+      degrees.set(filePath, degree);
+      if (degree > maxDegree) maxDegree = degree;
+    }
+  }
+
   const results: RankedFile[] = files.map((filePath) => {
     const fileTypeRelevance = computeFileTypeRelevance(filePath);
 
@@ -233,7 +321,7 @@ export function rankFiles(files: string[], options: RankingOptions): RankedFile[
 
     let dependencyProximity = 0;
     if (options.graph) {
-      dependencyProximity = computeDependencyProximity(filePath, exploredFiles, options.graph);
+      dependencyProximity = computeDependencyProximity(filePath, anchorFiles, options.graph);
     }
 
     const taskContextRelevance = computeTaskContextRelevance(
@@ -242,23 +330,25 @@ export function rankFiles(files: string[], options: RankingOptions): RankedFile[
       flaggedFiles,
     );
 
-    // changeFrequency is a placeholder — would need git log data to compute properly
-    const changeFrequency = 0.5;
+    const relationship = computeRelationshipScore(options.relationships?.get(filePath));
+    const centrality = computeCentrality(degrees.get(filePath) ?? 0, maxDegree);
 
     const signals: RankingSignals = {
+      relationship,
       dependencyProximity,
       recency,
       fileTypeRelevance,
       taskContextRelevance,
-      changeFrequency,
+      centrality,
     };
 
     const score =
+      signals.relationship * weights.relationship +
       signals.dependencyProximity * weights.dependencyProximity +
       signals.recency * weights.recency +
       signals.fileTypeRelevance * weights.fileTypeRelevance +
       signals.taskContextRelevance * weights.taskContextRelevance +
-      signals.changeFrequency * weights.changeFrequency;
+      signals.centrality * weights.centrality;
 
     return { path: filePath, score, signals };
   });

--- a/src/tools/get-related-files.ts
+++ b/src/tools/get-related-files.ts
@@ -3,6 +3,7 @@ import { loadFreshGraph } from '../graph/refresh.js';
 import { scanProject } from '../indexer/scanner.js';
 import { validatePath } from '../utils/validate-path.js';
 import { rankFiles } from '../cache/ranking.js';
+import { CacheStore } from '../cache/store.js';
 import { getTaskContext, type TaskContextResult } from '../tools/task-context.js';
 
 export interface RelatedFilesResult {
@@ -86,13 +87,18 @@ export async function getRelatedFiles(
     }
   }
 
-  // Rank candidates
+  // Rank candidates. The query file anchors dependency proximity, the
+  // classified relationships feed the relationship signal, and the cache
+  // store activates real recency data.
   const candidateArray = [...candidates];
   const ranked = rankFiles(candidateArray, {
     projectRoot,
     exploredFiles,
     flaggedFiles,
     graph,
+    cacheStore: new CacheStore(projectRoot),
+    queryFile: validated,
+    relationships: relationshipMap,
     limit,
   });
 

--- a/tests/unit/get-related-files.test.ts
+++ b/tests/unit/get-related-files.test.ts
@@ -91,6 +91,41 @@ describe('getRelatedFiles', () => {
     }
   });
 
+  it('ranks direct imports above two-hop files above same-directory bystanders', async () => {
+    // From src/index.ts: helper.ts is a direct import (1 hop), util.ts is two
+    // hops away (index -> helper -> util), other.ts is only a same-directory
+    // neighbor with no edges.
+    const result = await getRelatedFiles(tempDir, 'src/index.ts');
+    const score = (path: string) => result.relatedFiles.find((f) => f.path === path)?.score;
+
+    const helperScore = score('src/helper.ts');
+    const utilScore = score('src/util.ts');
+    const otherScore = score('src/other.ts');
+
+    expect(helperScore).toBeDefined();
+    expect(utilScore).toBeDefined();
+    expect(otherScore).toBeDefined();
+    expect(helperScore!).toBeGreaterThan(utilScore!);
+    expect(utilScore!).toBeGreaterThanOrEqual(otherScore!);
+  });
+
+  it('does not return identical scores for structurally different files (no task)', async () => {
+    // Regression: every source file used to tie at exactly 0.325 because no
+    // live signal differentiated candidates in the no-task path.
+    const result = await getRelatedFiles(tempDir, 'src/helper.ts');
+    expect(result.relatedFiles.length).toBeGreaterThan(1);
+    const distinctScores = new Set(result.relatedFiles.map((f) => f.score));
+    expect(distinctScores.size).toBeGreaterThan(1);
+  });
+
+  it('is deterministic: repeated calls return the same order', async () => {
+    const first = await getRelatedFiles(tempDir, 'src/index.ts');
+    const second = await getRelatedFiles(tempDir, 'src/index.ts');
+    expect(second.relatedFiles.map((f) => f.path)).toEqual(
+      first.relatedFiles.map((f) => f.path),
+    );
+  });
+
   it('works without task context', async () => {
     const result = await getRelatedFiles(tempDir, 'src/index.ts');
     expect(result.path).toBe('src/index.ts');

--- a/tests/unit/ranking.test.ts
+++ b/tests/unit/ranking.test.ts
@@ -4,6 +4,8 @@ import {
   computeRecency,
   computeDependencyProximity,
   computeTaskContextRelevance,
+  computeRelationshipScore,
+  computeCentrality,
   rankFiles,
   DEFAULT_WEIGHTS,
 } from '../../src/cache/ranking.js';
@@ -161,9 +163,53 @@ describe('computeDependencyProximity', () => {
     expect(score).toBe(0);
   });
 
-  it('should return 0 with no explored files', () => {
+  it('should return 0 with no anchor files', () => {
     const score = computeDependencyProximity('A', [], graph);
     expect(score).toBe(0);
+  });
+});
+
+describe('computeRelationshipScore', () => {
+  it('should score direct relationships highest', () => {
+    expect(computeRelationshipScore('imports')).toBe(1.0);
+    expect(computeRelationshipScore('imported-by')).toBe(1.0);
+  });
+
+  it('should order direct > transitive > same-directory', () => {
+    expect(computeRelationshipScore('imports')).toBeGreaterThan(
+      computeRelationshipScore('transitive-dependency'),
+    );
+    expect(computeRelationshipScore('transitive-dependency')).toBeGreaterThan(
+      computeRelationshipScore('same-directory'),
+    );
+  });
+
+  it('should return 0 for missing or unknown relationships', () => {
+    expect(computeRelationshipScore(undefined)).toBe(0);
+    expect(computeRelationshipScore('something-else')).toBe(0);
+  });
+});
+
+describe('computeCentrality', () => {
+  it('should return 1.0 for the most connected candidate', () => {
+    expect(computeCentrality(10, 10)).toBe(1.0);
+  });
+
+  it('should return 0 for unconnected files or empty graphs', () => {
+    expect(computeCentrality(0, 10)).toBe(0);
+    expect(computeCentrality(5, 0)).toBe(0);
+  });
+
+  it('should compress the range via log scaling', () => {
+    // A 1-edge leaf vs a 50-edge hub: linear would be 0.02, log keeps it
+    // meaningfully above zero so the signal is a tiebreaker, not a cliff.
+    const leaf = computeCentrality(1, 50);
+    expect(leaf).toBeGreaterThan(0.15);
+    expect(leaf).toBeLessThan(0.5);
+  });
+
+  it('should be monotonic in degree', () => {
+    expect(computeCentrality(5, 10)).toBeGreaterThan(computeCentrality(2, 10));
   });
 });
 
@@ -257,11 +303,12 @@ describe('rankFiles', () => {
     const ranked = rankFiles(files, {
       projectRoot: '/project',
       weights: {
+        relationship: 0,
         dependencyProximity: 0,
         recency: 0,
         fileTypeRelevance: 1.0,
         taskContextRelevance: 0,
-        changeFrequency: 0,
+        centrality: 0,
       },
     });
 
@@ -275,11 +322,12 @@ describe('rankFiles', () => {
     const contextOnly = rankFiles(files, {
       projectRoot: '/project',
       weights: {
+        relationship: 0,
         dependencyProximity: 0,
         recency: 0,
         fileTypeRelevance: 0,
         taskContextRelevance: 1.0,
-        changeFrequency: 0,
+        centrality: 0,
       },
       flaggedFiles: ['tests/unit/hash.test.ts'],
     });
@@ -312,23 +360,158 @@ describe('rankFiles', () => {
 
     for (const r of ranked) {
       expect(r.signals).toBeDefined();
+      expect(typeof r.signals.relationship).toBe('number');
       expect(typeof r.signals.dependencyProximity).toBe('number');
       expect(typeof r.signals.recency).toBe('number');
       expect(typeof r.signals.fileTypeRelevance).toBe('number');
       expect(typeof r.signals.taskContextRelevance).toBe('number');
-      expect(typeof r.signals.changeFrequency).toBe('number');
+      expect(typeof r.signals.centrality).toBe('number');
     }
+  });
+
+  it('should rank direct > two-hop >= same-directory from a query file (no task)', () => {
+    // A is the query file. B imports A directly, D is two hops away
+    // (A -> mid -> D), C is a same-directory bystander with no edges.
+    const graph = createMockGraph([
+      ['src/b.ts', 'src/a.ts'],
+      ['src/a.ts', 'src/mid.ts'],
+      ['src/mid.ts', 'src/deep/d.ts'],
+    ]);
+    const relationships = new Map<string, string>([
+      ['src/b.ts', 'imported-by'],
+      ['src/mid.ts', 'imports'],
+      ['src/deep/d.ts', 'transitive-dependency'],
+      ['src/c.ts', 'same-directory'],
+    ]);
+
+    const ranked = rankFiles(['src/c.ts', 'src/deep/d.ts', 'src/b.ts', 'src/mid.ts'], {
+      projectRoot: '/project',
+      graph,
+      queryFile: 'src/a.ts',
+      relationships,
+    });
+
+    const indexOf = (path: string) => ranked.findIndex((r) => r.path === path);
+    const score = (path: string) => ranked[indexOf(path)].score;
+
+    // Direct relationship beats the two-hop file, which beats (or ties) the
+    // same-directory bystander.
+    expect(score('src/b.ts')).toBeGreaterThan(score('src/deep/d.ts'));
+    expect(score('src/deep/d.ts')).toBeGreaterThanOrEqual(score('src/c.ts'));
+  });
+
+  it('should use the query file as a proximity anchor without explored files', () => {
+    const graph = createMockGraph([
+      ['src/a.ts', 'src/b.ts'],
+      ['src/b.ts', 'src/c.ts'],
+    ]);
+
+    const ranked = rankFiles(['src/b.ts', 'src/c.ts'], {
+      projectRoot: '/project',
+      graph,
+      queryFile: 'src/a.ts',
+    });
+
+    const b = ranked.find((r) => r.path === 'src/b.ts')!;
+    const c = ranked.find((r) => r.path === 'src/c.ts')!;
+    expect(b.signals.dependencyProximity).toBe(1.0); // direct neighbor of query
+    expect(c.signals.dependencyProximity).toBe(0.5); // two hops from query
+  });
+
+  it('should produce non-identical scores in the default no-task path', () => {
+    // Regression: scores used to collapse to a constant (0.325 for every
+    // source file) because no live signal differentiated candidates.
+    const graph = createMockGraph([
+      ['src/b.ts', 'src/a.ts'],
+      ['src/a.ts', 'src/mid.ts'],
+      ['src/mid.ts', 'src/deep/d.ts'],
+    ]);
+    const relationships = new Map<string, string>([
+      ['src/b.ts', 'imported-by'],
+      ['src/mid.ts', 'imports'],
+      ['src/deep/d.ts', 'transitive-dependency'],
+      ['src/c.ts', 'same-directory'],
+    ]);
+
+    const ranked = rankFiles(['src/c.ts', 'src/deep/d.ts', 'src/b.ts', 'src/mid.ts'], {
+      projectRoot: '/project',
+      graph,
+      queryFile: 'src/a.ts',
+      relationships,
+    });
+
+    const distinctScores = new Set(ranked.map((r) => r.score));
+    expect(distinctScores.size).toBeGreaterThan(1);
+  });
+
+  it('should be deterministic: same inputs produce the same order and scores', () => {
+    const graph = createMockGraph([
+      ['src/b.ts', 'src/a.ts'],
+      ['src/a.ts', 'src/mid.ts'],
+      ['src/mid.ts', 'src/deep/d.ts'],
+    ]);
+    const relationships = new Map<string, string>([
+      ['src/b.ts', 'imported-by'],
+      ['src/mid.ts', 'imports'],
+      ['src/deep/d.ts', 'transitive-dependency'],
+      ['src/c.ts', 'same-directory'],
+    ]);
+    const files = ['src/c.ts', 'src/deep/d.ts', 'src/b.ts', 'src/mid.ts'];
+    const options = {
+      projectRoot: '/project',
+      graph,
+      queryFile: 'src/a.ts',
+      relationships,
+    };
+
+    const first = rankFiles(files, options);
+    const second = rankFiles(files, options);
+
+    expect(second.map((r) => r.path)).toEqual(first.map((r) => r.path));
+    expect(second.map((r) => r.score)).toEqual(first.map((r) => r.score));
+  });
+
+  it('should let centrality break ties between hub and leaf candidates', () => {
+    // x and y have identical relationship/proximity to the query, but x is a
+    // hub (3 extra edges) while y is a leaf.
+    const graph = createMockGraph([
+      ['src/q.ts', 'src/x.ts'],
+      ['src/q.ts', 'src/y.ts'],
+      ['src/p1.ts', 'src/x.ts'],
+      ['src/p2.ts', 'src/x.ts'],
+      ['src/p3.ts', 'src/x.ts'],
+    ]);
+    const relationships = new Map<string, string>([
+      ['src/x.ts', 'imports'],
+      ['src/y.ts', 'imports'],
+    ]);
+
+    const ranked = rankFiles(['src/y.ts', 'src/x.ts'], {
+      projectRoot: '/project',
+      graph,
+      queryFile: 'src/q.ts',
+      relationships,
+    });
+
+    expect(ranked[0].path).toBe('src/x.ts');
+    expect(ranked[0].signals.centrality).toBeGreaterThan(ranked[1].signals.centrality);
   });
 });
 
 describe('DEFAULT_WEIGHTS', () => {
   it('should sum to 1.0', () => {
     const sum =
+      DEFAULT_WEIGHTS.relationship +
       DEFAULT_WEIGHTS.dependencyProximity +
       DEFAULT_WEIGHTS.recency +
       DEFAULT_WEIGHTS.fileTypeRelevance +
       DEFAULT_WEIGHTS.taskContextRelevance +
-      DEFAULT_WEIGHTS.changeFrequency;
+      DEFAULT_WEIGHTS.centrality;
     expect(sum).toBeCloseTo(1.0, 5);
+  });
+
+  it('should weight relationship and proximity above the centrality tiebreaker', () => {
+    expect(DEFAULT_WEIGHTS.relationship).toBeGreaterThan(DEFAULT_WEIGHTS.centrality);
+    expect(DEFAULT_WEIGHTS.dependencyProximity).toBeGreaterThan(DEFAULT_WEIGHTS.centrality);
   });
 });


### PR DESCRIPTION
Closes #168.

The '5-signal' ranking emitted constants in its only production path — all top results tied at exactly 0.325 (audit C6). Now:

- `cacheStore` wired through (recency is live, quantized to minutes for determinism)
- `changeFrequency` placeholder deleted; weights renormalized with documented rationale
- Relationship is the dominant signal (0.30): imports/imported-by > transitive > same-directory
- Dependency proximity anchors on the query file (works without a task; task anchors still add in)
- Degree-centrality tiebreaker (0.05, log-normalized) — the cheap step toward Aider's PageRank pattern

Before: top-10 all tied at 0.325, order arbitrary. After: clean tiers — direct edges 0.76–0.87, transitive 0.49–0.58, same-directory 0.19–0.50.

## Testing
516 unit + 8 integration pass (13 net new: B>D≥C ordering sanity, query-file anchor, determinism, not-all-identical regression).