### PR TITLE
test(telemetry): pin the report --json contract consumed by chroxy

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,6 +57,8 @@ Token report for /path/to/project (last 24h)
 
 Exits `0` on success, `1` on error (message on stderr).
 
+**`--json` output is a stable contract.** It serializes the `TokenReport` shape (`totalEvents`, `cacheHits`, `cacheMisses`, `cacheHitRatio`, `estimatedTokensSaved`, `topFiles`, `eventBreakdown`, and under `--diagnostics` a `diagnostics` block of `cacheEntryCount` / `staleEntryCount` / `dbFileSizeBytes` / `cacheAgeDistribution`). External tooling parses this — `estimatedTokensSaved` counts cache hits plus search (`summary_served`) savings. The key set is pinned by a contract test (`tests/unit/report-command.test.ts`); renaming or restructuring a field is a breaking change to this CLI contract.
+
 ## Tools Reference
 
 ### `get_file_summary`

--- a/tests/unit/report-command.test.ts
+++ b/tests/unit/report-command.test.ts
@@ -134,3 +134,71 @@ describe('formatReport', () => {
     expect(text).toContain('no telemetry recorded yet');
   });
 });
+
+// The `report --json` output is a published contract: chroxy's Control Room
+// Integrations tab parses it (RepoMemoryReportSchema in chroxy's
+// packages/protocol). These tests pin the exact key set at each level so a
+// rename or restructure fails here instead of silently breaking that consumer.
+// If you intend to change the shape, update this test AND chroxy's schema
+// together, and treat it as a breaking change to the CLI contract.
+describe('report --json contract (consumed by chroxy Integrations)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'report-contract-test-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, 'src', 'a.ts'), 'export const a = 1;\n');
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    clearConfigCache();
+    clearSummaryGenerationCache();
+  });
+
+  it('pins the top-level TokenReport keys', () => {
+    const report = runReport(tempDir);
+    expect(Object.keys(report).sort()).toEqual([
+      'cacheHitRatio',
+      'cacheHits',
+      'cacheMisses',
+      'estimatedTokensSaved',
+      'eventBreakdown',
+      'period',
+      'topFiles',
+      'totalEvents',
+    ]);
+  });
+
+  it('adds exactly a diagnostics block under --diagnostics, with a pinned key set', () => {
+    const base = Object.keys(runReport(tempDir));
+    const withDiag = runReport(tempDir, { diagnostics: true });
+
+    expect(Object.keys(withDiag).sort()).toEqual([...base, 'diagnostics'].sort());
+    expect(Object.keys(withDiag.diagnostics!).sort()).toEqual([
+      'cacheAgeDistribution',
+      'cacheEntryCount',
+      'dbFileSizeBytes',
+      'staleEntryCount',
+    ]);
+  });
+
+  it('holds the field types chroxy validates as a JSON round-trip', async () => {
+    await getFileSummary(tempDir, 'src/a.ts');
+    // Exercise the actual serialization boundary the consumer reads.
+    const report = JSON.parse(JSON.stringify(runReport(tempDir, { diagnostics: true })));
+
+    expect(typeof report.totalEvents).toBe('number');
+    expect(typeof report.cacheHits).toBe('number');
+    expect(typeof report.cacheMisses).toBe('number');
+    expect(report.cacheHitRatio).toBeGreaterThanOrEqual(0);
+    expect(report.cacheHitRatio).toBeLessThanOrEqual(1);
+    expect(report.estimatedTokensSaved).toBeGreaterThanOrEqual(0);
+    // chroxy flattens these two out of diagnostics; they must stay int|null-able.
+    expect(Number.isInteger(report.diagnostics.cacheEntryCount)).toBe(true);
+    expect(Number.isInteger(report.diagnostics.staleEntryCount)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

`repo-memory report --json` is now parsed by an external consumer — chroxy's Control Room "Integrations" tab (`RepoMemoryReportSchema` in chroxy's `packages/protocol`). Today nothing pins its shape: renaming `estimatedTokensSaved` or restructuring `diagnostics` would pass repo-memory's existing tests (they'd be updated alongside the change) while silently breaking chroxy's dashboard, with green CI on both sides.

I verified the two sides currently agree — chroxy reads a subset, names match, zod strips repo-memory's extra fields, and #187's savings change keeps `estimatedTokensSaved` a valid non-negative number. This PR locks that agreement so it can't regress unnoticed.

## What

- Contract `describe` block pinning the exact top-level `TokenReport` key set, the `diagnostics` key set, and the field types chroxy validates — across a real `JSON.stringify` round-trip (the actual boundary the consumer reads)
- `docs/usage.md`: documents `--json` as a stable contract, with the note that renaming a field is breaking

No production code change; 11 report-command tests pass (was 8).