### PR TITLE
feat(server): word-boundary relevance scoring for search_by_purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Your agent wants to understand `src/server.ts`. Normally it reads the whole file
 
 **First access (cache miss):**
 1. Agent calls `get_file_summary("src/server.ts")`
-2. repo-memory reads the file, SHA-256 hashes it, extracts a summary via regex (exports, imports, purpose, declarations, line count)
+2. repo-memory reads the file, SHA-256 hashes it, extracts a summary (exports, imports, purpose, declarations, line count) via the configured summarizer (AST by default)
 3. Stores the hash + summary in SQLite (`.repo-memory/cache.db` in your project)
 4. Returns the compact summary
 5. No savings yet — we had to read the file anyway
@@ -222,7 +222,7 @@ Config validation is per-key: an invalid value is skipped with a warning on stde
 
 ## Language Support
 
-Summaries are extracted via regex analysis, or from tree-sitter parse trees when `"summarizer": "ast"` is set. All language families below have AST support in `ast` mode, which adds semantic purpose lines derived from doc comments; regex stays as the universal fallback for other languages and unparseable files. Supported languages:
+Summaries are extracted from tree-sitter parse trees by default, or via regex analysis when `"summarizer": "regex"` is set. All language families below have AST support, which adds semantic purpose lines derived from doc comments; regex stays as the universal fallback for other languages and unparseable files. Supported languages:
 - **TypeScript / JavaScript** — exports, imports, declarations, purpose classification; AST mode adds JSDoc-derived purpose lines
 - **Python** — functions, classes (incl. `async def`), `__all__`, `from`/`import` statements; AST mode adds docstring-derived purpose lines
 - **Go** — exported names (uppercase), imports, type/func/var/const declarations; AST mode adds doc-comment purpose lines and grouped `var (…)` / `const (…)` support

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,7 +125,7 @@ Returns summaries for multiple files in one call. Each file goes through the sam
 
 ### `search_by_purpose`
 
-Searches cached file summaries by keyword. Matches against each file's purpose, exports, and top-level declarations. Only files that have been summarized before (via `get_file_summary`, `batch_file_summaries`, or `force_reread`) are searchable.
+Searches cached file summaries by keyword. Matches against each file's purpose, exports, top-level declarations, and path segments. Matching is word-boundary aware: identifiers are split on camelCase/snake_case/kebab-case boundaries, a whole-word hit outranks a prefix hit which outranks a bare substring, and terms shorter than 3 characters only count as whole words (so `id` finds `findUserById` but not `validation`). Only files that have been summarized before (via `get_file_summary`, `batch_file_summaries`, or `force_reread`) are searchable.
 
 **Input:**
 ```json
@@ -153,7 +153,7 @@ Searches cached file summaries by keyword. Matches against each file's purpose, 
 ```
 
 **Parameters:**
-- `query` (required): Space-separated keywords. Purpose matches are weighted highest, then exports, then declarations.
+- `query` (required): Space-separated keywords. Purpose matches are weighted highest, then exports, then declarations and path segments.
 - `limit` (optional): Max results. Default: 20.
 - `pathPrefix` (optional): Restrict results to files at or under this path (e.g. `"src/cache"`). Matched on a path boundary, so `"src/cache"` excludes `src/cache-utils.ts`.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -177,7 +177,7 @@ function registerTools(server: McpServer, config: RepoMemoryConfig): void {
 
     server.registerTool('search_by_purpose', {
       title: 'Search By Purpose',
-      description: 'Find files by what they do when you don\'t know filenames — prefer this over grep for concept searches ("where is auth handled"). Matches against file purpose, exports, and declarations. Check totalCached > 0 in the response; if 0, warm the cache with `repo-memory index` first. Optionally scope to a directory with pathPrefix.',
+      description: 'Find files by what they do when you don\'t know filenames — prefer this over grep for concept searches ("where is auth handled"). Matches whole words in file purpose, exports, declarations, and path segments (camelCase/snake_case split, so "store" finds CacheStore). Check totalCached > 0 in the response; if 0, warm the cache with `repo-memory index` first. Optionally scope to a directory with pathPrefix.',
       inputSchema: {
         query: z.string().describe('Search keywords (e.g., "database", "auth middleware", "validation")'),
         limit: z.number().optional().describe('Max results (default: 20)'),

--- a/src/tools/search-by-purpose.ts
+++ b/src/tools/search-by-purpose.ts
@@ -29,34 +29,87 @@ interface Match {
   score: number;
 }
 
-/** Score a summary against the query terms; null when nothing matched. */
-function scoreSummary(summary: FileSummary, queryTerms: string[]): Match | null {
+/**
+ * Lowercase word tokens of an identifier or free-text field: splits camelCase
+ * and PascalCase boundaries, snake_case, kebab-case, dots, and path
+ * separators. "CacheStore" -> ["cache","store"]; "get_file_summary" ->
+ * ["get","file","summary"].
+ */
+function tokenize(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/** Terms shorter than this only count on a whole-token match. */
+const MIN_SUBSTRING_TERM = 3;
+
+/**
+ * Match quality of one query term against one field, tiered by specificity:
+ * whole token (1.0) > token prefix (0.75) > bare substring (0.5). Short terms
+ * must match a whole token — "id" landing inside "validation" is noise, but
+ * "id" as an identifier word (findUserById) is a real hit.
+ */
+function termQuality(term: string, tokens: string[], raw: string): number {
+  if (tokens.includes(term)) return 1;
+  if (term.length < MIN_SUBSTRING_TERM) return 0;
+  if (tokens.some((t) => t.startsWith(term))) return 0.75;
+  if (raw.includes(term)) return 0.5;
+  return 0;
+}
+
+/**
+ * Score a cached entry against the query terms; null when nothing matched.
+ * Field weights: purpose 3 > exports 2 > declarations 1 = path 1. Each term
+ * contributes its match quality x the field weight, so a whole-word purpose
+ * hit outranks any pile of incidental substrings. Path segments count as a
+ * field of their own (sans extension) so directory and file names carry the
+ * concept signal they naturally encode — src/telemetry/tracker.ts should
+ * match "telemetry" even when its summary text doesn't say the word.
+ */
+function scoreEntry(path: string, summary: FileSummary, queryTerms: string[]): Match | null {
+  const fields = [
+    {
+      name: 'purpose',
+      weight: 3,
+      tokens: tokenize(summary.purpose),
+      raw: summary.purpose.toLowerCase(),
+    },
+    {
+      name: 'exports',
+      weight: 2,
+      tokens: summary.exports.flatMap(tokenize),
+      raw: summary.exports.join(' ').toLowerCase(),
+    },
+    {
+      name: 'declarations',
+      weight: 1,
+      tokens: summary.topLevelDeclarations.flatMap(tokenize),
+      raw: summary.topLevelDeclarations.join(' ').toLowerCase(),
+    },
+    {
+      name: 'path',
+      weight: 1,
+      tokens: tokenize(path.replace(/\.[a-z0-9]+$/i, '')),
+      raw: path.toLowerCase(),
+    },
+  ];
+
   const matchedOn: string[] = [];
   let score = 0;
-
-  const purpose = summary.purpose.toLowerCase();
-  const purposeMatches = queryTerms.filter((term) => purpose.includes(term));
-  if (purposeMatches.length > 0) {
-    matchedOn.push('purpose');
-    score += purposeMatches.length * 3; // purpose matches weighted highest
+  for (const field of fields) {
+    let fieldScore = 0;
+    for (const term of queryTerms) {
+      fieldScore += termQuality(term, field.tokens, field.raw) * field.weight;
+    }
+    if (fieldScore > 0) {
+      matchedOn.push(field.name);
+      score += fieldScore;
+    }
   }
-
-  const exportsLower = summary.exports.map((e) => e.toLowerCase());
-  const exportMatches = queryTerms.filter((term) =>
-    exportsLower.some((exp) => exp.includes(term)),
-  );
-  if (exportMatches.length > 0) {
-    matchedOn.push('exports');
-    score += exportMatches.length * 2;
-  }
-
-  const declsLower = summary.topLevelDeclarations.map((d) => d.toLowerCase());
-  const declMatches = queryTerms.filter((term) => declsLower.some((decl) => decl.includes(term)));
-  if (declMatches.length > 0) {
-    matchedOn.push('declarations');
-    score += declMatches.length;
-  }
-
   return matchedOn.length > 0 ? { matchedOn, score } : null;
 }
 
@@ -93,7 +146,7 @@ async function validateCandidate(
 
   const summary = await summarizeForProject(projectRoot, candidate.entry.path, contents);
   store.setEntry(candidate.entry.path, currentHash, summary);
-  const match = scoreSummary(summary, queryTerms);
+  const match = scoreEntry(candidate.entry.path, summary, queryTerms);
   if (!match) return null;
   return { entry: candidate.entry, summary, matchedOn: match.matchedOn, score: match.score };
 }
@@ -134,7 +187,7 @@ export async function searchByPurpose(
 
   for (const entry of entries) {
     if (!entry.summary) continue;
-    const match = scoreSummary(entry.summary, queryTerms);
+    const match = scoreEntry(entry.path, entry.summary, queryTerms);
     if (match) {
       candidates.push({ entry, summary: entry.summary, ...match });
     }

--- a/tests/unit/search-by-purpose.test.ts
+++ b/tests/unit/search-by-purpose.test.ts
@@ -344,3 +344,88 @@ describe('searchByPurpose freshness validation (invariant I5)', () => {
     expect(regenerated.fromCache).toBe(false);
   });
 });
+
+describe('searchByPurpose relevance scoring', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'repo-memory-search-rank-'));
+    await mkdir(join(tempDir, 'src/cache'), { recursive: true });
+    await mkdir(join(tempDir, 'src/backup'), { recursive: true });
+    await mkdir(join(tempDir, 'src/telemetry'), { recursive: true });
+
+    // Whole-word "store" lives here (CacheStore tokenizes to cache, store).
+    await writeFile(
+      join(tempDir, 'src/cache/store.ts'),
+      `export class CacheStore {\n  get() {}\n  set() {}\n}\n`,
+    );
+    // "store" appears only as a substring inside "restores"/"restoresBackups".
+    await writeFile(
+      join(tempDir, 'src/backup/manager.ts'),
+      `export function restoresBackups() { return true; }\n`,
+    );
+    // Nothing in the summary says "telemetry" — only the path does.
+    await writeFile(join(tempDir, 'src/telemetry/tracker.ts'), `export class Tracker {}\n`);
+    // "id" as a real identifier word vs "id" buried inside "validate".
+    await writeFile(
+      join(tempDir, 'src/cache/lookup.ts'),
+      `export function findUserById(id: string) { return id; }\n`,
+    );
+    await writeFile(
+      join(tempDir, 'src/cache/checks.ts'),
+      `export function validateInput(input: string) { return !!input; }\n`,
+    );
+
+    for (const f of [
+      'src/cache/store.ts',
+      'src/backup/manager.ts',
+      'src/telemetry/tracker.ts',
+      'src/cache/lookup.ts',
+      'src/cache/checks.ts',
+    ]) {
+      await getFileSummary(tempDir, f);
+    }
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('ranks a whole-word match above a substring match', async () => {
+    const result = await searchByPurpose(tempDir, 'store');
+    const paths = result.results.map((r) => r.path);
+    expect(paths[0]).toBe('src/cache/store.ts');
+    // The substring hit still matches, just lower.
+    expect(paths).toContain('src/backup/manager.ts');
+    expect(paths.indexOf('src/cache/store.ts')).toBeLessThan(
+      paths.indexOf('src/backup/manager.ts'),
+    );
+  });
+
+  it('splits camelCase identifiers into searchable words', async () => {
+    const result = await searchByPurpose(tempDir, 'user lookup');
+    expect(result.results[0].path).toBe('src/cache/lookup.ts');
+  });
+
+  it('short terms only match whole identifier words, not substrings', async () => {
+    const result = await searchByPurpose(tempDir, 'id');
+    const paths = result.results.map((r) => r.path);
+    expect(paths).toContain('src/cache/lookup.ts'); // findUserById -> ...by, id
+    expect(paths).not.toContain('src/cache/checks.ts'); // "id" inside "validate" is noise
+  });
+
+  it('matches on path segments when the summary text does not mention the term', async () => {
+    const result = await searchByPurpose(tempDir, 'telemetry');
+    expect(result.results.map((r) => r.path)).toContain('src/telemetry/tracker.ts');
+  });
+
+  it('matches a term that is a prefix of an identifier word', async () => {
+    const result = await searchByPurpose(tempDir, 'valid');
+    expect(result.results.map((r) => r.path)).toContain('src/cache/checks.ts');
+  });
+
+  it('does not match the file extension as a path word', async () => {
+    const result = await searchByPurpose(tempDir, 'ts');
+    expect(result.results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Ships the search relevance micro-fixes the agent-search audit recommended as the alternative to FTS5 ("first ship the 5-line relevance fixes... revisit FTS5 only with telemetry evidence"). The scorer was still naive substring matching: an exact export hit scored the same as an accidental infix, and short query terms matched inside unrelated words.

## Changes

- **Tokenized matching**: identifiers and purpose text split on camelCase/snake_case/kebab-case/dot boundaries — `store` finds `CacheStore` as a whole word.
- **Tiered match quality**: whole token (1.0) > token prefix (0.75) > bare substring (0.5), scaled by the existing field weights (purpose 3 > exports 2 > declarations 1), so real hits outrank incidental ones instead of tying.
- **Short-term noise guard**: terms under 3 chars only count on a whole-token match — `id` finds `findUserById` but no longer matches inside `validation`.
- **Path segments as a match field** (weight 1, extension excluded): `src/telemetry/tracker.ts` matches `telemetry` even when its summary text doesn't say the word. This is the name-match signal the ranking rework (#174) deliberately removed from `get_related_files` as belonging to search.
- Tool description + docs/usage.md updated; two stale "regex is default" README lines fixed (drift from the 0.12.0 flip).

No response-shape changes; no new tools or tables.

## Testing

- 6 new unit tests (word-vs-substring ranking, camelCase splitting, short-term guard, path matching, prefix tier, extension exclusion)
- 529 unit + 8 integration pass; typecheck, lint, build clean