### PR TITLE
chore(release): bump version to 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blamechris/repo-memory",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blamechris/repo-memory",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server that gives AI coding agents persistent memory about your codebase",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Release 0.17.0 — search observability: the telemetry now captures and surfaces the searches the lexical ranking can't satisfy, which is the evidence the agent-search audit (#160) gated the FTS5 decision on.

### Added
- **`search_miss` telemetry** (#193) — `search_by_purpose` now records a `search_miss` event (0 tokens, query in metadata) when a query matches nothing against a non-empty corpus. Previously these were invisible, so the FTS5 signal couldn't accrue.
- **`topMissedQueries` in the report** (#194) — `repo-memory report` aggregates failed searches into a ranked "failed searches" list, and `report --json` carries `topMissedQueries`. Turns the signal into a reviewable artifact.

### Changed
- Windows CI runs on Node 22 so it uses the better-sqlite3 prebuilt (12.x ships no Node-20 win32-x64 prebuilt) instead of a doomed source build (#190); global 20s unit test timeout absorbs Windows worker cold-start; `createPerfFixture` git calls disable background work (ENOTEMPTY teardown race)

### Internal
- `report --json` is pinned as a stable contract by a test (#191), since chroxy's Control Room Integrations tab parses it. The new `topMissedQueries` is an additive, deliberately-tested extension.

No breaking changes to MCP tools or the report JSON shape (additive field only).