### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Release 0.16.0 — the headline change is a telemetry-accuracy fix that directly affects downstream consumers of `repo-memory report --json` (e.g. chroxy's Integrations tab).

### Fixed
- **`estimatedTokensSaved` now counts `summary_served` events** (#187) — search-heavy projects previously reported `~0` tokens saved because the sum only counted cache hits. A project whose agents lean on `search_by_purpose` (chroxy: 198 searches vs 76 hits) was undercounting its savings by ~10x. The JSON shape is unchanged — only the value is corrected.
- Added the missing `@vitest/coverage-v8` devDependency so `npm run test:coverage` works (#185)

### Changed
- In-range dependency updates: MCP SDK 1.27→1.29, zod 4.3→4.4, plus dev tooling; `npm audit` clean (#182)
- `actions/checkout` and `actions/setup-node` bumped to v6 via Dependabot (#183, #184)
- Test suite hardened: disable git background work in perf fixtures to kill an ENOTEMPTY race; gitignore `coverage/` (#186)

### Infra
- Dependabot now manages dependencies monthly (grouped, majors held, web-tree-sitter pinned)
- CI runs a Node 20/22/26 + Windows matrix — green throughout this release

No MCP tool or response-shape changes.