### PR TITLE
chore(skills): pin the withheld self-merge posture in the profile

### DIFF
--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -77,6 +77,19 @@
 - Work sources: open GitHub issues + open PRs; design docs under `docs/planning/`. Ready signals: `complexity:low`/`complexity:medium`, `good first issue`, `help wanted`. Blocked signals: `wontfix`, `design-spike`.
 
 ## tackle-issues Customizations
+
+### Self-merge posture
+
+**Withheld.** Every merge in this repo is a human act. However clean the review and
+the checks are, PRs accumulate for `/batch-merge` or user review rather than
+self-merging, so Critical Rule 5 must be written in its WITHHELD form. `merge:on`
+is not honoured: an invocation flag cannot grant authority the repo withholds.
+
+Recorded in the profile, not just in the installed skill: `.claude/commands/` is
+regenerated on every `skill update`, this file is not. Without this line the next
+update takes the template default — gated self-merge — and silently re-enables
+unattended merges that were deliberately withheld.
+
 - Branch prefix `auto/`; worktrees under `.claude/worktrees/`. Per-issue verification = the full gate; run `npm run lint` independently (worktree agents leave unused vars that pass typecheck but fail lint).
 
 ## merge Customizations
@@ -95,6 +108,19 @@
 - Per-agent verification = the full gate `npm run typecheck && npm run lint && npm test && npm run build`. Worktrees under `.claude/worktrees/`; run lint independently (typecheck-passes/lint-fails footgun).
 
 ## autonomous-dev-flow Customizations
+
+### Self-merge posture
+
+**Withheld.** Every merge in this repo is a human act. However clean the review and
+the checks are, PRs accumulate for the user rather than self-merging, so Critical
+Rule 5 must be written in its WITHHELD form and the Unattended Merge Gate does not
+apply here.
+
+Recorded in the profile, not just in the installed skill: `.claude/commands/` is
+regenerated on every `skill update`, this file is not. Without this line the next
+update takes the template default — gated self-merge — and silently re-enables
+unattended merges that were deliberately withheld.
+
 - Full-gate verification per agent; worktrees under `.claude/worktrees/`; lint independently. Decompose only issues genuinely too large to implement directly.
 
 ## smoke-test Customizations


### PR DESCRIPTION
## What

Records this repo's **withheld** self-merge posture in `.claude/skill-profile.md`, under both `## autonomous-dev-flow Customizations` and `## tackle-issues Customizations`.

No behaviour changes today. The installed skills already carry Critical Rule 5 in its WITHHELD form — this makes that survive the next `skill update`.

## Why it matters

Rule 5's text is filled from the profile at install time, and `.claude/commands/` is **regenerated on every update** while the profile is not. With nothing in the profile, the next `skill update` takes the template default — **gated self-merge** — and silently grants agents authority to merge their own PRs here.

From the registry's schema docs:

> a repo that *intends* **withheld** but never pins it in the profile gets gated back on its next `skill update`, silently re-enabling unattended merges that someone had deliberately turned off.

That regression would appear as a routine skill refresh, with no diff that reads like a policy change. This closes it.

## Verification

The profile now contains exactly one `### Self-merge posture` block inside each of the two skill sections, and the skill's own guard (`self-merge-posture`, added in blamechris/skill-templates#159) already fails any install where Rule 5 goes missing entirely.

Part of the fleet-wide pass tracked in blamechris/skill-templates#144.
