### PR TITLE
feat(telemetry): record search_miss for zero-result queries

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,6 +184,7 @@ Searches cached file summaries by keyword. Matches against each file's purpose, 
 - `totalCached` is the number of summarized files in scope (after `pathPrefix` filtering), not the number of matches. If it is 0, warm the cache with `repo-memory index` first.
 - `scope` is present only when `pathPrefix` was given, echoing the normalized prefix.
 - `exports` is capped at 5 entries per result; when capped, `exportsTruncated` carries the total export count.
+- Telemetry: a query that returns results records one `summary_served` event; a query that matches **nothing against a non-empty corpus** records a `search_miss` (0 tokens, query in metadata) so failed searches are measurable. A search against an empty/cold cache records neither.
 
 ---
 

--- a/src/telemetry/tracker.ts
+++ b/src/telemetry/tracker.ts
@@ -5,7 +5,11 @@ export type TelemetryEvent =
   | 'cache_miss'
   | 'invalidation'
   | 'force_reread'
-  | 'summary_served';
+  | 'summary_served'
+  // A search_by_purpose query that matched nothing against a non-empty corpus
+  // — the "bad-ranking query" signal the FTS5 decision waits on (see #192).
+  // Books 0 tokens, so it never touches the savings sum or hit ratio.
+  | 'search_miss';
 
 export interface TelemetryEntry {
   id: number;

--- a/src/tools/search-by-purpose.ts
+++ b/src/tools/search-by-purpose.ts
@@ -206,27 +206,33 @@ export async function searchByPurpose(
     if (validated) served.push(validated);
   }
 
-  // Telemetry: ONE summary_served event per query, not per hit. Per-hit
-  // tracking booked every matched file as a full read avoided, inflating
-  // "tokens saved" by up to `limit`x. The realistic counterfactual for one
-  // search is the agent grepping and then reading roughly ONE candidate file
-  // in full, so we book the estimated raw-content tokens of one average
-  // served file (lineCount x ~40 chars/line / ~4 chars/token = lineCount x 10).
-  // Best-effort: a telemetry write failure (e.g. locked DB) must never fail
-  // the read path.
-  if (served.length > 0) {
-    try {
+  const totalCached = entries.filter((e) => e.summary).length;
+
+  // Telemetry, best-effort (audit invariant I8 — a write failure must never
+  // fail the read path):
+  //   - hit: ONE summary_served per query, not per result. Per-hit tracking
+  //     inflated "tokens saved" by up to `limit`x; the realistic counterfactual
+  //     for one search is grepping and reading ~ONE candidate file in full, so
+  //     we book one average served file (lineCount x ~40 chars/line / ~4
+  //     chars/token = lineCount x 10).
+  //   - miss: a query that matched nothing against a non-empty corpus is the
+  //     "bad-ranking query" signal the FTS5 decision waits on (#192). Books 0
+  //     tokens. Gated on totalCached > 0 so a cold cache (a setup state, not a
+  //     ranking failure) records nothing.
+  try {
+    const tracker = new TelemetryTracker(projectRoot);
+    if (served.length > 0) {
       const avgLineCount =
         served.reduce((sum, c) => sum + c.summary.lineCount, 0) / served.length;
-      new TelemetryTracker(projectRoot).trackEvent(
-        'summary_served',
-        served[0].entry.path,
-        Math.round(avgLineCount * 10),
-        { query, resultCount: served.length },
-      );
-    } catch {
-      // Telemetry is best-effort on read paths (audit invariant I8).
+      tracker.trackEvent('summary_served', served[0].entry.path, Math.round(avgLineCount * 10), {
+        query,
+        resultCount: served.length,
+      });
+    } else if (totalCached > 0) {
+      tracker.trackEvent('search_miss', undefined, 0, { query, totalCached });
     }
+  } catch {
+    // Telemetry is best-effort on read paths (audit invariant I8).
   }
 
   return {
@@ -241,7 +247,7 @@ export async function searchByPurpose(
         confidence: c.summary.confidence,
       };
     }),
-    totalCached: entries.filter((e) => e.summary).length,
+    totalCached,
     ...(normalizedPrefix ? { scope: normalizedPrefix } : {}),
   };
 }

--- a/tests/benchmarks/perf-utils.ts
+++ b/tests/benchmarks/perf-utils.ts
@@ -145,12 +145,17 @@ export function createPerfFixture(options: PerfFixtureOptions): string {
     writeFileSync(fullPath, content, 'utf-8');
   }
 
-  // Initialize git repo and commit
-  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
-  execFileSync('git', ['add', '.'], { cwd: tempDir, stdio: 'pipe' });
+  // Initialize git repo and commit. Disable git's background work (auto-gc,
+  // background maintenance, fsmonitor daemon) on every invocation — otherwise
+  // it keeps writing into .git after the command returns and races the
+  // fixture's teardown (ENOTEMPTY on rmSync). Same guard as the perf test's
+  // own git calls; this helper was the remaining unflagged source.
+  const GIT_QUIET = ['-c', 'gc.auto=0', '-c', 'maintenance.auto=false', '-c', 'core.fsmonitor=false'];
+  execFileSync('git', [...GIT_QUIET, 'init'], { cwd: tempDir, stdio: 'pipe' });
+  execFileSync('git', [...GIT_QUIET, 'add', '.'], { cwd: tempDir, stdio: 'pipe' });
   execFileSync(
     'git',
-    ['commit', '-m', 'initial fixture', '--no-gpg-sign'],
+    [...GIT_QUIET, 'commit', '-m', 'initial fixture', '--no-gpg-sign'],
     {
       cwd: tempDir,
       stdio: 'pipe',

--- a/tests/unit/report-command.test.ts
+++ b/tests/unit/report-command.test.ts
@@ -31,9 +31,7 @@ describe('runReport', () => {
     clearSummaryGenerationCache();
   });
 
-  // 20s: the first getFileSummary in a worker pays tree-sitter WASM startup,
-  // which can exceed the 5s default on contended CI runners.
-  it('reports cache hits and misses from recorded agent traffic', { timeout: 20_000 }, async () => {
+  it('reports cache hits and misses from recorded agent traffic', async () => {
     await getFileSummary(tempDir, 'src/greet.ts'); // miss
     await getFileSummary(tempDir, 'src/greet.ts'); // hit
 
@@ -74,7 +72,7 @@ describe('runReport', () => {
     expect(all.totalEvents).toBe(2);
   });
 
-  it('includes diagnostics on request', { timeout: 20_000 }, async () => {
+  it('includes diagnostics on request', async () => {
     await getFileSummary(tempDir, 'src/greet.ts');
     const report = runReport(tempDir, { diagnostics: true });
     expect(report.diagnostics).toBeDefined();

--- a/tests/unit/search-by-purpose.test.ts
+++ b/tests/unit/search-by-purpose.test.ts
@@ -148,6 +148,22 @@ describe('searchByPurpose', () => {
     expect(after).toBe(before);
   });
 
+  it('tracks a search_miss when a query matches nothing against a non-empty corpus', async () => {
+    const tracker = new TelemetryTracker(tempDir);
+    const before = tracker.getEvents({ eventType: 'search_miss' }).length;
+
+    const result = await searchByPurpose(tempDir, 'xyznonexistent');
+    expect(result.results).toEqual([]);
+    expect(result.totalCached).toBeGreaterThan(0); // there WAS a corpus
+
+    const misses = tracker.getEvents({ eventType: 'search_miss' });
+    expect(misses.length).toBe(before + 1);
+    const event = misses.reduce((a, b) => (b.id > a.id ? b : a));
+    expect(event.tokensEstimated).toBe(0); // a miss saves nothing
+    expect(event.filePath).toBeNull();
+    expect(event.metadata).toMatchObject({ query: 'xyznonexistent' });
+  });
+
   it('scopes results to a pathPrefix directory', async () => {
     // "validate" matches files in src/auth (validation.ts, middleware.ts) — scope to that dir.
     const result = await searchByPurpose(tempDir, 'validate', undefined, 'src/auth');
@@ -170,9 +186,18 @@ describe('searchByPurpose', () => {
 
   it('matches on a path boundary (prefix does not catch sibling names)', async () => {
     // "src/d" must NOT match "src/db/..." — only a full segment boundary counts.
+    const tracker = new TelemetryTracker(tempDir);
+    const before = tracker.getEvents({ eventType: 'search_miss' }).length;
+
     const result = await searchByPurpose(tempDir, 'database', undefined, 'src/d');
     expect(result.results).toEqual([]);
     expect(result.totalCached).toBe(0);
+
+    // Empty corpus (no files in scope) is a setup state, not a ranking failure —
+    // it must NOT record a search_miss (the FTS5 signal is misses against a
+    // non-empty corpus only, #192).
+    const after = tracker.getEvents({ eventType: 'search_miss' }).length;
+    expect(after).toBe(before);
   });
 
   it('omits scope when no pathPrefix is given', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/unit/**/*.test.ts'],
+    // Windows CI runners are slow to spin up a vitest worker and import the
+    // native/WASM deps (better-sqlite3, tree-sitter); that one-time cost lands
+    // on whichever test runs first in a worker and blew past the 5s default
+    // even for pure-string tests. A generous global ceiling kills that flake
+    // class without per-test overrides; a genuinely hung test still fails.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
Closes #192.

## Why

The agent-search audit (#160) deferred FTS5 with one gate: *"revisit only with telemetry evidence of bad-ranking queries."* We're running a measurement week to collect that — but `search_by_purpose` only recorded `summary_served` **when it returned results**. A query that found nothing recorded nothing, so the single most decision-relevant signal was invisible. The measurement week as built couldn't produce the evidence the audit said to wait for.

## What

- New `search_miss` telemetry event: fired when a search returns zero results **against a non-empty corpus** (`totalCached > 0`), with `{ query, totalCached }` metadata and 0 tokens
- Gated on `totalCached > 0` so a cold cache (setup state, not a ranking failure) records nothing — consistent with how a cold cache produces no telemetry elsewhere
- Best-effort in try/catch (audit invariant I8 — telemetry never fails the read path)

## Contract safety (re #191)

`search_miss` doesn't touch the `report --json` consumer contract: not a `cache_hit`/`cache_miss` (hit ratio unchanged), 0 tokens (savings sum unchanged), only adds an `eventBreakdown` key chroxy doesn't read. `totalEvents` rises, which is correct.

## Tests

- search_miss recorded on a real zero-result query (path/tokens/metadata pinned)
- no search_miss on an empty-corpus (cold/scoped-out) search
- 542 unit + 8 integration green