### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Release 0.14.0 — word-boundary relevance scoring for `search_by_purpose` (#177).

- Tokenized matching (camelCase/snake_case/kebab-case split): `store` finds `CacheStore` as a whole word
- Tiered match quality: whole word > prefix > substring, so real hits outrank accidental infixes
- Short-term noise guard: terms under 3 chars require a whole-token match
- Path segments join the match corpus, so directory/file names carry concept signal

No response-shape changes.