### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",

--- a/tests/unit/report-command.test.ts
+++ b/tests/unit/report-command.test.ts
@@ -31,7 +31,9 @@ describe('runReport', () => {
     clearSummaryGenerationCache();
   });
 
-  it('reports cache hits and misses from recorded agent traffic', async () => {
+  // 20s: the first getFileSummary in a worker pays tree-sitter WASM startup,
+  // which can exceed the 5s default on contended CI runners.
+  it('reports cache hits and misses from recorded agent traffic', { timeout: 20_000 }, async () => {
     await getFileSummary(tempDir, 'src/greet.ts'); // miss
     await getFileSummary(tempDir, 'src/greet.ts'); // hit
 
@@ -72,7 +74,7 @@ describe('runReport', () => {
     expect(all.totalEvents).toBe(2);
   });
 
-  it('includes diagnostics on request', async () => {
+  it('includes diagnostics on request', { timeout: 20_000 }, async () => {
     await getFileSummary(tempDir, 'src/greet.ts');
     const report = runReport(tempDir, { diagnostics: true });
     expect(report.diagnostics).toBeDefined();


### PR DESCRIPTION
## Summary

Release 0.15.0:

- **`repo-memory report` CLI** (#179) — token telemetry from the shell at zero MCP token cost
- **`validateEntry` cache-key fix on Windows** (#180) — unchanged files no longer read as invalid
- **CI matrix**: Node 20/22/26 + Windows job, all green; actions bumped ahead of the 2026-06-16 runtime migration (#180)