### PR TITLE
fix(telemetry): count summary_served in estimated tokens saved

### DIFF
--- a/src/telemetry/tracker.ts
+++ b/src/telemetry/tracker.ts
@@ -122,9 +122,13 @@ export class TelemetryTracker {
     const hitTotal = cacheHits + cacheMisses;
     const hitRatio = hitTotal > 0 ? cacheHits / hitTotal : 0;
 
+    // Savings = cache hits (full read avoided, raw minus summary) plus
+    // summary_served (one conservative per-query estimate of the read a
+    // search replaced — see search-by-purpose). force_reread/cache_miss book
+    // costs, not savings, and stay excluded.
     const tokenRow = db
       .prepare(
-        `SELECT COALESCE(SUM(tokens_estimated), 0) as total FROM telemetry WHERE event_type = 'cache_hit'${since ? ' AND timestamp >= ?' : ''}`,
+        `SELECT COALESCE(SUM(tokens_estimated), 0) as total FROM telemetry WHERE event_type IN ('cache_hit', 'summary_served')${since ? ' AND timestamp >= ?' : ''}`,
       )
       .get(...params) as { total: number };
 

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -58,6 +58,16 @@ describe('TelemetryTracker', () => {
     expect(stats.totalTokensSaved).toBe(350);
   });
 
+  it('getStats counts search savings but not reread/miss costs', () => {
+    tracker.trackEvent('cache_hit', 'a.ts', 100);
+    tracker.trackEvent('summary_served', 'b.ts', 250); // search counterfactual counts
+    tracker.trackEvent('force_reread', 'c.ts', 999); // a cost, not a saving
+    tracker.trackEvent('cache_miss', 'd.ts', 300); // likewise
+
+    const stats = tracker.getStats();
+    expect(stats.totalTokensSaved).toBe(350);
+  });
+
   it('disabled tracker does not record events', () => {
     const disabledTracker = new TelemetryTracker(tempDir, false);
     disabledTracker.trackEvent('cache_hit', 'a.ts', 100);


### PR DESCRIPTION
Spotted in a live report: chroxy showed `tokens saved: ~0` next to a top-files list crediting a single search ~37k tokens. `getStats` summed only `cache_hit` events, so projects whose agents lean on `search_by_purpose` reported zero headline savings.

`summary_served` has been a conservative per-query counterfactual since #171 (one average-file read per search, not per match) — it belongs in the sum. `force_reread` and `cache_miss` book costs and stay excluded.

New unit test pins the inclusion/exclusion split; 538 tests green.