### PR TITLE
test: disable git background work in perf fixtures; ignore coverage/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .repo-memory/
 *.tsbuildinfo
 .DS_Store
+coverage/

--- a/tests/unit/performance-budget.test.ts
+++ b/tests/unit/performance-budget.test.ts
@@ -36,11 +36,11 @@ describe.skipIf(process.platform === 'win32')('performance budgets', () => {
 
     // Initialize git so scanProject works correctly
     const { execFileSync } = await import('child_process');
-    execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
-    execFileSync('git', ['add', '.'], { cwd: tempDir, stdio: 'pipe' });
+    execFileSync('git', ['-c', 'gc.auto=0', '-c', 'maintenance.auto=false', '-c', 'core.fsmonitor=false', 'init'], { cwd: tempDir, stdio: 'pipe' });
+    execFileSync('git', ['-c', 'gc.auto=0', '-c', 'maintenance.auto=false', '-c', 'core.fsmonitor=false', 'add', '.'], { cwd: tempDir, stdio: 'pipe' });
     execFileSync(
       'git',
-      ['commit', '-m', 'init', '--no-gpg-sign'],
+      ['-c', 'gc.auto=0', '-c', 'maintenance.auto=false', '-c', 'core.fsmonitor=false', 'commit', '-m', 'init', '--no-gpg-sign'],
       {
         cwd: tempDir,
         stdio: 'pipe',


### PR DESCRIPTION
Two CI runs hit `ENOTEMPTY` removing the perf test's tempdir even with retried removal — `git init/add/commit` on 100 files spawns auto-gc/background-maintenance that keeps writing into `.git` after the command returns, outlasting the 500ms retry budget. This disables `gc.auto`, `maintenance.auto`, and `core.fsmonitor` on each invocation, killing the race at the source.

Also adds `coverage/` to .gitignore (output of the now-working `npm run test:coverage`, fixed in the previous PR).