### PR TITLE
chore(release): bump version to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
Bump version to 0.13.0 — the agent-search overhaul from the swarm audit (#160), all 8 scoped issues (#161–#168) implemented:

- **Correctness:** cache-poisoning fix in get_changed_files (#169); search results validated before serving (#171); multi-process/multi-version hardening incl. migration-race and WAL-open fixes (#173)
- **Graph:** import targets resolve to real files (#170); persisted dependency graph is now the read path — zero file re-reads when nothing changed (#172)
- **Quality:** relevance ranking actually ranks (#174); telemetry no longer inflates savings (#171)
- **Tokens:** navigation responses reshaped, −54% on the dependency graph, −18–68% across the tier (#175)

Note: `get_dependency_graph` and `get_project_map` response shapes changed (adjacency maps; derivable fields dropped).