### PR TITLE
feat(telemetry): add 'repo-memory report' CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Only missing or stale entries are re-summarized; unchanged files are left untouc
 
 To automate it, drop a git `post-merge` hook in the project (see [docs/usage.md](docs/usage.md#cli) for the snippet) so every pull keeps the cache warm.
 
+### Check the savings
+Telemetry events are always recorded by the cache paths; the `report` subcommand reads them from the shell, so you never need to enable the `telemetry` MCP tool group (~100 tokens/turn of system prompt) just to see the numbers:
+
+```bash
+repo-memory report                  # all recorded events for the current directory
+repo-memory report --hours 24      # last day only
+repo-memory report --json          # machine-readable
+repo-memory report --diagnostics   # add cache health (entry counts, db size)
+```
+
 ## How It Works
 
 ### The problem

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,27 @@ To keep the cache warm automatically, run it from a git `post-merge` hook so eve
 
 The subshell-and-background form keeps pulls fast; with `--quiet` the run is silent. Note `post-merge` does not fire on rebase pulls (`git pull --rebase`).
 
+### `repo-memory report [projectRoot] [--hours N] [--json] [--diagnostics]`
+
+Prints the token telemetry report for a project and exits. Telemetry events are always recorded by the cache paths — the `telemetry` tool group only gates the `get_token_report` MCP tool — so this reads the same data from the shell at zero token cost, in any project, without touching its config.
+
+- `projectRoot` (optional): directory to report on. Default: current directory.
+- `--hours N`: restrict to the last N hours (default: all recorded events).
+- `--json`: print the raw report JSON (same shape as `get_token_report`).
+- `--diagnostics`: include cache health (entry counts, stale entries, db size, age distribution).
+
+```
+$ repo-memory report --hours 24
+Token report for /path/to/project (last 24h)
+  events:        156 (132 hits / 24 misses, 84.6% hit ratio)
+  tokens saved:  ~482,000
+  breakdown:     cache_hit 132, cache_miss 24
+  top files:
+    12x src/server.ts (~8,400 tokens)
+```
+
+Exits `0` on success, `1` on error (message on stderr).
+
 ## Tools Reference
 
 ### `get_file_summary`

--- a/src/cli/report-command.ts
+++ b/src/cli/report-command.ts
@@ -1,0 +1,139 @@
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getTokenReport, type TokenReport } from '../tools/get-token-report.js';
+
+export interface ReportOptions {
+  /** Restrict the report to the last N hours (default: all recorded events). */
+  hours?: number;
+  /** Include cache health diagnostics (entry counts, stale entries, db size). */
+  diagnostics?: boolean;
+}
+
+/**
+ * Read-only telemetry report for a project, sharing getTokenReport with the
+ * MCP tool. The point of the CLI form: telemetry *events* are always recorded
+ * by the cache paths, but the `get_token_report` MCP tool belongs to the
+ * `telemetry` tool group (off by default, ~100 tokens/turn of system prompt
+ * when on) — this reads the same data from the shell at zero token cost.
+ */
+export function runReport(projectRoot: string, options: ReportOptions = {}): TokenReport {
+  const root = resolve(projectRoot);
+  if (!existsSync(root)) {
+    throw new Error(`project root does not exist: ${root}`);
+  }
+  if (!statSync(root).isDirectory()) {
+    throw new Error(`project root is not a directory: ${root}`);
+  }
+  return getTokenReport(
+    root,
+    options.hours != null ? 'last_n_hours' : 'all',
+    options.hours,
+    undefined,
+    options.diagnostics,
+  );
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+export function formatReport(projectRoot: string, report: TokenReport, hours?: number): string {
+  const window = hours != null ? `last ${hours}h` : 'all recorded events';
+  const ratio =
+    report.cacheHits + report.cacheMisses > 0
+      ? `${(report.cacheHitRatio * 100).toFixed(1)}%`
+      : 'n/a';
+  const lines = [
+    `Token report for ${resolve(projectRoot)} (${window})`,
+    `  events:        ${report.totalEvents} (${report.cacheHits} hits / ${report.cacheMisses} misses, ${ratio} hit ratio)`,
+    `  tokens saved:  ~${formatTokens(report.estimatedTokensSaved)}`,
+  ];
+
+  const breakdown = Object.entries(report.eventBreakdown)
+    .map(([type, count]) => `${type} ${count}`)
+    .join(', ');
+  if (breakdown) {
+    lines.push(`  breakdown:     ${breakdown}`);
+  }
+
+  if (report.topFiles.length > 0) {
+    lines.push('  top files:');
+    for (const file of report.topFiles.slice(0, 5)) {
+      lines.push(
+        `    ${file.accessCount}x ${file.path} (~${formatTokens(file.tokensEstimated)} tokens)`,
+      );
+    }
+  }
+
+  if (report.diagnostics) {
+    const d = report.diagnostics;
+    const ages = Object.entries(d.cacheAgeDistribution)
+      .filter(([, count]) => count > 0)
+      .map(([bucket, count]) => `${bucket}: ${count}`)
+      .join(', ');
+    lines.push(
+      `  cache:         ${d.cacheEntryCount} entries (${d.staleEntryCount} stale >30d), db ${(d.dbFileSizeBytes / 1024 / 1024).toFixed(1)} MB`,
+    );
+    if (ages) {
+      lines.push(`  entry age:     ${ages}`);
+    }
+  }
+
+  if (report.totalEvents === 0) {
+    lines.push('  (no telemetry recorded yet — agent traffic through the MCP server populates this)');
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Thin argv wrapper for `repo-memory report [projectRoot] [--hours N] [--json] [--diagnostics]`.
+ * Exits 0 on success, 1 on error (message to stderr).
+ */
+export async function runReportCli(argv: string[]): Promise<never> {
+  const usage =
+    'Usage: repo-memory report [projectRoot] [--hours N] [--json] [--diagnostics]\n';
+  let projectRoot: string | undefined;
+  let hours: number | undefined;
+  let json = false;
+  let diagnostics = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--diagnostics') {
+      diagnostics = true;
+    } else if (arg === '--hours') {
+      const value = Number(argv[++i]);
+      if (!Number.isFinite(value) || value <= 0) {
+        process.stderr.write(`repo-memory report: --hours expects a positive number\n${usage}`);
+        process.exit(1);
+      }
+      hours = value;
+    } else if (arg.startsWith('-')) {
+      process.stderr.write(`repo-memory report: unknown option '${arg}'\n${usage}`);
+      process.exit(1);
+    } else if (projectRoot === undefined) {
+      projectRoot = arg;
+    } else {
+      process.stderr.write(`repo-memory report: unexpected argument '${arg}'\n${usage}`);
+      process.exit(1);
+    }
+  }
+
+  try {
+    const root = projectRoot ?? process.cwd();
+    const report = runReport(root, { hours, diagnostics });
+    // stdout is safe here — like `index`, the report command never runs while
+    // the MCP stdio transport is active.
+    process.stdout.write(
+      json ? JSON.stringify(report, null, 2) + '\n' : formatReport(root, report, hours),
+    );
+    process.exit(0);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`repo-memory report: ${message}\n`);
+    process.exit(1);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -337,11 +337,15 @@ async function main() {
 }
 
 // Subcommand dispatch: `repo-memory index [projectRoot]` prewarms the summary
-// cache and exits. Anything else starts the MCP server on stdio, where stdout
-// is reserved for the protocol channel.
+// cache and exits; `repo-memory report [projectRoot]` prints the telemetry
+// report and exits. Anything else starts the MCP server on stdio, where
+// stdout is reserved for the protocol channel.
 if (process.argv[2] === 'index') {
   const { runIndexCli } = await import('./cli/index-command.js');
   await runIndexCli(process.argv.slice(3));
+} else if (process.argv[2] === 'report') {
+  const { runReportCli } = await import('./cli/report-command.js');
+  await runReportCli(process.argv.slice(3));
 } else {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/tests/unit/report-command.test.ts
+++ b/tests/unit/report-command.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runReport, formatReport } from '../../src/cli/report-command.js';
+import { TelemetryTracker } from '../../src/telemetry/tracker.js';
+import { clearConfigCache } from '../../src/config.js';
+import { clearSummaryGenerationCache } from '../../src/indexer/summarize.js';
+import { closeDatabase } from '../../src/persistence/db.js';
+import { getFileSummary } from '../../src/tools/get-file-summary.js';
+
+describe('runReport', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'report-command-test-'));
+    mkdirSync(join(tempDir, 'src'));
+    const body = Array.from(
+      { length: 40 },
+      (_, i) => `export function greet${i}(name: string): string {\n  return \`hi \${name} from ${i}\`;\n}`,
+    ).join('\n');
+    writeFileSync(join(tempDir, 'src', 'greet.ts'), body + '\n');
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('reports cache hits and misses from recorded agent traffic', async () => {
+    await getFileSummary(tempDir, 'src/greet.ts'); // miss
+    await getFileSummary(tempDir, 'src/greet.ts'); // hit
+
+    const report = runReport(tempDir);
+    expect(report.period).toBe('all');
+    expect(report.cacheMisses).toBe(1);
+    expect(report.cacheHits).toBe(1);
+    expect(report.cacheHitRatio).toBe(0.5);
+    expect(report.estimatedTokensSaved).toBeGreaterThan(0);
+    expect(report.topFiles[0].path).toBe('src/greet.ts');
+    expect(report.diagnostics).toBeUndefined();
+  });
+
+  it('reports zero events for a project with no telemetry', () => {
+    const report = runReport(tempDir);
+    expect(report.totalEvents).toBe(0);
+    expect(report.estimatedTokensSaved).toBe(0);
+  });
+
+  it('restricts the window with hours', async () => {
+    // An event recorded well before the window must be excluded; backdate it
+    // directly in the table.
+    const tracker = new TelemetryTracker(tempDir);
+    tracker.trackEvent('cache_hit', 'src/old.ts', 100);
+    const { getDatabase } = await import('../../src/persistence/db.js');
+    getDatabase(tempDir)
+      .prepare('UPDATE telemetry SET timestamp = ?')
+      .run(Date.now() - 10 * 3600000);
+
+    tracker.trackEvent('cache_hit', 'src/new.ts', 50);
+
+    const recent = runReport(tempDir, { hours: 1 });
+    expect(recent.period).toBe('last_n_hours');
+    expect(recent.totalEvents).toBe(1);
+    expect(recent.topFiles[0].path).toBe('src/new.ts');
+
+    const all = runReport(tempDir);
+    expect(all.totalEvents).toBe(2);
+  });
+
+  it('includes diagnostics on request', async () => {
+    await getFileSummary(tempDir, 'src/greet.ts');
+    const report = runReport(tempDir, { diagnostics: true });
+    expect(report.diagnostics).toBeDefined();
+    expect(report.diagnostics!.cacheEntryCount).toBe(1);
+    expect(report.diagnostics!.dbFileSizeBytes).toBeGreaterThan(0);
+  });
+
+  it('rejects a project root that does not exist', () => {
+    expect(() => runReport(join(tempDir, 'no-such-dir'))).toThrow(/does not exist/);
+  });
+
+  it('rejects a project root that is a file', () => {
+    expect(() => runReport(join(tempDir, 'src', 'greet.ts'))).toThrow(/not a directory/);
+  });
+});
+
+describe('formatReport', () => {
+  it('renders counts, ratio, and top files', () => {
+    const text = formatReport(
+      '/proj',
+      {
+        period: 'all',
+        totalEvents: 3,
+        cacheHits: 2,
+        cacheMisses: 1,
+        cacheHitRatio: 0.667,
+        estimatedTokensSaved: 1234,
+        topFiles: [{ path: 'src/a.ts', accessCount: 2, tokensEstimated: 1000 }],
+        eventBreakdown: { cache_hit: 2, cache_miss: 1 },
+      },
+      undefined,
+    );
+    expect(text).toContain('2 hits / 1 misses');
+    expect(text).toContain('66.7% hit ratio');
+    expect(text).toContain('~1,234');
+    expect(text).toContain('2x src/a.ts');
+    expect(text).toContain('all recorded events');
+  });
+
+  it('renders an empty-telemetry hint and n/a ratio', () => {
+    const text = formatReport(
+      '/proj',
+      {
+        period: 'last_n_hours',
+        totalEvents: 0,
+        cacheHits: 0,
+        cacheMisses: 0,
+        cacheHitRatio: 0,
+        estimatedTokensSaved: 0,
+        topFiles: [],
+        eventBreakdown: {},
+      },
+      4,
+    );
+    expect(text).toContain('last 4h');
+    expect(text).toContain('n/a hit ratio');
+    expect(text).toContain('no telemetry recorded yet');
+  });
+});


### PR DESCRIPTION
## Summary

Reads the token telemetry report from the shell at zero MCP token cost.

Telemetry events are **always recorded** by the cache paths — the `telemetry` tool group only gates the `get_token_report` MCP tool, which costs ~100 tokens/turn of system prompt when enabled. This adds a CLI sibling to `index`:

```
repo-memory report [projectRoot] [--hours N] [--json] [--diagnostics]
```

- Shares `getTokenReport` with the MCP tool (`--json` emits the identical shape)
- Human-readable default: events, hit ratio, estimated tokens saved, top files; `--diagnostics` adds cache health
- Zero-event hint points at agent traffic as the data source
- No new MCP tools; no config changes needed in target projects

Smoke-tested against this repo's live cache (23 events, 100% hit ratio, ~7k tokens saved over 48h).

## Testing

- 8 new unit tests (hit/miss aggregation, `--hours` windowing, diagnostics, root validation, formatter rendering incl. empty-telemetry hint)
- 537 unit + 8 integration pass; typecheck, lint, build clean