### PR TITLE
feat(telemetry): surface failed searches (topMissedQueries) in the report

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,7 @@ Token report for /path/to/project (last 24h)
 
 Exits `0` on success, `1` on error (message on stderr).
 
-**`--json` output is a stable contract.** It serializes the `TokenReport` shape (`totalEvents`, `cacheHits`, `cacheMisses`, `cacheHitRatio`, `estimatedTokensSaved`, `topFiles`, `eventBreakdown`, and under `--diagnostics` a `diagnostics` block of `cacheEntryCount` / `staleEntryCount` / `dbFileSizeBytes` / `cacheAgeDistribution`). External tooling parses this — `estimatedTokensSaved` counts cache hits plus search (`summary_served`) savings. The key set is pinned by a contract test (`tests/unit/report-command.test.ts`); renaming or restructuring a field is a breaking change to this CLI contract.
+**`--json` output is a stable contract.** It serializes the `TokenReport` shape (`totalEvents`, `cacheHits`, `cacheMisses`, `cacheHitRatio`, `estimatedTokensSaved`, `topFiles`, `topMissedQueries`, `eventBreakdown`, and under `--diagnostics` a `diagnostics` block of `cacheEntryCount` / `staleEntryCount` / `dbFileSizeBytes` / `cacheAgeDistribution`). External tooling parses this — `estimatedTokensSaved` counts cache hits plus search (`summary_served`) savings, and `topMissedQueries` lists the searches that matched nothing (query + count) so ranking gaps are reviewable. The key set is pinned by a contract test (`tests/unit/report-command.test.ts`); renaming or restructuring a field is a breaking change to this CLI contract.
 
 ## Tools Reference
 

--- a/src/cli/report-command.ts
+++ b/src/cli/report-command.ts
@@ -65,6 +65,14 @@ export function formatReport(projectRoot: string, report: TokenReport, hours?: n
     }
   }
 
+  if (report.topMissedQueries.length > 0) {
+    const total = report.topMissedQueries.reduce((sum, m) => sum + m.count, 0);
+    lines.push(`  failed searches: ${total} (queries that matched nothing — candidates for ranking gaps)`);
+    for (const miss of report.topMissedQueries.slice(0, 5)) {
+      lines.push(`    ${miss.count}x "${miss.query}"`);
+    }
+  }
+
   if (report.diagnostics) {
     const d = report.diagnostics;
     const ages = Object.entries(d.cacheAgeDistribution)

--- a/src/tools/get-token-report.ts
+++ b/src/tools/get-token-report.ts
@@ -19,6 +19,14 @@ export interface TokenReport {
   cacheHitRatio: number;
   estimatedTokensSaved: number;
   topFiles: Array<{ path: string; accessCount: number; tokensEstimated: number }>;
+  /**
+   * `search_by_purpose` queries that matched nothing against a non-empty
+   * corpus, aggregated by query and ranked by frequency (top 10). This is the
+   * "bad-ranking query" signal the FTS5 decision waits on (#192): a reviewable
+   * list of what agents searched for and the lexical ranking couldn't satisfy.
+   * Always present; empty when there were no such misses.
+   */
+  topMissedQueries: Array<{ query: string; count: number }>;
   eventBreakdown: Record<string, number>;
   diagnostics?: CacheDiagnostics;
 }
@@ -108,6 +116,20 @@ export function getTokenReport(
     .sort((a, b) => b.accessCount - a.accessCount)
     .slice(0, 10);
 
+  // Aggregate failed searches by their query text (search_miss carries the
+  // query in metadata) so the FTS5 signal is a reviewable list, not raw rows.
+  const missMap = new Map<string, number>();
+  for (const event of events) {
+    if (event.eventType !== 'search_miss') continue;
+    const query = (event.metadata as { query?: unknown } | null)?.query;
+    if (typeof query !== 'string') continue;
+    missMap.set(query, (missMap.get(query) ?? 0) + 1);
+  }
+  const topMissedQueries = [...missMap.entries()]
+    .map(([query, count]) => ({ query, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
   const report: TokenReport = {
     period: effectivePeriod,
     totalEvents: stats.totalEvents,
@@ -116,6 +138,7 @@ export function getTokenReport(
     cacheHitRatio: stats.hitRatio,
     estimatedTokensSaved: stats.totalTokensSaved,
     topFiles,
+    topMissedQueries,
     eventBreakdown: stats.eventsByType,
   };
 

--- a/tests/unit/report-command.test.ts
+++ b/tests/unit/report-command.test.ts
@@ -80,6 +80,21 @@ describe('runReport', () => {
     expect(report.diagnostics!.dbFileSizeBytes).toBeGreaterThan(0);
   });
 
+  it('aggregates failed searches into topMissedQueries', () => {
+    const tracker = new TelemetryTracker(tempDir);
+    tracker.trackEvent('search_miss', undefined, 0, { query: 'websocket reconnect', totalCached: 5 });
+    tracker.trackEvent('search_miss', undefined, 0, { query: 'websocket reconnect', totalCached: 5 });
+    tracker.trackEvent('search_miss', undefined, 0, { query: 'oauth refresh', totalCached: 5 });
+
+    const report = runReport(tempDir);
+    expect(report.topMissedQueries).toEqual([
+      { query: 'websocket reconnect', count: 2 },
+      { query: 'oauth refresh', count: 1 },
+    ]);
+    // A miss books no tokens, so the savings sum stays clean.
+    expect(report.estimatedTokensSaved).toBe(0);
+  });
+
   it('rejects a project root that does not exist', () => {
     expect(() => runReport(join(tempDir, 'no-such-dir'))).toThrow(/does not exist/);
   });
@@ -101,6 +116,7 @@ describe('formatReport', () => {
         cacheHitRatio: 0.667,
         estimatedTokensSaved: 1234,
         topFiles: [{ path: 'src/a.ts', accessCount: 2, tokensEstimated: 1000 }],
+        topMissedQueries: [{ query: 'websocket reconnect', count: 3 }],
         eventBreakdown: { cache_hit: 2, cache_miss: 1 },
       },
       undefined,
@@ -110,6 +126,8 @@ describe('formatReport', () => {
     expect(text).toContain('~1,234');
     expect(text).toContain('2x src/a.ts');
     expect(text).toContain('all recorded events');
+    expect(text).toContain('failed searches: 3');
+    expect(text).toContain('3x "websocket reconnect"');
   });
 
   it('renders an empty-telemetry hint and n/a ratio', () => {
@@ -123,6 +141,7 @@ describe('formatReport', () => {
         cacheHitRatio: 0,
         estimatedTokensSaved: 0,
         topFiles: [],
+        topMissedQueries: [],
         eventBreakdown: {},
       },
       4,
@@ -130,6 +149,7 @@ describe('formatReport', () => {
     expect(text).toContain('last 4h');
     expect(text).toContain('n/a hit ratio');
     expect(text).toContain('no telemetry recorded yet');
+    expect(text).not.toContain('failed searches');
   });
 });
 
@@ -167,6 +187,7 @@ describe('report --json contract (consumed by chroxy Integrations)', () => {
       'eventBreakdown',
       'period',
       'topFiles',
+      'topMissedQueries',
       'totalEvents',
     ]);
   });


### PR DESCRIPTION
Follow-on to #193. That PR started recording `search_miss` events; this one makes them readable.

## Why

`search_miss` captures the FTS5 decision signal — but the actionable part (which queries failed) was buried in event metadata, needing raw SQL. The *count* surfaced in `eventBreakdown`; the *queries* didn't. The measurement week needs a reviewable artifact, not rows to hand-query.

## What

- `getTokenReport` aggregates `search_miss` events by query → `topMissedQueries` (top 10 by frequency), always present on `TokenReport` (empty when none)
- `repo-memory report` renders `failed searches: N` plus the top missed queries
- Additive field on the `report --json` contract (#191): zod consumers like chroxy ignore unknown keys, so it's non-breaking; the contract test's pinned key set is updated to include it deliberately

## Tests

- runReport aggregates/ranks misses by query; a miss books 0 tokens (savings sum stays clean)
- formatReport renders the failed-searches block, and omits it when empty
- 543 unit + 8 integration green; live smoke against chroxy clean