### PR TITLE
feat(server): token-budget response shaping for navigation tools

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,7 +53,6 @@ Returns a cached summary of a file. If the file has not changed since last read,
 ```json
 {
   "path": "src/server.ts",
-  "hash": "a1b2c3d4e5f6...",
   "summary": {
     "purpose": "entry point",
     "exports": ["main"],
@@ -63,7 +62,6 @@ Returns a cached summary of a file. If the file has not changed since last read,
     "confidence": "high"
   },
   "fromCache": true,
-  "reason": "cache_hit: hash unchanged",
   "cacheAge": 42,
   "suggestFullRead": false
 }
@@ -73,7 +71,6 @@ Returns a cached summary of a file. If the file has not changed since last read,
 ```json
 {
   "path": "src/server.ts",
-  "hash": "f6e5d4c3b2a1...",
   "summary": {
     "purpose": "entry point",
     "exports": ["main"],
@@ -83,15 +80,13 @@ Returns a cached summary of a file. If the file has not changed since last read,
     "confidence": "high"
   },
   "fromCache": false,
-  "reason": "cache_miss: hash changed",
-  "cacheAge": null,
   "suggestFullRead": false
 }
 ```
 
 **Notes:**
 - `suggestFullRead` is `true` when the summary confidence is `"low"`, indicating the agent should read the full file for accuracy.
-- `cacheAge` is in seconds since last check, or `null` if no prior cache entry exists.
+- `cacheAge` is in seconds since the cached entry was last validated; it is only present on cache hits.
 - Summary quality depends on the `summarizer` setting in `.repo-memory.json`: `"ast"` (default) or `"regex"`. AST mode (TS/JS, Python, Go, Rust, Kotlin, Java) yields more accurate exports and a semantic `purpose` line naming the dominant symbols; other languages and files that fail to parse fall back to the regex engine automatically. See the README's Configuration section.
 
 ---
@@ -114,7 +109,6 @@ Returns summaries for multiple files in one call. Each file goes through the sam
     { "path": "src/server.ts", "fromCache": true, "summary": { "...": "..." } },
     { "path": "src/cache/store.ts", "fromCache": false, "summary": { "...": "..." } }
   ],
-  "totalFiles": 3,
   "cacheHits": 1,
   "cacheMisses": 1,
   "errors": [
@@ -145,12 +139,10 @@ Searches cached file summaries by keyword. Matches against each file's purpose, 
 **Output:**
 ```json
 {
-  "query": "cache invalidation",
   "results": [
     {
       "path": "src/cache/invalidation.ts",
       "purpose": "source",
-      "matchedOn": ["exports", "declarations"],
       "exports": ["CacheInvalidator"],
       "confidence": "high"
     }
@@ -166,8 +158,9 @@ Searches cached file summaries by keyword. Matches against each file's purpose, 
 - `pathPrefix` (optional): Restrict results to files at or under this path (e.g. `"src/cache"`). Matched on a path boundary, so `"src/cache"` excludes `src/cache-utils.ts`.
 
 **Notes:**
-- `totalCached` is the number of summarized files in scope (after `pathPrefix` filtering), not the number of matches.
+- `totalCached` is the number of summarized files in scope (after `pathPrefix` filtering), not the number of matches. If it is 0, warm the cache with `repo-memory index` first.
 - `scope` is present only when `pathPrefix` was given, echoing the normalized prefix.
+- `exports` is capped at 5 entries per result; when capped, `exportsTruncated` carries the total export count.
 
 ---
 
@@ -217,7 +210,6 @@ Returns a structural overview of the project including directory tree, entry poi
 **Input:**
 ```json
 {
-  "project_root": "/absolute/path/to/project",
   "depth": 2
 }
 ```
@@ -227,17 +219,15 @@ Returns a structural overview of the project including directory tree, entry poi
 {
   "tree": {
     "name": "repo-memory",
-    "path": ".",
     "files": [
-      { "name": "server.ts", "purpose": "entry point", "size": 4096 }
+      { "name": "server.ts", "purpose": "entry point" }
     ],
     "children": [
       {
         "name": "cache",
-        "path": "src/cache",
         "files": [
-          { "name": "hash.ts", "purpose": "utility", "size": 512 },
-          { "name": "store.ts", "purpose": "data access", "size": 2048 }
+          { "name": "hash.ts", "purpose": "utility" },
+          { "name": "store.ts", "purpose": "data access" }
         ],
         "children": [],
         "fileCount": 5
@@ -256,10 +246,10 @@ Returns a structural overview of the project including directory tree, entry poi
 ```
 
 **Notes:**
-- `depth` limits how deep the directory tree is traversed. Omit for full depth.
+- `project_root` (optional): Absolute path to the project root. Defaults to the server's working directory, like every other tool.
+- `depth` limits how deep the directory tree is traversed. Defaults to 2; pass a larger value for deeper structure.
 - `entryPoints` lists files whose summarized purpose is `"entry point"`.
-- File entries are kept compact (`name`, `purpose`, `size`). Per-file confidence is available
-  via `get_file_summary`; recency is covered by `get_changed_files`.
+- File entries are kept compact (`name`, `purpose`). A directory's path is derivable from its nesting. Per-file confidence is available via `get_file_summary`; recency is covered by `get_changed_files`.
 - Zero-byte `.gitkeep` placeholder files are omitted from the tree.
 
 ---
@@ -331,13 +321,13 @@ Invalidates cached entries. Can target a single file or clear the entire cache.
 
 ### `get_dependency_graph`
 
-Returns dependency graph information. Can query a specific file's dependencies/dependents or get a summary of the most connected files.
+Returns dependency graph information as adjacency maps. Can query a specific file's dependencies/dependents or get a summary of the most connected files. Calling without `path` returns a large whole-repo summary — prefer passing `path`.
 
 **Input (specific file):**
 ```json
 {
   "path": "src/server.ts",
-  "direction": "dependencies",
+  "direction": "both",
   "depth": 1
 }
 ```
@@ -345,38 +335,57 @@ Returns dependency graph information. Can query a specific file's dependencies/d
 **Output:**
 ```json
 {
-  "nodes": [
-    "src/server.ts",
-    "src/tools/get-file-summary.ts",
-    "src/tools/get-changed-files.ts",
-    "src/tools/invalidate.ts"
-  ],
-  "edges": [
-    { "from": "src/server.ts", "to": "src/tools/get-file-summary.ts" },
-    { "from": "src/server.ts", "to": "src/tools/get-changed-files.ts" },
-    { "from": "src/server.ts", "to": "src/tools/invalidate.ts" }
-  ],
+  "deps": {
+    "src/server.ts": [
+      "src/tools/get-changed-files.ts",
+      "src/tools/get-file-summary.ts",
+      "src/tools/invalidate.ts"
+    ]
+  },
+  "dependents": {
+    "src/server.ts": []
+  },
   "stats": {
     "totalFiles": 4,
-    "totalEdges": 3,
-    "mostConnected": [
-      { "path": "src/types.ts", "connections": 12 },
-      { "path": "src/cache/store.ts", "connections": 8 }
-    ]
+    "totalEdges": 3
   }
 }
 ```
 
-**Input (full graph summary):**
+**Input (whole-repo summary):**
 ```json
 {}
 ```
 
+**Output (whole-repo summary):**
+```json
+{
+  "deps": {
+    "src/cache/store.ts": ["src/persistence/db.js", "src/types.ts"],
+    "src/types.ts": []
+  },
+  "stats": {
+    "totalFiles": 118,
+    "totalEdges": 284,
+    "mostConnected": [
+      { "path": "src/types.ts", "connections": 12 },
+      { "path": "src/cache/store.ts", "connections": 8 }
+    ]
+  },
+  "truncated": true
+}
+```
+
 **Parameters:**
-- `path` (optional): File to query. Omit for full graph summary.
-- `direction` (optional): `"dependencies"`, `"dependents"`, or `"both"` (default: `"both"`).
+- `path` (optional): File to query. Omit only when you want the whole-repo summary.
+- `direction` (optional): `"dependencies"`, `"dependents"`, or `"both"` (default: `"both"`). `deps` is present when the direction includes dependencies; `dependents` when it includes dependents.
 - `depth` (optional): Max traversal depth for transitive queries.
-- `symbol` (optional): Filter edges by import specifier (e.g. `"UserService"`), returning only edges that import that symbol.
+- `symbol` (optional): Filter edges by import specifier (e.g. `"UserService"`), returning only edges that import that symbol (as a `deps` adjacency map).
+- `limit` (optional, no-path summary mode only): Max files included in `deps`, ranked by connectivity (default: 50).
+
+**Notes:**
+- `stats.mostConnected` appears only in the no-path summary mode.
+- In summary mode, `stats.totalFiles`/`stats.totalEdges` are whole-graph counts; `truncated: true` flags that `deps` was capped by `limit`.
 
 ---
 

--- a/src/indexer/project-map.ts
+++ b/src/indexer/project-map.ts
@@ -8,11 +8,9 @@ import type { FileSummary } from '../types.js';
 
 export interface DirectoryNode {
   name: string;
-  path: string;
   files: Array<{
     name: string;
     purpose: string;
-    size: number;
   }>;
   children: DirectoryNode[];
   fileCount: number;
@@ -76,7 +74,6 @@ function buildTree(
 ): DirectoryNode {
   const root: DirectoryNode = {
     name: rootName,
-    path: '.',
     files: [],
     children: [],
     fileCount: 0,
@@ -99,7 +96,6 @@ function buildTree(
 
     const node: DirectoryNode = {
       name: basename(dirPath),
-      path: dirPath,
       files: [],
       children: [],
       fileCount: 0,
@@ -123,7 +119,6 @@ function buildTree(
     dir.files.push({
       name,
       purpose: entry.summary.purpose,
-      size: entry.size,
     });
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,13 +38,16 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
   server.registerTool('get_project_map', {
     title: 'Get Project Map',
     description:
-      'Returns a structural overview of the project including directory tree, entry points, and key modules.',
+      'Returns a structural overview of the project including directory tree, entry points, and key modules. Depth defaults to 2; pass a larger depth only when you need deeper structure.',
     inputSchema: {
-      project_root: z.string().describe('Absolute path to the project root'),
-      depth: z.number().optional().describe('Max directory depth to include'),
+      project_root: z
+        .string()
+        .optional()
+        .describe('Absolute path to the project root (default: current working directory)'),
+      depth: z.number().optional().describe('Max directory depth to include (default: 2)'),
     },
   }, async ({ project_root, depth }) => {
-    const projectMap = await getProjectMap(project_root, depth);
+    const projectMap = await getProjectMap(project_root ?? process.cwd(), depth);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(projectMap) }],
     };
@@ -53,7 +56,7 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
   server.registerTool('get_related_files', {
     title: 'Get Related Files',
     description:
-      'Returns files related to the given file, ranked by dependency proximity and relevance. Useful for finding what else to look at when exploring a file.',
+      'Returns files related to the given file, ranked by dependency proximity and relevance. One call replaces grepping for imports and grepping for usages separately.',
     inputSchema: {
       path: z.string().describe('File path relative to project root'),
       limit: z.number().optional().describe('Max results (default: 10)'),
@@ -70,19 +73,23 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
   server.registerTool('get_dependency_graph', {
     title: 'Get Dependency Graph',
     description:
-      'Returns dependency graph information. If a path is given, returns its dependencies/dependents. If no path, returns a summary of the most connected files.',
+      'Returns dependency graph information as adjacency maps. If a path is given, returns its dependencies/dependents. Calling without a path returns a large whole-repo summary of the most connected files — prefer passing a path.',
     inputSchema: {
-      path: z.string().optional().describe('File path to query, or omit for full graph summary'),
+      path: z.string().optional().describe('File path to query; omit only when you want a whole-repo summary'),
       direction: z
         .enum(['dependencies', 'dependents', 'both'])
         .optional()
         .describe('Query direction (default: both)'),
       depth: z.number().optional().describe('Max traversal depth'),
       symbol: z.string().optional().describe('Filter edges by import specifier (e.g., "UserService")'),
+      limit: z
+        .number()
+        .optional()
+        .describe('No-path summary mode only: max files included (default: 50)'),
     },
-  }, async ({ path, direction, depth, symbol }) => {
+  }, async ({ path, direction, depth, symbol, limit }) => {
     const projectRoot = process.cwd();
-    const result = await getDependencyGraphTool(projectRoot, path, direction, depth, symbol);
+    const result = await getDependencyGraphTool(projectRoot, path, direction, depth, symbol, limit);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };
@@ -170,7 +177,7 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
 
     server.registerTool('search_by_purpose', {
       title: 'Search By Purpose',
-      description: 'Search cached file summaries by keyword. Matches against file purpose, exports, and declarations. Requires files to have been previously summarized. Optionally scope to a directory with pathPrefix.',
+      description: 'Find files by what they do when you don\'t know filenames — prefer this over grep for concept searches ("where is auth handled"). Matches against file purpose, exports, and declarations. Check totalCached > 0 in the response; if 0, warm the cache with `repo-memory index` first. Optionally scope to a directory with pathPrefix.',
       inputSchema: {
         query: z.string().describe('Search keywords (e.g., "database", "auth middleware", "validation")'),
         limit: z.number().optional().describe('Max results (default: 20)'),

--- a/src/tools/batch-file-summaries.ts
+++ b/src/tools/batch-file-summaries.ts
@@ -3,7 +3,6 @@ import { validatePath } from '../utils/validate-path.js';
 
 export interface BatchFileSummariesResult {
   results: FileSummaryResult[];
-  totalFiles: number;
   cacheHits: number;
   cacheMisses: number;
   errors: Array<{ path: string; error: string }>;
@@ -31,5 +30,5 @@ export async function batchFileSummaries(
     }
   }
 
-  return { results, totalFiles: paths.length, cacheHits, cacheMisses, errors };
+  return { results, cacheHits, cacheMisses, errors };
 }

--- a/src/tools/get-dependency-graph.ts
+++ b/src/tools/get-dependency-graph.ts
@@ -2,14 +2,22 @@ import { DependencyGraph } from '../graph/dependency-graph.js';
 import { loadFreshGraph } from '../graph/refresh.js';
 import { validatePath } from '../utils/validate-path.js';
 
+/** Default number of files included in the no-path whole-repo summary. */
+const DEFAULT_SUMMARY_LIMIT = 50;
+
 export interface DependencyGraphResult {
-  nodes: string[];
-  edges: Array<{ from: string; to: string }>;
+  /** Adjacency map: file -> files it imports (present when direction includes dependencies). */
+  deps?: Record<string, string[]>;
+  /** Adjacency map: file -> files that import it (present when direction includes dependents). */
+  dependents?: Record<string, string[]>;
   stats: {
     totalFiles: number;
     totalEdges: number;
-    mostConnected: Array<{ path: string; connections: number }>;
+    /** Only present in the no-path whole-repo summary mode. */
+    mostConnected?: Array<{ path: string; connections: number }>;
   };
+  /** True when the no-path summary was capped by `limit`; stats carry whole-graph totals. */
+  truncated?: boolean;
 }
 
 export async function getDependencyGraphTool(
@@ -18,6 +26,7 @@ export async function getDependencyGraphTool(
   direction?: 'dependencies' | 'dependents' | 'both',
   depth?: number,
   symbol?: string,
+  limit?: number,
 ): Promise<DependencyGraphResult> {
   if (path) {
     path = validatePath(projectRoot, path);
@@ -33,7 +42,7 @@ export async function getDependencyGraphTool(
     return getNeighborhood(graph, path, direction ?? 'both', depth);
   }
 
-  return getFullSummary(graph);
+  return getFullSummary(graph, limit ?? DEFAULT_SUMMARY_LIMIT);
 }
 
 function getNeighborhood(
@@ -42,39 +51,30 @@ function getNeighborhood(
   direction: 'dependencies' | 'dependents' | 'both',
   depth?: number,
 ): DependencyGraphResult {
-  const nodes = new Set<string>();
-  const edges: Array<{ from: string; to: string }> = [];
-  nodes.add(path);
+  const files = new Set<string>([path]);
+  let totalEdges = 0;
+  const result: DependencyGraphResult = { stats: { totalFiles: 0, totalEdges: 0 } };
 
   if (direction === 'dependencies' || direction === 'both') {
-    const deps = depth !== undefined
+    const targets = depth !== undefined
       ? graph.getTransitiveDependencies(path, depth)
       : graph.getDependencies(path);
-    for (const dep of deps) {
-      nodes.add(dep);
-      edges.push({ from: path, to: dep });
-    }
+    for (const target of targets) files.add(target);
+    totalEdges += targets.length;
+    result.deps = { [path]: [...targets].sort() };
   }
 
   if (direction === 'dependents' || direction === 'both') {
-    const deps = depth !== undefined
+    const sources = depth !== undefined
       ? graph.getTransitiveDependents(path, depth)
       : graph.getDependents(path);
-    for (const dep of deps) {
-      nodes.add(dep);
-      edges.push({ from: dep, to: path });
-    }
+    for (const source of sources) files.add(source);
+    totalEdges += sources.length;
+    result.dependents = { [path]: [...sources].sort() };
   }
 
-  return {
-    nodes: [...nodes].sort(),
-    edges,
-    stats: {
-      totalFiles: nodes.size,
-      totalEdges: edges.length,
-      mostConnected: graph.getMostConnected(5),
-    },
-  };
+  result.stats = { totalFiles: files.size, totalEdges };
+  return result;
 }
 
 function getSymbolEdges(
@@ -83,50 +83,50 @@ function getSymbolEdges(
   path?: string,
 ): DependencyGraphResult {
   const matchingEdges = graph.getEdgesBySymbol(symbol, path);
-  const nodes = new Set<string>();
-  const edges: Array<{ from: string; to: string }> = [];
+  const files = new Set<string>();
+  const deps: Record<string, string[]> = {};
 
   for (const edge of matchingEdges) {
-    nodes.add(edge.source);
-    nodes.add(edge.target);
-    edges.push({ from: edge.source, to: edge.target });
+    files.add(edge.source);
+    files.add(edge.target);
+    (deps[edge.source] ??= []).push(edge.target);
+  }
+  for (const source of Object.keys(deps)) {
+    deps[source].sort();
   }
 
   return {
-    nodes: [...nodes].sort(),
-    edges,
+    deps,
     stats: {
-      totalFiles: nodes.size,
-      totalEdges: edges.length,
-      mostConnected: graph.getMostConnected(5),
+      totalFiles: files.size,
+      totalEdges: matchingEdges.length,
     },
   };
 }
 
-function getFullSummary(graph: DependencyGraph): DependencyGraphResult {
-  const mostConnected = graph.getMostConnected(10);
-  const allNodes = new Set<string>();
-  const edges: Array<{ from: string; to: string }> = [];
-
-  for (const entry of mostConnected) {
-    allNodes.add(entry.path);
-    for (const dep of graph.getDependencies(entry.path)) {
-      allNodes.add(dep);
-      edges.push({ from: entry.path, to: dep });
-    }
-    for (const dep of graph.getDependents(entry.path)) {
-      allNodes.add(dep);
-      edges.push({ from: dep, to: entry.path });
-    }
+function getFullSummary(graph: DependencyGraph, limit: number): DependencyGraphResult {
+  // Rank every node by connectivity; the summary covers the top `limit`.
+  const ranked = graph.getMostConnected(Number.MAX_SAFE_INTEGER);
+  const totalFiles = ranked.length;
+  let totalEdges = 0;
+  for (const { path } of ranked) {
+    totalEdges += graph.getDependencies(path).length;
   }
 
+  const included = ranked.slice(0, Math.max(0, limit));
+  const deps: Record<string, string[]> = {};
+  for (const { path } of included) {
+    deps[path] = graph.getDependencies(path).sort();
+  }
+
+  const truncated = totalFiles > included.length;
   return {
-    nodes: [...allNodes].sort(),
-    edges,
+    deps,
     stats: {
-      totalFiles: allNodes.size,
-      totalEdges: edges.length,
-      mostConnected,
+      totalFiles,
+      totalEdges,
+      mostConnected: graph.getMostConnected(10),
     },
+    ...(truncated ? { truncated: true } : {}),
   };
 }

--- a/src/tools/get-file-summary.ts
+++ b/src/tools/get-file-summary.ts
@@ -12,11 +12,10 @@ import { validatePath } from '../utils/validate-path.js';
 
 export interface FileSummaryResult {
   path: string;
-  hash: string;
   summary: FileSummary;
   fromCache: boolean;
-  reason: string;
-  cacheAge: number | null;
+  /** Seconds since the cached entry was last validated; only present on cache hits. */
+  cacheAge?: number;
   suggestFullRead: boolean;
 }
 
@@ -46,9 +45,6 @@ export async function getFileSummary(
 
   // Check cache
   const cached = store.getEntry(relativePath);
-  const cacheAge = cached
-    ? Math.floor((Date.now() - cached.lastChecked) / 1000)
-    : null;
 
   const tracker = new TelemetryTracker(projectRoot);
 
@@ -60,11 +56,9 @@ export async function getFileSummary(
 
     return {
       path: relativePath,
-      hash: currentHash,
       summary: cached.summary,
       fromCache: true,
-      reason: 'cache_hit: hash unchanged',
-      cacheAge,
+      cacheAge: Math.floor((Date.now() - cached.lastChecked) / 1000),
       suggestFullRead: cached.summary.confidence === 'low',
     };
   }
@@ -82,26 +76,14 @@ export async function getFileSummary(
   }
   store.setEntry(relativePath, currentHash, summary);
 
-  let reason: string;
-  if (!cached) {
-    reason = 'cache_miss: no prior entry';
-  } else if (cached.hash !== currentHash) {
-    reason = 'cache_miss: hash changed';
-  } else {
-    reason = 'cache_miss: no summary in cache';
-  }
-
   if (trackTelemetry) {
     tracker.trackEvent('cache_miss', relativePath, 0);
   }
 
   return {
     path: relativePath,
-    hash: currentHash,
     summary,
     fromCache: false,
-    reason,
-    cacheAge,
     suggestFullRead: summary.confidence === 'low',
   };
 }

--- a/src/tools/get-project-map.ts
+++ b/src/tools/get-project-map.ts
@@ -1,8 +1,17 @@
 import { buildProjectMap, type ProjectMap } from '../indexer/project-map.js';
 
+/**
+ * Default directory depth for the project map. An undepthed map of a large
+ * repo costs thousands of tokens; depth 2 keeps the first orientation call
+ * cheap while still showing the second-level structure. Pass an explicit
+ * `depth` for more (buildProjectMap itself stays unlimited-by-default for
+ * programmatic reuse).
+ */
+const DEFAULT_DEPTH = 2;
+
 export async function getProjectMap(
   projectRoot: string,
   depth?: number,
 ): Promise<ProjectMap> {
-  return buildProjectMap(projectRoot, depth !== undefined ? { depth } : undefined);
+  return buildProjectMap(projectRoot, { depth: depth ?? DEFAULT_DEPTH });
 }

--- a/src/tools/search-by-purpose.ts
+++ b/src/tools/search-by-purpose.ts
@@ -7,16 +7,18 @@ import { TelemetryTracker } from '../telemetry/tracker.js';
 import type { CacheEntry, FileSummary } from '../types.js';
 import { toPosix } from '../utils/posix-path.js';
 
+/** Max exports listed per result; the rest collapse into `exportsTruncated`. */
+const MAX_EXPORTS_PER_RESULT = 5;
+
 export interface SearchResult {
   path: string;
   purpose: string;
-  matchedOn: string[]; // which fields matched: "purpose", "exports", "declarations"
-  exports: string[];
+  exports: string[]; // capped at MAX_EXPORTS_PER_RESULT
+  exportsTruncated?: number; // total export count, present only when `exports` was capped
   confidence: string;
 }
 
 export interface SearchByPurposeResult {
-  query: string;
   results: SearchResult[];
   totalCached: number;
   scope?: string; // present when results were restricted to a pathPrefix
@@ -175,14 +177,17 @@ export async function searchByPurpose(
   }
 
   return {
-    query,
-    results: served.map((c) => ({
-      path: c.entry.path,
-      purpose: c.summary.purpose,
-      matchedOn: c.matchedOn,
-      exports: c.summary.exports,
-      confidence: c.summary.confidence,
-    })),
+    results: served.map((c) => {
+      const exports = c.summary.exports;
+      const capped = exports.length > MAX_EXPORTS_PER_RESULT;
+      return {
+        path: c.entry.path,
+        purpose: c.summary.purpose,
+        exports: capped ? exports.slice(0, MAX_EXPORTS_PER_RESULT) : exports,
+        ...(capped ? { exportsTruncated: exports.length } : {}),
+        confidence: c.summary.confidence,
+      };
+    }),
     totalCached: entries.filter((e) => e.summary).length,
     ...(normalizedPrefix ? { scope: normalizedPrefix } : {}),
   };

--- a/tests/integration/v1-flow.test.ts
+++ b/tests/integration/v1-flow.test.ts
@@ -80,12 +80,10 @@ describe('V1 end-to-end flow', () => {
     expect(summary1.summary.purpose).toBe('entry point: function main'); // AST default
     expect(summary1.summary.exports).toContain('main');
     expect(summary1.summary.imports).toContain('./utils/greet.js');
-    expect(summary1.hash).toHaveLength(64);
 
     // Step 3: Get same file summary again — cache hit
     const summary2 = await getFileSummary(projectDir, 'src/index.ts');
     expect(summary2.fromCache).toBe(true);
-    expect(summary2.hash).toBe(summary1.hash);
     expect(summary2.summary).toEqual(summary1.summary);
 
     // Step 4: Modify a file

--- a/tests/integration/v2-flow.test.ts
+++ b/tests/integration/v2-flow.test.ts
@@ -88,8 +88,8 @@ describe('V2 end-to-end flow', () => {
       'src/index.ts',
       'dependencies',
     );
-    expect(graphResult.nodes).toContain('src/index.ts');
-    expect(graphResult.edges.length).toBeGreaterThan(0);
+    expect(Object.keys(graphResult.deps!)).toContain('src/index.ts');
+    expect(graphResult.deps!['src/index.ts'].length).toBeGreaterThan(0);
 
     // Step 3: Create a task for investigating a bug
     const task = createTaskTool(projectDir, 'Investigate user validation bug');
@@ -136,7 +136,7 @@ describe('V2 end-to-end flow', () => {
       'dependents',
     );
     // user.ts depends on validate
-    expect(impactGraph.nodes).toContain('src/services/user.ts');
+    expect(impactGraph.dependents!['src/utils/validate.ts']).toContain('src/services/user.ts');
   });
 
   it('cross-turn: task state persists after database restart', async () => {

--- a/tests/integration/v3-flow.test.ts
+++ b/tests/integration/v3-flow.test.ts
@@ -230,7 +230,7 @@ describe('V3 end-to-end flow', () => {
       'src/utils/validate.ts',
       'dependents',
     );
-    expect(impactGraph.nodes).toContain('src/services/user.ts');
+    expect(impactGraph.dependents!['src/utils/validate.ts']).toContain('src/services/user.ts');
 
     // Step 15: End session 2
     sessionManager2.endSession(session2.id);

--- a/tests/unit/batch-file-summaries.test.ts
+++ b/tests/unit/batch-file-summaries.test.ts
@@ -52,13 +52,14 @@ describe('batchFileSummaries', () => {
     expect(result.results[2].summary.exports).toContain('Gamma');
   });
 
-  it('returns correct totalFiles count', async () => {
+  it('omits the totalFiles echo from the response', async () => {
     const result = await batchFileSummaries(tempDir, [
       'src/alpha.ts',
       'src/beta.ts',
     ]);
 
-    expect(result.totalFiles).toBe(2);
+    expect(result).not.toHaveProperty('totalFiles');
+    expect(Object.keys(result).sort()).toEqual(['cacheHits', 'cacheMisses', 'errors', 'results']);
   });
 
   it('reports cache hits vs misses', async () => {
@@ -96,8 +97,5 @@ describe('batchFileSummaries', () => {
     expect(result.errors).toHaveLength(2);
     expect(result.errors[0].path).toBe('nonexistent.ts');
     expect(result.errors[1].path).toBe('../../../etc/passwd');
-
-    // totalFiles still reflects all requested paths
-    expect(result.totalFiles).toBe(3);
   });
 });

--- a/tests/unit/cache-correctness.test.ts
+++ b/tests/unit/cache-correctness.test.ts
@@ -51,15 +51,16 @@ describe('Cache correctness regression tests', () => {
     // Second call — cache hit
     const result2 = await getFileSummary(tmpDir, filePath);
     expect(result2.fromCache).toBe(true);
-    expect(result2.hash).toBe(result1.hash);
+    expect(result2.summary).toEqual(result1.summary);
 
     // Modify the file
     writeFileSync(absPath, 'export const a = 2;\n');
 
-    // Third call — should detect change
+    // Third call — should detect change and store the new hash
     const result3 = await getFileSummary(tmpDir, filePath);
     expect(result3.fromCache).toBe(false);
-    expect(result3.hash).not.toBe(result1.hash);
+    const entry = new CacheStore(tmpDir).getEntry(filePath);
+    expect(entry!.hash).toBe(hashContents('export const a = 2;\n'));
   });
 
   it('should handle file deleted after caching', async () => {
@@ -131,12 +132,12 @@ describe('Cache correctness regression tests', () => {
     // Cache has result2's hash, so this is a miss that regenerates and updates cache
     const result3 = await getFileSummary(tmpDir, filePath);
     expect(result3.fromCache).toBe(false);
-    expect(result3.hash).toBe(result1.hash);
+    expect(result3.summary).toEqual(result1.summary);
 
     // Now the cache has the original hash+summary again — this should be a hit
     const result4 = await getFileSummary(tmpDir, filePath);
     expect(result4.fromCache).toBe(true);
-    expect(result4.hash).toBe(result1.hash);
+    expect(result4.summary).toEqual(result1.summary);
   });
 
   it('should handle empty files gracefully', async () => {
@@ -149,7 +150,7 @@ describe('Cache correctness regression tests', () => {
     const result = await getFileSummary(tmpDir, filePath);
     expect(result.summary.lineCount).toBe(0);
     expect(result.fromCache).toBe(false);
-    expect(result.hash).toBeTruthy();
+    expect(new CacheStore(tmpDir).getEntry(filePath)!.hash).toBeTruthy();
   });
 
   it('should hash binary files without crashing', async () => {
@@ -196,25 +197,25 @@ describe('Cache correctness regression tests', () => {
     writeFileSync(absPath, 'export const v = 1;\n');
     addAndCommit(tmpDir, [filePath]);
 
+    const store = new CacheStore(tmpDir);
+
     // First modification
     writeFileSync(absPath, 'export const v = 2;\n');
     const result1 = await getFileSummary(tmpDir, filePath);
-    const hash1 = result1.hash;
+    expect(result1.fromCache).toBe(false);
+    expect(store.getEntry(filePath)!.hash).toBe(hashContents('export const v = 2;\n'));
 
     // Second modification
     writeFileSync(absPath, 'export const v = 3;\n');
     const result2 = await getFileSummary(tmpDir, filePath);
-    const hash2 = result2.hash;
-
-    // Each should have a different hash
-    expect(hash1).not.toBe(hash2);
     expect(result2.fromCache).toBe(false);
+    expect(store.getEntry(filePath)!.hash).toBe(hashContents('export const v = 3;\n'));
 
     // Third modification
     writeFileSync(absPath, 'export const v = 4;\n');
     const result3 = await getFileSummary(tmpDir, filePath);
-    expect(result3.hash).not.toBe(hash2);
     expect(result3.fromCache).toBe(false);
+    expect(store.getEntry(filePath)!.hash).toBe(hashContents('export const v = 4;\n'));
   });
 
   it('should regenerate summary when cache entry has no summary', async () => {

--- a/tests/unit/get-dependency-graph.test.ts
+++ b/tests/unit/get-dependency-graph.test.ts
@@ -29,31 +29,65 @@ describe('getDependencyGraphTool', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('returns dependencies for a single file', async () => {
+  it('returns dependencies for a single file as an adjacency map', async () => {
     const result = await getDependencyGraphTool(tempDir, 'src/index.ts', 'dependencies');
-    expect(result.nodes).toContain('src/index.ts');
-    expect(result.nodes).toContain('src/helper.ts');
-    expect(result.edges.some((e) => e.from === 'src/index.ts' && e.to === 'src/helper.ts')).toBe(true);
+    expect(result.deps).toEqual({ 'src/index.ts': ['src/helper.ts'] });
+    expect(result.dependents).toBeUndefined();
+    expect(result).not.toHaveProperty('nodes');
+    expect(result).not.toHaveProperty('edges');
   });
 
-  it('returns dependents for a single file', async () => {
+  it('returns dependents for a single file as an adjacency map', async () => {
     const result = await getDependencyGraphTool(tempDir, 'src/helper.ts', 'dependents');
-    expect(result.nodes).toContain('src/index.ts');
+    expect(result.dependents).toEqual({ 'src/helper.ts': ['src/index.ts'] });
+    expect(result.deps).toBeUndefined();
+  });
+
+  it('returns both maps for direction=both (the default)', async () => {
+    const result = await getDependencyGraphTool(tempDir, 'src/helper.ts');
+    expect(result.deps).toEqual({ 'src/helper.ts': ['src/util.ts'] });
+    expect(result.dependents).toEqual({ 'src/helper.ts': ['src/index.ts'] });
+    expect(result.stats.totalFiles).toBe(3);
+    expect(result.stats.totalEdges).toBe(2);
+  });
+
+  it('omits mostConnected for path-scoped queries', async () => {
+    const result = await getDependencyGraphTool(tempDir, 'src/index.ts');
+    expect(result.stats.mostConnected).toBeUndefined();
   });
 
   it('returns full summary when no path given', async () => {
     const result = await getDependencyGraphTool(tempDir);
-    expect(result.stats.mostConnected.length).toBeGreaterThan(0);
-    expect(result.nodes.length).toBeGreaterThan(0);
+    expect(result.stats.mostConnected!.length).toBeGreaterThan(0);
+    expect(Object.keys(result.deps!).length).toBeGreaterThan(0);
+    expect(result).not.toHaveProperty('nodes');
+    expect(result).not.toHaveProperty('edges');
+    expect(result.truncated).toBeUndefined(); // 3 files fit well under the default limit
+  });
+
+  it('caps the no-path summary at limit and flags truncation with whole-graph totals', async () => {
+    const result = await getDependencyGraphTool(
+      tempDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+    );
+    expect(Object.keys(result.deps!)).toHaveLength(1);
+    expect(result.truncated).toBe(true);
+    expect(result.stats.totalFiles).toBe(3); // whole-graph count, not the capped count
+    expect(result.stats.totalEdges).toBe(2);
   });
 
   it('respects depth parameter', async () => {
     const result = await getDependencyGraphTool(tempDir, 'src/index.ts', 'dependencies', 1);
-    expect(result.nodes).toContain('src/helper.ts');
+    expect(result.deps!['src/index.ts']).toContain('src/helper.ts');
     // At depth 1, should not include transitive deps of helper
+    expect(result.deps!['src/index.ts']).not.toContain('src/util.ts');
   });
 
-  it('mostConnected and nodes contain only real repo files (no bare modules or phantoms)', async () => {
+  it('mostConnected and adjacency maps contain only real repo files (no bare modules or phantoms)', async () => {
     // A file with external imports must not introduce phantom graph nodes
     writeFileSync(
       join(tempDir, 'src', 'externals.ts'),
@@ -67,9 +101,13 @@ describe('getDependencyGraphTool', () => {
     );
 
     const result = await getDependencyGraphTool(tempDir);
-    expect(result.stats.mostConnected.length).toBeGreaterThan(0);
+    expect(result.stats.mostConnected!.length).toBeGreaterThan(0);
 
-    const allPaths = [...result.nodes, ...result.stats.mostConnected.map((m) => m.path)];
+    const allPaths = [
+      ...Object.keys(result.deps!),
+      ...Object.values(result.deps!).flat(),
+      ...result.stats.mostConnected!.map((m) => m.path),
+    ];
     for (const p of allPaths) {
       expect(existsSync(join(tempDir, p)), `${p} should be a real repo file`).toBe(true);
     }
@@ -83,32 +121,34 @@ describe('getDependencyGraphTool', () => {
   describe('symbol filter', () => {
     it('filters by symbol when path is given', async () => {
       const result = await getDependencyGraphTool(tempDir, 'src/index.ts', undefined, undefined, 'helper');
-      expect(result.edges).toEqual([{ from: 'src/index.ts', to: 'src/helper.ts' }]);
-      expect(result.nodes).toContain('src/index.ts');
-      expect(result.nodes).toContain('src/helper.ts');
+      expect(result.deps).toEqual({ 'src/index.ts': ['src/helper.ts'] });
+      expect(result.stats.totalFiles).toBe(2);
+      expect(result.stats.totalEdges).toBe(1);
+    });
+
+    it('omits mostConnected for symbol queries', async () => {
+      const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'helper');
+      expect(result.stats.mostConnected).toBeUndefined();
     });
 
     it('filters by symbol when path is NOT given (search all edges)', async () => {
       const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'util');
-      expect(result.edges.some((e) => e.from === 'src/helper.ts' && e.to === 'src/util.ts')).toBe(true);
-      expect(result.nodes).toContain('src/helper.ts');
-      expect(result.nodes).toContain('src/util.ts');
+      expect(result.deps!['src/helper.ts']).toContain('src/util.ts');
     });
 
     it('returns empty results for non-existent symbol', async () => {
       const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'NonExistent');
-      expect(result.nodes).toEqual([]);
-      expect(result.edges).toEqual([]);
+      expect(result.deps).toEqual({});
       expect(result.stats.totalFiles).toBe(0);
       expect(result.stats.totalEdges).toBe(0);
     });
 
     it('uses case-sensitive matching', async () => {
       const result = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'Helper');
-      expect(result.edges).toEqual([]);
+      expect(result.deps).toEqual({});
 
       const result2 = await getDependencyGraphTool(tempDir, undefined, undefined, undefined, 'helper');
-      expect(result2.edges.length).toBeGreaterThan(0);
+      expect(Object.keys(result2.deps!).length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/unit/get-file-summary.test.ts
+++ b/tests/unit/get-file-summary.test.ts
@@ -26,13 +26,27 @@ describe('getFileSummary', () => {
 
     expect(result.fromCache).toBe(false);
     expect(result.path).toBe(filePath);
-    expect(result.hash).toBeTypeOf('string');
-    expect(result.hash.length).toBe(64); // SHA-256 hex
     expect(result.summary.purpose).toBe('function hello'); // AST default
     expect(result.summary.exports).toContain('hello');
     expect(result.summary.lineCount).toBe(4);
-    expect(result.reason).toBe('cache_miss: no prior entry');
-    expect(result.cacheAge).toBeNull();
+    expect(result.cacheAge).toBeUndefined();
+  });
+
+  it('exposes only the slim response shape (no hash/reason debug fields)', async () => {
+    const filePath = 'src/example.ts';
+    await writeFile(join(tempDir, filePath), 'export const x = 1;\n', 'utf-8');
+
+    const miss = await getFileSummary(tempDir, filePath);
+    expect(miss).not.toHaveProperty('hash');
+    expect(miss).not.toHaveProperty('reason');
+    expect(miss).not.toHaveProperty('cacheAge'); // only present on cache hits
+    expect(Object.keys(miss).sort()).toEqual(['fromCache', 'path', 'suggestFullRead', 'summary']);
+
+    const hit = await getFileSummary(tempDir, filePath);
+    expect(hit.fromCache).toBe(true);
+    expect(hit).not.toHaveProperty('hash');
+    expect(hit).not.toHaveProperty('reason');
+    expect(hit.cacheAge).toBeTypeOf('number');
   });
 
   it('persists the file import edges when the summary regenerates', async () => {
@@ -61,9 +75,7 @@ describe('getFileSummary', () => {
 
     const second = await getFileSummary(tempDir, filePath);
     expect(second.fromCache).toBe(true);
-    expect(second.hash).toBe(first.hash);
     expect(second.summary).toEqual(first.summary);
-    expect(second.reason).toBe('cache_hit: hash unchanged');
     expect(second.cacheAge).toBeTypeOf('number');
     expect(second.cacheAge).toBeGreaterThanOrEqual(0);
   });
@@ -83,13 +95,10 @@ describe('getFileSummary', () => {
 
     const second = await getFileSummary(tempDir, filePath);
     expect(second.fromCache).toBe(false);
-    expect(second.hash).not.toBe(first.hash);
     expect(second.summary.exports).toContain('b');
     expect(second.summary.exports).toContain('c');
     expect(second.summary.exports).not.toContain('a');
-    expect(second.reason).toBe('cache_miss: hash changed');
-    expect(second.cacheAge).toBeTypeOf('number');
-    expect(second.cacheAge).toBeGreaterThanOrEqual(0);
+    expect(second.cacheAge).toBeUndefined();
   });
 
   it('throws when the file does not exist', async () => {

--- a/tests/unit/graph-freshness.test.ts
+++ b/tests/unit/graph-freshness.test.ts
@@ -134,7 +134,7 @@ describe('persisted graph freshness', () => {
     rmSync(join(tempDir, 'src', 'util.ts'));
 
     const result = await getDependencyGraphTool(tempDir, 'src/helper.ts', 'dependencies');
-    expect(result.nodes).not.toContain('src/util.ts');
+    expect(result.deps!['src/helper.ts']).not.toContain('src/util.ts');
     expect(edgeCount('src/util.ts')).toBe(0);
   });
 
@@ -149,7 +149,7 @@ describe('persisted graph freshness', () => {
     rmSync(join(tempDir, 'src', 'extra.ts'));
 
     const result = await getDependencyGraphTool(tempDir, 'src/util.ts', 'dependents');
-    expect(result.nodes).not.toContain('src/extra.ts');
+    expect(result.dependents!['src/util.ts']).not.toContain('src/extra.ts');
     expect(edgeCount('src/extra.ts')).toBe(0);
   });
 });

--- a/tests/unit/project-map.test.ts
+++ b/tests/unit/project-map.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { buildProjectMap } from '../../src/indexer/project-map.js';
+import { getProjectMap } from '../../src/tools/get-project-map.js';
 import { closeDatabase } from '../../src/persistence/db.js';
 
 function createTempProject(): string {
@@ -62,10 +63,22 @@ describe('buildProjectMap', () => {
   it('should build directory tree with correct structure', async () => {
     const map = await buildProjectMap(tempDir);
 
-    expect(map.tree.path).toBe('.');
     const childNames = map.tree.children.map((c) => c.name).sort();
     expect(childNames).toContain('docs');
     expect(childNames).toContain('src');
+  });
+
+  it('should omit derivable path from directory nodes', async () => {
+    const map = await buildProjectMap(tempDir);
+
+    function collectNodes(node: typeof map.tree): Array<typeof map.tree> {
+      return [node, ...node.children.flatMap(collectNodes)];
+    }
+
+    for (const node of collectNodes(map.tree)) {
+      expect(node).not.toHaveProperty('path');
+      expect(Object.keys(node).sort()).toEqual(['children', 'fileCount', 'files', 'name']);
+    }
   });
 
   it('should identify entry points', async () => {
@@ -96,7 +109,7 @@ describe('buildProjectMap', () => {
     expect(map.tree.fileCount).toBe(9);
   });
 
-  it('should include only name, purpose, and size on file entries', async () => {
+  it('should include only name and purpose on file entries', async () => {
     const map = await buildProjectMap(tempDir);
 
     // Collect all file entries from the tree
@@ -112,10 +125,9 @@ describe('buildProjectMap', () => {
     expect(allFiles.length).toBeGreaterThan(0);
 
     for (const file of allFiles) {
-      expect(file.size).toBeGreaterThan(0);
       expect(typeof file.name).toBe('string');
       expect(typeof file.purpose).toBe('string');
-      expect(Object.keys(file).sort()).toEqual(['name', 'purpose', 'size']);
+      expect(Object.keys(file).sort()).toEqual(['name', 'purpose']);
     }
   });
 
@@ -134,6 +146,30 @@ describe('buildProjectMap', () => {
     }
 
     expect(collectNames(map.tree)).not.toContain('.gitkeep');
+  });
+
+  it('tool layer defaults depth to 2 when not provided', async () => {
+    // Add a depth-3 directory; the default map must cut it off.
+    mkdirSync(join(tempDir, 'src', 'deep', 'deeper'), { recursive: true });
+    writeFileSync(join(tempDir, 'src', 'deep', 'marker.ts'), 'export const marker = 1;\n');
+    writeFileSync(
+      join(tempDir, 'src', 'deep', 'deeper', 'buried.ts'),
+      'export const buried = true;\n',
+    );
+
+    const map = await getProjectMap(tempDir);
+
+    const srcNode = map.tree.children.find((c) => c.name === 'src');
+    const deepNode = srcNode!.children.find((c) => c.name === 'deep');
+    expect(deepNode).toBeDefined(); // depth 2 is included
+    expect(deepNode!.children).toHaveLength(0); // depth 3 is cut off by the default
+
+    // An explicit depth still wins over the default.
+    const deepMap = await getProjectMap(tempDir, 3);
+    const explicitDeep = deepMap.tree.children
+      .find((c) => c.name === 'src')!
+      .children.find((c) => c.name === 'deep')!;
+    expect(explicitDeep.children.map((c) => c.name)).toContain('deeper');
   });
 
   it('should reuse cached summaries on repeated calls', async () => {

--- a/tests/unit/search-by-purpose.test.ts
+++ b/tests/unit/search-by-purpose.test.ts
@@ -59,7 +59,6 @@ describe('searchByPurpose', () => {
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const entryResult = result.results.find(r => r.path === 'src/index.ts');
     expect(entryResult).toBeDefined();
-    expect(entryResult!.matchedOn).toContain('purpose');
   });
 
   it('matches on exports field', async () => {
@@ -67,7 +66,6 @@ describe('searchByPurpose', () => {
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const matched = result.results.find(r => r.path === 'src/auth/middleware.ts');
     expect(matched).toBeDefined();
-    expect(matched!.matchedOn).toContain('exports');
   });
 
   it('matches on declarations field', async () => {
@@ -75,20 +73,15 @@ describe('searchByPurpose', () => {
     expect(result.results.length).toBeGreaterThanOrEqual(1);
     const matched = result.results.find(r => r.path === 'src/db/connection.ts');
     expect(matched).toBeDefined();
-    expect(matched!.matchedOn).toContain('declarations');
   });
 
-  it('returns matchedOn array correctly with multiple field matches', async () => {
-    // "validate" should match exports like validateToken, validateEmail, validatePassword
-    // and declarations with the same names
+  it('omits the query echo and matchedOn debug metadata from the response', async () => {
     const result = await searchByPurpose(tempDir, 'validate');
     expect(result.results.length).toBeGreaterThanOrEqual(1);
+    expect(result).not.toHaveProperty('query');
     for (const r of result.results) {
-      expect(r.matchedOn.length).toBeGreaterThanOrEqual(1);
-      // Each matchedOn entry should be one of the valid field names
-      for (const field of r.matchedOn) {
-        expect(['purpose', 'exports', 'declarations']).toContain(field);
-      }
+      expect(r).not.toHaveProperty('matchedOn');
+      expect(Object.keys(r).sort()).toEqual(['confidence', 'exports', 'path', 'purpose']);
     }
   });
 
@@ -101,7 +94,6 @@ describe('searchByPurpose', () => {
   it('returns empty results for no matches', async () => {
     const result = await searchByPurpose(tempDir, 'xyznonexistent');
     expect(result.results).toEqual([]);
-    expect(result.query).toBe('xyznonexistent');
     expect(result.totalCached).toBeGreaterThan(0);
   });
 
@@ -117,11 +109,6 @@ describe('searchByPurpose', () => {
   it('returns totalCached count', async () => {
     const result = await searchByPurpose(tempDir, 'source');
     expect(result.totalCached).toBe(5);
-  });
-
-  it('returns query in result', async () => {
-    const result = await searchByPurpose(tempDir, 'database');
-    expect(result.query).toBe('database');
   });
 
   it('uses default limit of 20', async () => {
@@ -217,6 +204,27 @@ describe('searchByPurpose', () => {
     const a = await searchByPurpose(tempDir, 'database', undefined, 'src\\db');
     expect(a.scope).toBe('src/db');
     expect(a.results.every(r => r.path.startsWith('src/db/'))).toBe(true);
+  });
+
+  it('caps exports at 5 per result and reports the total via exportsTruncated', async () => {
+    const manyExports = Array.from(
+      { length: 8 },
+      (_, i) => `export function searchableThing${i}() {}`,
+    ).join('\n');
+    await writeFile(join(tempDir, 'src/many-exports.ts'), `${manyExports}\n`);
+    await getFileSummary(tempDir, 'src/many-exports.ts');
+
+    const result = await searchByPurpose(tempDir, 'searchableThing');
+    const matched = result.results.find(r => r.path === 'src/many-exports.ts');
+    expect(matched).toBeDefined();
+    expect(matched!.exports).toHaveLength(5);
+    expect(matched!.exportsTruncated).toBe(8);
+
+    // Results with 5 or fewer exports carry no truncation marker.
+    const small = await searchByPurpose(tempDir, 'authMiddleware');
+    const smallMatch = small.results.find(r => r.path === 'src/auth/middleware.ts');
+    expect(smallMatch!.exports.length).toBeLessThanOrEqual(5);
+    expect(smallMatch!.exportsTruncated).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #165.

Latency was a measured non-problem; tokens are the cost. This reshapes the navigation tier per the audit's Protocol report — zero new tools, field deletions + defaults + optional params:

- `get_dependency_graph`: adjacency maps (`deps`/`dependents`) replace nodes[]+edges[] triple-serialization; `mostConnected` only in no-path mode; new `limit` (default 50) with `truncated` marker; description warns about no-path cost
- `get_project_map`: depth defaults to 2; derivable `path` and per-file `size` dropped; `project_root` optional (cwd default, back-compat kept)
- `get_file_summary`/`batch_file_summaries`: `hash`/`reason` dropped from responses; `cacheAge` only on hits; `totalFiles` echo dropped
- `search_by_purpose`: `query` echo and `matchedOn` dropped; exports capped at 5 with `exportsTruncated`
- Tool descriptions rewritten to win the selection contest vs built-in Grep/Read

Measured on this repo: no-path graph −54%, path-scoped graph −68%, summaries/batch/search −18–20%, map −23% (bigger on deep repos).

## Testing
507+ unit + 8 integration pass (rebased on #174 and re-verified); new shape tests assert removed keys stay removed; docs/usage.md examples updated.